### PR TITLE
Fix transient test failures

### DIFF
--- a/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
@@ -18,7 +18,9 @@
 package org.apache.ivy.plugins.circular;
 
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.core.IvyContext;
 import org.apache.ivy.util.Message;
+import org.apache.ivy.util.MessageLoggerEngine;
 import org.apache.ivy.util.MockMessageLogger;
 
 import junit.framework.TestCase;
@@ -27,12 +29,17 @@ public class IgnoreCircularDependencyStrategyTest extends TestCase {
     private CircularDependencyStrategy strategy;
 
     private MockMessageLogger mockMessageImpl;
+    private MessageLoggerEngine messageLoggerEngine;
 
     protected void setUp() throws Exception {
         strategy = IgnoreCircularDependencyStrategy.getInstance();
 
         mockMessageImpl = new MockMessageLogger();
-        Message.setDefaultLogger(mockMessageImpl);
+        messageLoggerEngine = setupMockLogger(mockMessageImpl);
+    }
+
+    protected void tearDown() throws Exception {
+        resetMockLogger(messageLoggerEngine);
     }
 
     public void testLog() throws Exception {
@@ -47,5 +54,21 @@ public class IgnoreCircularDependencyStrategyTest extends TestCase {
 
         // should only log the circular dependency once
         assertEquals(1, mockMessageImpl.getLogs().size());
+    }
+
+    private MessageLoggerEngine setupMockLogger(final MockMessageLogger mockLogger) {
+        if (mockLogger == null) {
+            return null;
+        }
+        final MessageLoggerEngine loggerEngine = IvyContext.getContext().getIvy().getLoggerEngine();
+        loggerEngine.pushLogger(mockLogger);
+        return loggerEngine;
+    }
+
+    private void resetMockLogger(final MessageLoggerEngine loggerEngine) {
+        if (loggerEngine == null) {
+            return;
+        }
+        loggerEngine.popLogger();
     }
 }

--- a/test/java/org/apache/ivy/util/MockMessageLogger.java
+++ b/test/java/org/apache/ivy/util/MockMessageLogger.java
@@ -66,6 +66,7 @@ public class MockMessageLogger extends AbstractMessageLogger {
     }
 
     public void clear() {
+        super.clearProblems();
         _logs.clear();
         _rawLogs.clear();
         _endProgress.clear();


### PR DESCRIPTION
The `WarnCircularDependencyStrategyTest` fails once in a while on Jenkins. Looking at the testcase, it resets/updates a shared JVM level logger instance (via `Message.setDefaultLogger`) across test methods. Given that JUnit can run the test methods parallely across different testcase instances, this can (and indeed seems to be) run into race conditions causing the tests to fail. The test was also leaving around the mock message logger as the default logger even after the test was complete.

The commit here fixes these issues and uses a test method specific logger instances and doesn't share them across the test methods. The `IgnoreCircularDependencyStrategyTest` had a similar issue, so that's been included in this fix as well.
