### PR TITLE
Lets ssh-based resolvers use an ~/.ssh/config file to find username/hostname/keyfile options

### DIFF
--- a/doc/resolver/sftp.html
+++ b/doc/resolver/sftp.html
@@ -37,11 +37,12 @@ If your server supports ssh but not sftp, there is also an <a href="../resolver/
 
 Note that sftp is also supported by vfs, so you can use a vfs resolver instead. The advantage of this resolver is that you have a better control over authentication, it can prompt for username/password credentials, or you can use private/public key authentication, which is not possible with the vfs resolver. When it prompts for username/password, it uses a Swing dialog, which is not possible in a headless environment. If you want to prompt for the credentials on the command line, use ant input task for example before calling ivy.
 
-All necessary connection parameters can be set here via attributes.
+All necessary connection parameters can be set here via attributes, or via an OpenSSH-style config file specified by sshConfig.
 However all attributes defined in the pattern url of the resolver will have higher priority and will overwrite the values given here. To specify connection parameters in the pattern, you have to specify a full url and not just a path as pattern.
 e.g. pattern="/path/to/my/repos/[artifact].[ext]" will use all connection parameters from this class
 e.g. pattern="sftp://myserver.com/path/to/my/repos/[artifact].[ext]" will use all parameters from the attributes with the exception of the host, which will be "myserver.com"
 e.g. pattern="sftp://user:geheim@myserver.com:8022/path/to/my/repos/[artifact].[ext]" will use only the keyFile and keyFilePassword from the attributes (if needed). Rest will come from the url.
+
 
 
 Note that the authentication features of this resolver are exactly the same as the ssh resolver. Choosing between the two is often a matter of server implementation. If your server supports sftp, usually it's preferrable.
@@ -67,6 +68,9 @@ This resolver shares the <a href="../settings/resolvers.html#common">common attr
         <td>No, defaults to host given on the patterns, fail if none is set</td></tr>
     <tr><td>port</td><td>The port to connect to</td>
         <td>No, defaults to 22</td></tr>
+    <tr><td>sshConfig</td><td>Path to an OpenSSH-style config file containing additional
+            configuration</td>
+        <td>No</td></tr>
 </tbody>
 </table>
 <h1>Child elements</h1>
@@ -114,6 +118,14 @@ Will connect to yourserver.com on port 8022 with user 'user' and password 'gehei
 </sftp>
 </code>
 Will connect to yourserver.com on port 8022 with user 'user' and use keyFile path/to/key/file for keyFile and the value of password variable for keyFilePassword authentication for ivy files, and to myserver.com on port 8022 using user 'user' with the same keyFile/keyFilePassword pair for the artifacts.
+
+<code type="xml">
+<sftp host="myhost" sshConfig="/path/to/.ssh/config">
+  <ivy pattern="/path/to/ivy/[module]/ivy.xml"/>
+  <artifact pattern="/path/to/[organisation]/[module]/[artifact].[ext]"/>
+</ssh>
+</code>
+Will connect to the host named by myhost according to the config file in /path/to/.ssh/config, using the hostname, username, and optionally IdentityFile specified in the config section "Host myhost". For example, if the corresponding Host section contains "Hostname yourserver.com" and "User myremoteusername", it will connect to yourserver.com using username myremoteusername.
 
 	</textarea>
 <script type="text/javascript">xooki.postProcess();</script>

--- a/doc/resolver/ssh.html
+++ b/doc/resolver/ssh.html
@@ -55,6 +55,10 @@ This resolver shares the <a href="../settings/resolvers.html#common">common attr
         <td>No, defaults to host given on the patterns, fail if none is set</td></tr>
     <tr><td>port</td><td>The port to connect to</td>
         <td>No, defaults to 22</td></tr>
+    <tr><td>sshConfig</td><td>Path to an OpenSSH-style config file containing additional
+            configuration</td>
+        <td>No</td></tr>
+
     <tr><td>publishPermissions</td><td>A four digit string (e.g., 0644, see "man chmod", "man open") specifying the permissions of the published files. <span class="since">(since 2.0)</span>
 </td><td>No, defaults to scp standard behaviour</td></tr>
 </tbody>
@@ -89,6 +93,13 @@ Will connect to myhost.com using myuser and prompt for the password.
 </code>
 Will connect to yourserver.com on port 8022 with user geheim and use keyFile path/to/key/file for keyFile and the value of password variable for keyFilePassword authentication for ivy files, and to myserver.com on port 8022 using user geheim with the same keyFile/keyFilePassword pair for the artifacts.
 
