### PR TITLE
IVY-1522 Windows OS file path resolution fix

### DIFF
--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -595,8 +595,8 @@ public final class FileUtil {
         // }
         String root = null;
         int colon = path.indexOf(':');
-        if (colon > 0) { // && (ON_DOS || ON_NETWARE)) {
-
+        // essentially a Windows OS check (see IVY-1522 for more details)
+        if (colon > 0 && isFilesystemRoot(path.substring(0, colon + 1) + sep)) { // && (ON_DOS || ON_NETWARE)) {
             int next = colon + 1;
             root = path.substring(0, next);
             char[] ca = path.toCharArray();
@@ -623,6 +623,24 @@ public final class FileUtil {
             path = path.substring(1);
         }
         return new String[] {root, path};
+    }
+
+    private static boolean isFilesystemRoot(final String path) {
+        if (path == null) {
+            return false;
+        }
+        final File[] filesystemRoots = File.listRoots();
+        if (filesystemRoots == null) {
+            // in the rare cases when the listing of filesystem roots returns null, we have no way to ascertain
+            // if the "path" is a filesystem root. We return false in such cases
+            return false;
+        }
+        for (final File filesystemRoot : filesystemRoots) {
+            if (filesystemRoot.getName().equals(path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/test/java/org/apache/ivy/ant/ivy-module-version-with-colon.xml
+++ b/test/java/org/apache/ivy/ant/ivy-module-version-with-colon.xml
@@ -1,0 +1,29 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.    
+-->
+<ivy-module version="1.0">
+    <info organisation="apache"
+          module="version-with-colon"
+          revision="1.0.0.20:18:36"
+          status="release">
+    </info>
+    <configurations>
+        <conf name="default"/>
+        <conf name="compile"/>
+    </configurations>
+</ivy-module>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.apache.org/jira/browse/IVY-1522.

This commit also includes a new test method to verify this fix. My local testing with these changes hasn't shown any regressions. However, I don't have a Windows OS to test this on and my testing has been on a *nix OS. The test included in this commit needs to be run against a Windows OS to ascertain that the fix indeed fixes the issue.
