### PR TITLE
IVY-1526 Use parent pom's license (if any) if the child pom doesn't explicitly have its own

### DIFF
--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParser.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParser.java
@@ -35,6 +35,7 @@ import org.apache.ivy.core.module.descriptor.Configuration.Visibility;
 import org.apache.ivy.core.module.descriptor.DefaultArtifact;
 import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DependencyDescriptor;
+import org.apache.ivy.core.module.descriptor.License;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.resolve.ResolveData;
@@ -159,7 +160,15 @@ public final class PomModuleDescriptorParser implements ModuleDescriptorParser {
 
             mdBuilder.setHomePage(domReader.getHomePage());
             mdBuilder.setDescription(domReader.getDescription());
-            mdBuilder.setLicenses(domReader.getLicenses());
+            // if this module doesn't have an explicit license, use the parent's license (if any)
+            final License[] licenses = domReader.getLicenses();
+            if (licenses != null && licenses.length > 0) {
+                mdBuilder.setLicenses(licenses);
+            } else {
+                if (parentDescr != null) {
+                    mdBuilder.setLicenses(parentDescr.getLicenses());
+                }
+            }
 
             ModuleRevisionId relocation = domReader.getRelocation();
 

--- a/test/java/org/apache/ivy/plugins/parser/m2/test-parent-with-licenses.pom
+++ b/test/java/org/apache/ivy/plugins/parser/m2/test-parent-with-licenses.pom
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.    
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache</groupId>
+    <artifactId>test-ivy-license-parent</artifactId>
+    <packaging>jar</packaging>
+    <name>Test License parent project</name>
+
+    <version>1.0.1</version>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+</project>

--- a/test/java/org/apache/ivy/plugins/parser/m2/test-project-with-overridden-licenses.pom
+++ b/test/java/org/apache/ivy/plugins/parser/m2/test-project-with-overridden-licenses.pom
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.    
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>test-ivy-license-parent</artifactId>
+        <version>1.0.1</version>
+    </parent>
+    <groupId>org.apache</groupId>
+    <artifactId>test-ivy-license-overridden</artifactId>
+    <packaging>jar</packaging>
+    <name>Test License project</name>
+
+    <version>1.0.2</version>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+</project>

--- a/test/java/org/apache/ivy/plugins/parser/m2/test-project-with-parent-licenses.pom
+++ b/test/java/org/apache/ivy/plugins/parser/m2/test-project-with-parent-licenses.pom
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.    
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>test-ivy-license-parent</artifactId>
+        <version>1.0.1</version>
+    </parent>
+    <groupId>org.apache</groupId>
+    <artifactId>test-ivy-license</artifactId>
+    <packaging>jar</packaging>
+    <name>Test License project</name>
+
+    <version>1.0.2</version>
+</project>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.apache.org/jira/browse/IVY-1526.

Maven, natively, uses the parent pom's license if the child project doesn't specify its own licenses in the pom.xml [1]. The commit here does a change which behaves similarly when Ivy is resolving a Maven dependency - the parent's licenses are applied on the module descriptor if the module itself doesn't specify its licenses.

The commit also includes a couple of new tests to verify this change.

[1] http://www.mail-archive.com/users%40maven.apache.org/msg125044.html - Trying this against a sample parent/child Maven projects does show that the parent pom's license is used in the absence of any licenses in the child project.