### PR TITLE
Fix for IVY-1531

### DIFF
--- a/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorBuilder.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorBuilder.java
@@ -290,9 +290,18 @@ public class PomModuleDescriptorBuilder {
         if ((mRevId != null) && mRevId.getModuleId().equals(moduleRevId.getModuleId())) {
             return;
         }
-
+        // experimentation shows the following, excluded modules are
+        // inherited from parent POMs if either of the following is true:
+        // the <exclusions> element is missing or the <exclusions> element
+        // is present, but empty.
+        List<ModuleId> excluded = dep.getExcludedModules();
+        if (excluded.isEmpty()) {
+            excluded = getDependencyMgtExclusions(ivyModuleDescriptor, dep.getGroupId(),
+                    dep.getArtifactId());
+        }
+        final boolean excludeAllTransitiveDeps = shouldExcludeAllTransitiveDeps(excluded);
         DefaultDependencyDescriptor dd = new PomDependencyDescriptor(dep, ivyModuleDescriptor,
-                moduleRevId);
+                moduleRevId, !excludeAllTransitiveDeps);
         scope = (scope == null || scope.length() == 0) ? getDefaultScope(dep) : scope;
         ConfMapper mapping = MAVEN2_CONF_MAPPING.get(scope);
         mapping.addMappingConfs(dd, dep.isOptional());
@@ -327,16 +336,12 @@ public class PomModuleDescriptorBuilder {
             dd.addDependencyArtifact(optionalizedScope, depArtifact);
         }
 
-        // experimentation shows the following, excluded modules are
-        // inherited from parent POMs if either of the following is true:
-        // the <exclusions> element is missing or the <exclusions> element
-        // is present, but empty.
-        List<ModuleId> excluded = dep.getExcludedModules();
-        if (excluded.isEmpty()) {
-            excluded = getDependencyMgtExclusions(ivyModuleDescriptor, dep.getGroupId(),
-                dep.getArtifactId());
-        }
         for (ModuleId excludedModule : excluded) {
+            // This represents exclude all transitive dependencies, which we have already taken
+            // in account while defining the DefaultDependencyDescriptor itself
+            if ("*".equals(excludedModule.getOrganisation()) && "*".equals(excludedModule.getName())) {
+                continue;
+            }
             String[] confs = dd.getModuleConfigurations();
             for (int k = 0; k < confs.length; k++) {
                 dd.addExcludeRule(confs[k], new DefaultExcludeRule(new ArtifactId(excludedModule,
@@ -346,6 +351,21 @@ public class PomModuleDescriptorBuilder {
         }
 
         ivyModuleDescriptor.addDependency(dd);
+    }
+
+    private static boolean shouldExcludeAllTransitiveDeps(final List<ModuleId> exclusions) {
+        if (exclusions == null || exclusions.isEmpty()) {
+            return false;
+        }
+        for (final ModuleId exclusion : exclusions) {
+            if (exclusion == null) {
+                continue;
+            }
+            if ("*".equals(exclusion.getOrganisation()) && "*".equals(exclusion.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void addDependency(DependencyDescriptor descriptor) {
@@ -690,8 +710,8 @@ public class PomModuleDescriptorBuilder {
         private final PomDependencyData pomDependencyData;
 
         private PomDependencyDescriptor(PomDependencyData pomDependencyData,
-                ModuleDescriptor moduleDescriptor, ModuleRevisionId revisionId) {
-            super(moduleDescriptor, revisionId, true, false, true);
+                ModuleDescriptor moduleDescriptor, ModuleRevisionId revisionId, final boolean transitive) {
+            super(moduleDescriptor, revisionId, true, false, transitive);
             this.pomDependencyData = pomDependencyData;
         }
 

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -536,7 +536,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
         DependencyDescriptor[] dds = md.getDependencies();
         assertNotNull(dds);
-        assertEquals(3, dds.length);
+        assertEquals(4, dds.length);
         assertEquals(ModuleRevisionId.newInstance("commons-logging", "commons-logging", "1.0.4"),
             dds[0].getDependencyRevisionId());
         assertEquals(new HashSet(Arrays.asList(new String[] {"compile", "runtime"})), new HashSet(
@@ -569,6 +569,17 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(new HashSet(Arrays.asList(new String[] {"runtime(*)"})),
             new HashSet(Arrays.asList(dds[2].getDependencyConfigurations("runtime"))));
         assertEquals(0, dds[2].getAllExcludeRules().length);
+
+        // test for IVY-1531 (where the pom.xml can have a exclusion for groupid=* and artifactid=*, implying transitive=false, in ivy land)
+        final DependencyDescriptor excludeAllTransitiveDepsDescriptor = dds[3];
+        assertEquals(ModuleRevisionId.newInstance("org.owasp.esapi", "esapi", "2.1.0"), excludeAllTransitiveDepsDescriptor.getDependencyRevisionId());
+        assertEquals(new HashSet(Arrays.asList(new String[] {"compile", "runtime"})), new HashSet(Arrays.asList(excludeAllTransitiveDepsDescriptor.getModuleConfigurations())));
+        assertEquals(new HashSet(Arrays.asList(new String[] {"master(*)", "compile(*)"})),
+                new HashSet(Arrays.asList(excludeAllTransitiveDepsDescriptor.getDependencyConfigurations("compile"))));
+        assertEquals(new HashSet(Arrays.asList(new String[] {"runtime(*)"})),
+                new HashSet(Arrays.asList(excludeAllTransitiveDepsDescriptor.getDependencyConfigurations("runtime"))));
+        assertEquals("No exclusion elements were expected to be present for " + excludeAllTransitiveDepsDescriptor, 0, excludeAllTransitiveDepsDescriptor.getAllExcludeRules().length);
+        assertFalse("Dependency  " + excludeAllTransitiveDepsDescriptor + " was expected to have transitive=false", excludeAllTransitiveDepsDescriptor.isTransitive());
     }
 
     public void testWithPlugins() throws Exception {

--- a/test/java/org/apache/ivy/plugins/parser/m2/test-exclusion.pom
+++ b/test/java/org/apache/ivy/plugins/parser/m2/test-exclusion.pom
@@ -57,5 +57,16 @@
         <exclusion />
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.owasp.esapi</groupId>
+      <artifactId>esapi</artifactId>
+      <version>2.1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The commit here contains a potential fix for the issue reported in https://issues.apache.org/jira/browse/IVY-1531.

Maven pom.xml allows dependency exclusion to include groupid=* and artifactid=* in the exclusion, which technically translates to transitive = false in Ivy world. The commit here handles that explicitly so that it doesn't lead to a ivy.xml (generated off pom.xml) to have something like:

       <exclude org="" module="" name="" type="" ext="*" conf="" matcher="exact"/>

which effectively excludes the dependency which has this exclusion (as noted in that JIRA).

The change in this commit now generates the ivy.xml as follows for such exclusions in pom.xml:

       <dependency org="org.owasp.esapi" name="esapi" rev="2.1.0" force="true" transitive="false" conf="compile->compile(*),master(*);runtime->runtime(*)"/>

(notice the transitive=false in there)

This commit also includes a test which verifies this change.