### PR TITLE
Use the specified timeout for connections in BasicURLHandler

### DIFF
--- a/src/java/org/apache/ivy/util/url/BasicURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/BasicURLHandler.java
@@ -64,6 +64,7 @@ public class BasicURLHandler extends AbstractURLHandler {
         try {
             url = normalizeToURL(url);
             con = url.openConnection();
+            con.setConnectTimeout(timeout);
             con.setRequestProperty("User-Agent", getUserAgent());
             if (con instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) con;

--- a/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
@@ -45,15 +45,16 @@ public class BasicURLHandlerTest extends TestCase {
     }
 
     public void testIsReachable() throws Exception {
-        assertTrue(handler.isReachable(new URL("http://www.google.fr/")));
-        assertFalse(handler.isReachable(new URL("http://www.google.fr/unknownpage.html")));
+        final int connectionTimeoutInMillis = 15000; // 15 seconds
+        assertTrue(handler.isReachable(new URL("http://www.google.fr/"), connectionTimeoutInMillis));
+        assertFalse(handler.isReachable(new URL("http://www.google.fr/unknownpage.html"), connectionTimeoutInMillis));
 
-        assertTrue(handler.isReachable(new File("build.xml").toURI().toURL()));
-        assertFalse(handler.isReachable(new File("unknownfile.xml").toURI().toURL()));
+        assertTrue(handler.isReachable(new File("build.xml").toURI().toURL(), connectionTimeoutInMillis));
+        assertFalse(handler.isReachable(new File("unknownfile.xml").toURI().toURL(), connectionTimeoutInMillis));
 
         // to test ftp we should know of an anonymous ftp site... !
         // assertTrue(handler.isReachable(new URL("ftp://ftp.mozilla.org/pub/dir.sizes")));
-        assertFalse(handler.isReachable(new URL("ftp://ftp.mozilla.org/unknown.file")));
+        assertFalse(handler.isReachable(new URL("ftp://ftp.mozilla.org/unknown.file"), connectionTimeoutInMillis));
     }
 
     public void testContentEncoding() throws Exception {


### PR DESCRIPTION
The commit here fixes the `BasicURLHandler` to use the specified timeout for connection timeout. It also updates the `BasicURLHandlerTest` to specify a timeout while using this handler so that the test doesn't take unnecessary long (currently takes around 4 minutes) trying to test connection to an non-existent location.

At this point, the goal of this PR _isn't_ to enhance the `BasicURLHandler` for various other timeouts aspects, but merely to take into account the passed timeout and let the `BasicURLHandlerTest` complete faster.