+<code type="xml">
+<ssh host="myhost" sshConfig="/path/to/.ssh/config">
+  <ivy pattern="/path/to/ivy/[module]/ivy.xml"/>
+  <artifact pattern="/path/to/[organisation]/[module]/[artifact].[ext]"/>
+</ssh>
+</code>
+Will connect to the host named by myhost according to the config file in /path/to/.ssh/config, using the hostname, username, and optionally IdentityFile specified in the config section "Host myhost". For example, if the corresponding Host section contains "Hostname yourserver.com" and "User myremoteusername", it will connect to yourserver.com using username myremoteusername.
 	</textarea>
 <script type="text/javascript">xooki.postProcess();</script>
 </body>

--- a/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
@@ -338,10 +338,17 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
         this.allowedAgentUse = allowedAgentUse;
     }
 
+    /**
+     * @return sshConfig Path to a local ssh config file
+     */
     public String getSshConfig() {
         return sshConfig;
     }
 
+    /**
+     * @param sshConfig
+     *            Path to a local ssh config file
+     */
     public void setSshConfig(String sshConfig) {
         this.sshConfig = sshConfig;
     }

--- a/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
@@ -29,7 +29,10 @@ import org.apache.ivy.util.Credentials;
 import org.apache.ivy.util.CredentialsUtil;
 import org.apache.ivy.util.Message;
 
+import com.jcraft.jsch.ConfigRepository.Config;
 import com.jcraft.jsch.Session;
+import com.jcraft.jsch.OpenSSHConfig;
+import com.jcraft.jsch.ConfigRepository;
 
 public abstract class AbstractSshBasedRepository extends AbstractRepository {
 
@@ -48,6 +51,8 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
     private int port = -1;
 
     private boolean allowedAgentUse = false;
+
+    private String sshConfig = null;
 
     public AbstractSshBasedRepository() {
         super();
@@ -74,6 +79,8 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
         int port = getPort();
         String user = getUser();
         String userPassword = getUserPassword();
+        String sshConfig = getSshConfig();
+        File keyFile = getKeyFile();
         if (uri != null && uri.getScheme() != null) {
             if (uri.getHost() != null) {
                 host = uri.getHost();
@@ -91,10 +98,26 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
                 }
             }
         }
+
+        if (sshConfig != null) {
+            ConfigRepository configRepository = OpenSSHConfig.parseFile(sshConfig);
+            Config config = configRepository.getConfig(host);
+            host = config.getHostname();
+            if (user == null) {
+                user = config.getUser();
+            }
+            String keyFilePath = config.getValue("IdentityFile");
+            if (keyFilePath != null && keyFile == null) {
+                keyFile = new File(keyFilePath);
+            }
+        }
+
+
         if (host == null) {
             throw new IllegalArgumentException(
                     "missing host information. host should be provided either "
-                            + "directly on the repository or in the connection URI");
+                            + "directly on the repository or in the connection URI "
+                            + ", or in the openssh config file specified by sshConfig");
         }
         if (user == null) {
             Credentials c = requestCredentials(host);
@@ -105,7 +128,7 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
                 Message.error("username is not set");
             }
         }
-        return SshCache.getInstance().getSession(host, port, user, userPassword, getKeyFile(),
+        return SshCache.getInstance().getSession(host, port, user, userPassword, keyFile,
             getKeyFilePassword(), getPassFile(), isAllowedAgentUse());
     }
 
@@ -313,6 +336,14 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
      */
     public void setAllowedAgentUse(boolean allowedAgentUse) {
         this.allowedAgentUse = allowedAgentUse;
+    }
+
+    public String getSshConfig() {
+        return sshConfig;
+    }
+
+    public void setSshConfig(String sshConfig) {
+        this.sshConfig = sshConfig;
     }
 
     protected abstract String getRepositoryScheme();

--- a/src/java/org/apache/ivy/plugins/resolver/AbstractSshBasedResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/AbstractSshBasedResolver.java
@@ -143,5 +143,16 @@ public abstract class AbstractSshBasedResolver extends RepositoryResolver {
         getSshBasedRepository().setPort(port);
     }
 
+    /**
+     * sets the path to an OpenSSH-style config file to be used for reading configuration values for
+     * an ssh repository, such as a username
+     *
+     * @param path
+     *            of the config file
+     */
+    public void setSshConfig(String sshConfig) {
+        getSshBasedRepository().setSshConfig(sshConfig);
+    }
+
     public abstract String getTypeName();
 }


### PR DESCRIPTION
I haven't tested it for sftp, but it should theoretically work just as well as it does for the ssh resolver. Plays nice with the ssh-agent feature from Jsch, too.
