### PR TITLE
Fix transient test failures

### DIFF
--- a/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
@@ -18,7 +18,9 @@
 package org.apache.ivy.plugins.circular;
 
 import org.apache.ivy.TestHelper;
+import org.apache.ivy.core.IvyContext;
 import org.apache.ivy.util.Message;
+import org.apache.ivy.util.MessageLoggerEngine;
 import org.apache.ivy.util.MockMessageLogger;
 
 import junit.framework.TestCase;
@@ -27,12 +29,17 @@ public class IgnoreCircularDependencyStrategyTest extends TestCase {
     private CircularDependencyStrategy strategy;
 
     private MockMessageLogger mockMessageImpl;
+    private MessageLoggerEngine messageLoggerEngine;
 
     protected void setUp() throws Exception {
         strategy = IgnoreCircularDependencyStrategy.getInstance();
 
         mockMessageImpl = new MockMessageLogger();
-        Message.setDefaultLogger(mockMessageImpl);
+        messageLoggerEngine = setupMockLogger(mockMessageImpl);
+    }
+
+    protected void tearDown() throws Exception {
+        resetMockLogger(messageLoggerEngine);
     }
 
     public void testLog() throws Exception {
@@ -47,5 +54,21 @@ public class IgnoreCircularDependencyStrategyTest extends TestCase {
 
         // should only log the circular dependency once
         assertEquals(1, mockMessageImpl.getLogs().size());
+    }
+
+    private MessageLoggerEngine setupMockLogger(final MockMessageLogger mockLogger) {
+        if (mockLogger == null) {
+            return null;
+        }
+        final MessageLoggerEngine loggerEngine = IvyContext.getContext().getIvy().getLoggerEngine();
+        loggerEngine.pushLogger(mockLogger);
+        return loggerEngine;
+    }
+
+    private void resetMockLogger(final MessageLoggerEngine loggerEngine) {
+        if (loggerEngine == null) {
+            return;
+        }
+        loggerEngine.popLogger();
     }
 }

--- a/test/java/org/apache/ivy/plugins/circular/WarnCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/WarnCircularDependencyStrategyTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ivy.plugins.circular;
 
+import junit.framework.TestCase;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyContext;
 import org.apache.ivy.core.event.EventManager;
@@ -25,31 +26,33 @@ import org.apache.ivy.core.resolve.ResolveEngine;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
-import org.apache.ivy.util.Message;
+import org.apache.ivy.util.MessageLoggerEngine;
 import org.apache.ivy.util.MockMessageLogger;
-
-import junit.framework.TestCase;
 
 public class WarnCircularDependencyStrategyTest extends TestCase {
     private CircularDependencyStrategy strategy;
 
-    private MockMessageLogger mockMessageImpl;
+    private MessageLoggerEngine loggerEngine;
+    private MockMessageLogger mockMessageLogger;
 
     protected void setUp() throws Exception {
+        // setup a new IvyContext for each test
+        IvyContext.pushNewContext();
         strategy = WarnCircularDependencyStrategy.getInstance();
-
-        resetLogger();
+        mockMessageLogger = new MockMessageLogger();
+        loggerEngine = setupMockLogger(mockMessageLogger);
     }
 
-    private void resetLogger() {
-        mockMessageImpl = new MockMessageLogger();
-        Message.setDefaultLogger(mockMessageImpl);
+    protected void tearDown() throws Exception {
+        resetMockLogger(loggerEngine);
+        // pop the context we setup before
+        IvyContext.popContext();
     }
+
 
     public void testLog() throws Exception {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.0, #B;1.0"));
-
-        mockMessageImpl.assertLogWarningContains("circular dependency found: #A;1.0->#B;1.0");
+        mockMessageLogger.assertLogWarningContains("circular dependency found: #A;1.0->#B;1.0");
     }
 
     public void testRemoveDuplicates() throws Exception {
@@ -57,28 +60,29 @@ public class WarnCircularDependencyStrategyTest extends TestCase {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
 
         // should only log the circular dependency once
-        assertEquals(1, mockMessageImpl.getLogs().size());
+        assertEquals(1, mockMessageLogger.getWarns().size());
     }
 
     public void testRemoveDuplicates2() throws Exception {
         setResolveContext("1");
-        resetLogger();
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
 
         // should only log the circular dependency once
-        assertEquals(1, mockMessageImpl.getLogs().size());
+        assertEquals(1, mockMessageLogger.getWarns().size());
 
         setResolveContext("2");
-        resetLogger();
+        // clear previous logs
+        mockMessageLogger.clear();
+
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
         // should log the message
-        assertEquals(1, mockMessageImpl.getLogs().size());
+        assertEquals(1, mockMessageLogger.getWarns().size());
 
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
 
         // should not log the message again
-        assertEquals(1, mockMessageImpl.getLogs().size());
+        assertEquals(1, mockMessageLogger.getWarns().size());
     }
 
     private void setResolveContext(String resolveId) {
@@ -86,5 +90,21 @@ public class WarnCircularDependencyStrategyTest extends TestCase {
         IvyContext.getContext().setResolveData(
             new ResolveData(new ResolveEngine(settings, new EventManager(),
                     new SortEngine(settings)), new ResolveOptions().setResolveId(resolveId)));
+    }
+
+    private MessageLoggerEngine setupMockLogger(final MockMessageLogger mockLogger) {
+        if (mockLogger == null) {
+            return null;
+        }
+        final MessageLoggerEngine loggerEngine = IvyContext.getContext().getIvy().getLoggerEngine();
+        loggerEngine.pushLogger(mockLogger);
+        return loggerEngine;
+    }
+
+    private void resetMockLogger(final MessageLoggerEngine loggerEngine) {
+        if (loggerEngine == null) {
+            return;
+        }
+        loggerEngine.popLogger();
     }
 }

--- a/test/java/org/apache/ivy/util/MockMessageLogger.java
+++ b/test/java/org/apache/ivy/util/MockMessageLogger.java
@@ -66,6 +66,7 @@ public class MockMessageLogger extends AbstractMessageLogger {
     }
 
     public void clear() {
+        super.clearProblems();
         _logs.clear();
         _rawLogs.clear();
         _endProgress.clear();


### PR DESCRIPTION
The commit here fixes the transient test failures that we keep seeing in `WarnCircularDependencyStrategyTest`. More details about the fix are in this previous PR https://github.com/apache/ant-ivy/pull/22, but the real fix here is that we use a proper fresh `IvyContext` for each test method instead of unintentionally using the same one across test methods.