### PR TITLE
Add feature for PomModuleDescriptorParser disabled handle source and javadoc artifact for speed up  …

### DIFF
--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParser.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParser.java
@@ -306,6 +306,15 @@ public final class PomModuleDescriptorParser implements ModuleDescriptorParser {
             // no main artifact in pom, we don't need to search for meta artifacts
             return;
         }
+        
+        final boolean disabledForSourcesAndJavadoc = "true".equals(ivySettings.substitute("${disabledForSourcesAndJavadoc}"));
+        if(disabledForSourcesAndJavadoc){
+            Message.debug("disabledForSourcesAndJavadoc=true ( in ivysettings.xml or System property )  ignore sources and javadoc artifact");
+            return;
+        }else{
+            Message.debug("if you want ignore sources and javadoc artifact ,try set disabledForSourcesAndJavadoc=true  ( in ivysettings.xml or System property )  for speed up! ");
+        }
+        
         ModuleDescriptor md = mdBuilder.getModuleDescriptor();
         ModuleRevisionId mrid = md.getModuleRevisionId();
         DependencyResolver resolver = ivySettings.getResolver(mrid);


### PR DESCRIPTION
PomModuleDescriptorParser disabled handle source and javadoc artifact  by set disabledForSourcesAndJavadoc=true,

by ivysettings.xml  like:

``` xml
<ivysettings>
    <property name="disabledForSourcesAndJavadoc" value="true"/>
    ....

by System property,like -DdisabledForSourcesAndJavadoc=true
```
