### PR TITLE
Fix IVY-1555

### DIFF
--- a/test/java/org/apache/ivy/ant/IvyConfigureTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConfigureTest.java
@@ -18,9 +18,11 @@
 package org.apache.ivy.ant;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.core.module.status.Status;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
@@ -305,4 +307,22 @@ public class IvyConfigureTest {
         configure.setOverride("unknown");
     }
 
+    /**
+     * Tests that if the Ivy settings file <code>include</code>s another file as <code>optional</code>,
+     * then the absence of that file doesn't lead to failures
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOptionalFileInclude() throws Exception {
+        final File ivySettingsXml = new File("test/repositories/ivysettings-optional-file-include.xml");
+        final Ivy ivy = new Ivy();
+        ivy.configure(ivySettingsXml);
+        final IvySettings ivySettings = ivy.getSettings();
+        // just test that it indeed parsed fine
+        assertTrue("Unexpected number of resolvers in Ivy settings", ivySettings.getResolvers().isEmpty());
+        final List<Status> statuses =ivySettings.getStatusManager().getStatuses();
+        assertEquals("Unexpected number of custom status in parsed Ivy settings", 1, statuses.size());
+        assertEquals("Custom status not found in the parsed Ivy settings", "ivy-1555", statuses.get(0).getName());
+    }
 }

--- a/test/repositories/ivysettings-optional-file-include.xml
+++ b/test/repositories/ivysettings-optional-file-include.xml
@@ -1,0 +1,27 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<ivysettings>
+    <!-- Include a non-existent file and mark it optional -->
+    <include file="${ivy.settings.dir}/foo/bar/i-am-not-present.xml" optional="true"/>
+    <!-- Same as previous non-existent file, but use an url attribute this time -->
+    <include url="${ivy.settings.dir.url}/foo/bar/i-am-not-present.xml" optional="true"/>
+    <statuses>
+        <status name="ivy-1555" integration="false"/>
+    </statuses>
+</ivysettings>


### PR DESCRIPTION
The commit here includes a fix and test case for the issue reported in https://issues.apache.org/jira/browse/IVY-1555 where the absence of a `optional` settings file included in another file, errors out the build.

The commit in this PR, takes into account the `optional` attribute value before deciding whether or not to cause the `IOException` to error out or be ignored (with a verbose log message).
