### PR TITLE
Fix IVY-1495

### DIFF
--- a/test/java/org/apache/ivy/core/settings/ivysettings-cache-ttl-matcher.xml
+++ b/test/java/org/apache/ivy/core/settings/ivysettings-cache-ttl-matcher.xml
@@ -1,0 +1,25 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<ivysettings>
+    <caches default="foo">
+        <cache name="foo" defaultTTL="30000ms">
+            <ttl organisation="foo\S*" duration="60000ms" matcher="regexp"/>
+        </cache>
+    </caches>
+</ivysettings>


### PR DESCRIPTION
The commit here is a potential fix for the issue reported in https://issues.apache.org/jira/browse/IVY-1495. The issue happens when the `ivysettings.xml` is being parsed and the `IvySettings` instance isn't yet available for getting hold of a relevant `matcher` referred to in the `ttl` config.

The commit here delays the access to the `matcher` from the `settings` instance, to when the settings instance is available.

The commit also includes a test case to verify the change.