### PR TITLE
Fix download URL for findbugs task

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -606,14 +606,17 @@
 
     <target name="init-findbugs" unless="findbugs.home">
         <!-- Findbugs: Getting Findbugs -->
+        <property name="findbugs.version"
+                  value="1.3.5"
+                  description="Version of Findbugs to use"/>
         <property name="findbugs.download.name"
-                  value="findbugs-1.3.5"
+                  value="findbugs-${findbugs.version}"
                   description="Name of the download file without suffix. Also the internal root directory of the ZIP."/>
         <property name="findbugs.download.file"
                   value="${findbugs.download.name}.zip"
                   description="The filename of the ZIP."/>
         <property name="findbugs.download.url"
-                  value="http://garr.dl.sourceforge.net/sourceforge/findbugs/${findbugs.download.file}"
+                  value="https://jaist.dl.sourceforge.net/project/findbugs/findbugs/${findbugs.version}/${findbugs.download.file}"
                   description="The download adress at a mirror of Sourceforge."/>
         <property name="findbugs.download.to"
                   value="${build.dir}/.downloads"


### PR DESCRIPTION
The commit here fixes the download URL used in the `init-findbugs` task, that has been failing[1] for a while due to reference to an URL that no longer works.

The goal of this PR is to just get the download working fine and it's not an intention at this point to upgrade a more recent compatible version of findbugs.


[1] https://builds.apache.org/view/A/view/Ant/job/Ivy-check/343/console