### PR TITLE
Convert tests to JUnit 4, clean up code

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -44,29 +44,27 @@
     </publications>
     <dependencies>
         <dependency org="org.apache.ant" name="ant" rev="1.9.9" conf="default,ant->default"/>
-        <dependency org="commons-httpclient" name="commons-httpclient" rev="3.0" conf="default,httpclient->runtime,master" />
+        <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" conf="default,httpclient->runtime,master"/>
         <dependency org="oro" name="oro" rev="2.0.8" conf="default,oro->default"/>
-        <dependency org="commons-vfs" name="commons-vfs" rev="1.0" conf="default,vfs->default" />
-        <dependency org="com.jcraft" name="jsch" rev="0.1.54" conf="default,sftp->default" />
-        <dependency org="com.jcraft" name="jsch.agentproxy" rev="0.0.9" conf="default,sftp->default" />
-        <dependency org="com.jcraft" name="jsch.agentproxy.connector-factory" rev="0.0.9" conf="default,sftp->default" />
-        <dependency org="com.jcraft" name="jsch.agentproxy.jsch" rev="0.0.9" conf="default,sftp->default" />
-        <dependency org="org.bouncycastle" name="bcpg-jdk15on" rev="1.52" conf="default" />
-        <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.52" conf="default" />
+        <dependency org="commons-vfs" name="commons-vfs" rev="1.0" conf="default,vfs->default"/>
+        <dependency org="com.jcraft" name="jsch" rev="0.1.54" conf="default,sftp->default"/>
+        <dependency org="com.jcraft" name="jsch.agentproxy" rev="0.0.9" conf="default,sftp->default"/>
+        <dependency org="com.jcraft" name="jsch.agentproxy.connector-factory" rev="0.0.9" conf="default,sftp->default"/>
+        <dependency org="com.jcraft" name="jsch.agentproxy.jsch" rev="0.0.9" conf="default,sftp->default"/>
+        <dependency org="org.bouncycastle" name="bcpg-jdk15on" rev="1.52" conf="default"/>
+        <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.52" conf="default"/>
 
         <!-- Test dependencies -->
-        <dependency org="junit" name="junit" rev="3.8.2" conf="test->default" />
-        <dependency org="commons-lang" name="commons-lang" rev="2.6" conf="test->default" />
-        <dependency org="org.apache.ant" name="ant-testutil" rev="1.9.9" conf="test->default" transitive="false" />
+        <dependency org="junit" name="junit" rev="4.12" conf="test->default"/>
+        <dependency org="org.hamcrest" name="hamcrest-core" rev="1.3" conf="test->default"/>
+        <dependency org="commons-lang" name="commons-lang" rev="2.6" conf="test->default"/>
+        <dependency org="org.apache.ant" name="ant-testutil" rev="1.9.9" conf="test->default" transitive="false"/>
         <dependency org="org.apache.ant" name="ant-launcher" rev="1.9.9" conf="test->default" transitive="false"/>
         <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3" conf="test->default" transitive="false"/>
         <dependency org="xmlunit" name="xmlunit" rev="1.6" conf="test->default" transitive="false"/>
-        
-        <!-- This dependency is necessary for having validation in junit tests when running with JDK1.4 -->
-        <dependency org="xerces" name="xercesImpl" rev="2.6.2" conf="test->default" />
-        <dependency org="xerces" name="xmlParserAPIs" rev="2.6.2" conf="test->default" />
 
-        <!-- Global exclude for junit -->
-        <exclude org="junit" module="junit" conf="core,default,httpclient,oro,vfs,sftp,standalone,ant" />
+        <!-- Global exclude for junit and hamcrest -->
+        <exclude org="junit" module="junit" conf="core,default,httpclient,oro,vfs,sftp,standalone,ant"/>
+        <exclude org="org.hamcrest" module="hamcrest-core" conf="core,default,httpclient,oro,vfs,sftp,standalone,ant"/>
     </dependencies>
 </ivy-module>

--- a/test/java/org/apache/ivy/IvyTest.java
+++ b/test/java/org/apache/ivy/IvyTest.java
@@ -25,13 +25,18 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
-public class IvyTest extends TestCase {
+public class IvyTest {
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
     }
@@ -41,10 +46,12 @@ public class IvyTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testMultipleInstances() throws Exception {
         // this test checks that IvyContext is properly set and unset when using multiple instances
         // of Ivy. We also check logging, because it heavily relies on IvyContext.

--- a/test/java/org/apache/ivy/MainTest.java
+++ b/test/java/org/apache/ivy/MainTest.java
@@ -25,13 +25,18 @@ import org.apache.ivy.util.cli.ParseException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class MainTest {
 
     private File cache;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -51,22 +56,18 @@ public class MainTest {
 
     @Test
     public void testBadOption() throws Exception {
-        try {
-            run(new String[] {"-bad"});
-            fail("running Ivy Main with -bad option should raise an exception");
-        } catch (ParseException ex) {
-            assertEquals("Unrecognized option: -bad", ex.getMessage());
-        }
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("Unrecognized option: -bad");
+
+        run(new String[] {"-bad"});
     }
 
     @Test
     public void testMissingParameter() throws Exception {
-        try {
-            run(new String[] {"-ivy"});
-            fail("running Ivy Main with missing argument for -ivy option should raise an exception");
-        } catch (ParseException ex) {
-            assertEquals("no argument for: ivy", ex.getMessage());
-        }
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("no argument for: ivy");
+
+        run(new String[] {"-ivy"});
     }
 
     @Test

--- a/test/java/org/apache/ivy/MainTest.java
+++ b/test/java/org/apache/ivy/MainTest.java
@@ -23,25 +23,33 @@ import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.cli.CommandLine;
 import org.apache.ivy.util.cli.ParseException;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class MainTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class MainTest {
 
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         cache = new File("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testHelp() throws Exception {
         run(new String[] {"-?"});
     }
 
+    @Test
     public void testBadOption() throws Exception {
         try {
             run(new String[] {"-bad"});
@@ -51,6 +59,7 @@ public class MainTest extends TestCase {
         }
     }
 
+    @Test
     public void testMissingParameter() throws Exception {
         try {
             run(new String[] {"-ivy"});
@@ -60,24 +69,28 @@ public class MainTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveSimple() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
+    @Test
     public void testResolveSimpleWithConfs() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "-confs", "default"});
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
+    @Test
     public void testResolveSimpleWithConfs2() throws Exception {
         run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs", "default",
                 "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
+    @Test
     public void testExtraParams1() throws Exception {
         String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
                 "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "foo1",
@@ -90,6 +103,7 @@ public class MainTest extends TestCase {
         assertEquals("foo2", leftOver[1]);
     }
 
+    @Test
     public void testExtraParams2() throws Exception {
         String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
                 "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "--",
@@ -102,6 +116,7 @@ public class MainTest extends TestCase {
         assertEquals("foo2", leftOver[1]);
     }
 
+    @Test
     public void testExtraParams3() throws Exception {
         String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
                 "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"};

--- a/test/java/org/apache/ivy/TestFixture.java
+++ b/test/java/org/apache/ivy/TestFixture.java
@@ -19,7 +19,6 @@ package org.apache.ivy;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,18 +37,21 @@ import org.apache.ivy.plugins.resolver.util.ResolvedResource;
  * Example of use:
  * 
  * <pre>
- * public class MyTest extends TestCase {
+ * public class MyTest {
  *     private TestFixture fixture;
- * 
- *     protected void setUp() throws Exception {
+ *
+ *     @Before
+ *     public void setUp() throws Exception {
  *         fixture = new TestFixture();
  *         // additional setup here
  *     }
- * 
- *     protected void tearDown() throws Exception {
+ *
+ *     @After
+ *     public void tearDown() throws Exception {
  *         fixture.clean();
  *     }
- * 
+ *
+ *     @Test
  *     public void testXXX() throws Exception {
  *         fixture.addMD(&quot;#A;1-&gt; { #B;[1.5,1.6] #C;2.5 }&quot;).addMD(&quot;#B;1.5-&gt;#D;2.0&quot;)
  *                 .addMD(&quot;#B;1.6-&gt;#D;2.0&quot;).addMD(&quot;#C;2.5-&gt;#D;[1.0,1.6]&quot;).addMD(&quot;#D;1.5&quot;)
@@ -115,7 +117,7 @@ public class TestFixture {
         return ((FileResource) r.getResource()).getFile();
     }
 
-    public ResolveReport resolve(String mrid) throws MalformedURLException, ParseException,
+    public ResolveReport resolve(String mrid) throws ParseException,
             IOException {
         return ivy.resolve(getIvyFile(mrid), TestHelper.newResolveOptions(getSettings()));
     }

--- a/test/java/org/apache/ivy/TestHelper.java
+++ b/test/java/org/apache/ivy/TestHelper.java
@@ -48,7 +48,7 @@ import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 
-import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
 
 public class TestHelper {
 
@@ -97,7 +97,7 @@ public class TestHelper {
     public static void assertModuleRevisionIds(String expectedMrids,
             Collection/* <ModuleRevisionId> */mrids) {
         Collection expected = parseMrids(expectedMrids);
-        Assert.assertEquals(expected, mrids);
+        assertEquals(expected, mrids);
     }
 
     /**
@@ -284,8 +284,7 @@ public class TestHelper {
 
     /**
      * Cleans up the test repository and cache.
-     * 
-     * @see #newTestSettings()
+     *
      */
     public static void cleanTest() {
         cleanTestRepository();

--- a/test/java/org/apache/ivy/ant/AntBuildResolverTest.java
+++ b/test/java/org/apache/ivy/ant/AntBuildResolverTest.java
@@ -24,13 +24,18 @@ import org.apache.ivy.ant.AntWorkspaceResolver.WorkspaceArtifact;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.DownloadStatus;
 import org.apache.ivy.core.report.ResolveReport;
+
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class AntBuildResolverTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class AntBuildResolverTest {
 
     private static final ModuleRevisionId MRID_MODULE1 = ModuleRevisionId.newInstance("org.acme",
         "module1", "1.1");
@@ -44,8 +49,8 @@ public class AntBuildResolverTest extends TestCase {
 
     private WorkspaceArtifact wa;
 
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.cleanCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
@@ -67,11 +72,12 @@ public class AntBuildResolverTest extends TestCase {
         configure.execute();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testNoProject() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -84,6 +90,7 @@ public class AntBuildResolverTest extends TestCase {
         assertEquals(MRID_MODULE1, report.getDependencies().get(0).getResolvedId());
     }
 
+    @Test
     public void testProject() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -105,6 +112,7 @@ public class AntBuildResolverTest extends TestCase {
             report.getArtifactsReports(MRID_PROJECT1)[0].getLocalFile());
     }
 
+    @Test
     public void testProjectFolder() throws Exception {
         wa.setPath("target/classes");
 
@@ -127,6 +135,7 @@ public class AntBuildResolverTest extends TestCase {
             report.getArtifactsReports(MRID_PROJECT1)[0].getLocalFile());
     }
 
+    @Test
     public void testDependencyArtifact() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -148,6 +157,7 @@ public class AntBuildResolverTest extends TestCase {
             report.getArtifactsReports(MRID_PROJECT1)[0].getLocalFile());
     }
 
+    @Test
     public void testCachePath() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -169,6 +179,7 @@ public class AntBuildResolverTest extends TestCase {
             path.list()[1]);
     }
 
+    @Test
     public void testCachePathFolder() throws Exception {
         wa.setPath("target/classes");
 

--- a/test/java/org/apache/ivy/ant/AntBuildTriggerTest.java
+++ b/test/java/org/apache/ivy/ant/AntBuildTriggerTest.java
@@ -23,9 +23,14 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.util.FileUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Test;
 
-public class AntBuildTriggerTest extends TestCase {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AntBuildTriggerTest {
+    @Test
     public void test() throws Exception {
         assertFalse(new File("test/triggers/ant-build/A/A.jar").exists());
 
@@ -39,7 +44,8 @@ public class AntBuildTriggerTest extends TestCase {
         assertTrue(new File("test/triggers/ant-build/local/A/A.jar").exists());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(new File("test/triggers/ant-build/local/A"));
         FileUtil.forceDelete(new File("test/triggers/ant-build/cache"));
     }

--- a/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
+++ b/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
@@ -17,12 +17,16 @@
  */
 package org.apache.ivy.ant;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Vector;
 
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.BuildLogger;
 import org.apache.tools.ant.DefaultLogger;
@@ -34,9 +38,11 @@ import org.apache.tools.ant.ProjectHelper;
 import org.apache.tools.ant.input.DefaultInputHandler;
 import org.apache.tools.ant.input.InputHandler;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Test;
 
-public class AntCallTriggerTest extends TestCase {
+public class AntCallTriggerTest {
+    @Test
     public void test() throws Exception {
         assertFalse(new File("test/triggers/ant-call/A/out/foo.txt").exists());
         runAnt(new File("test/triggers/ant-call/A/build.xml"), "resolve");
@@ -44,7 +50,8 @@ public class AntCallTriggerTest extends TestCase {
         assertTrue(new File("test/triggers/ant-call/A/out/foo.txt").exists());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(new File("test/triggers/ant-call/A/out"));
         FileUtil.forceDelete(new File("test/triggers/ant-call/cache"));
     }
@@ -173,6 +180,7 @@ public class AntCallTriggerTest extends TestCase {
      * @param project
      *            the project instance.
      * @param inputHandlerClassname
+     *            String
      * @exception BuildException
      *                if a specified InputHandler implementation could not be loaded.
      */

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -17,22 +17,26 @@
  */
 package org.apache.ivy.ant;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.ParseException;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.util.CollectionUtils;
+
 import org.apache.tools.ant.Project;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import org.xml.sax.SAXException;
 
-import junit.framework.TestCase;
-
-public class BuildOBRTaskTest extends TestCase {
+public class BuildOBRTaskTest {
 
     private File cache;
 
@@ -40,7 +44,8 @@ public class BuildOBRTaskTest extends TestCase {
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
         project = TestHelper.newProject();
 
@@ -54,12 +59,12 @@ public class BuildOBRTaskTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
-    private BundleRepoDescriptor readObr(File obrFile) throws FileNotFoundException,
-            ParseException, IOException, SAXException {
+    private BundleRepoDescriptor readObr(File obrFile) throws IOException, SAXException {
         BundleRepoDescriptor obr;
         FileInputStream in = new FileInputStream(obrFile);
         try {
@@ -70,6 +75,7 @@ public class BuildOBRTaskTest extends TestCase {
         return obr;
     }
 
+    @Test
     public void testDir() throws Exception {
         buildObr.setBaseDir(new File("test/test-repo/bundlerepo"));
         File obrFile = new File("build/cache/obr.xml");

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -42,15 +42,12 @@ public class BuildOBRTaskTest {
 
     private BuildOBRTask buildObr;
 
-    private Project project;
-
     @Before
     public void setUp() {
         createCache();
-        project = TestHelper.newProject();
 
         buildObr = new BuildOBRTask();
-        buildObr.setProject(project);
+        buildObr.setProject(TestHelper.newProject());
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
     }
 

--- a/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
+++ b/test/java/org/apache/ivy/ant/FixDepsTaskTest.java
@@ -26,17 +26,24 @@ import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class FixDepsTaskTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FixDepsTaskTest {
 
     private FixDepsTask fixDeps;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -46,10 +53,12 @@ public class FixDepsTaskTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
 
@@ -78,6 +87,7 @@ public class FixDepsTaskTest extends TestCase {
         assertEquals("2.0", md.getDependencies()[0].getDependencyRevisionId().getRevision());
     }
 
+    @Test
     public void testMulticonf() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
 
@@ -124,6 +134,7 @@ public class FixDepsTaskTest extends TestCase {
         assertEquals("default", md.getDependencies()[1].getDependencyConfigurations("compile")[0]);
     }
 
+    @Test
     public void testTransitivity() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-transitive.xml");
 
@@ -181,6 +192,7 @@ public class FixDepsTaskTest extends TestCase {
         assertEquals("*", md.getDependencies()[2].getDependencyConfigurations("compile")[0]);
     }
 
+    @Test
     public void testFixedResolve() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-transitive.xml");
 

--- a/test/java/org/apache/ivy/ant/IvyAntSettingsBuildFileTest.java
+++ b/test/java/org/apache/ivy/ant/IvyAntSettingsBuildFileTest.java
@@ -18,50 +18,66 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.core.report.ResolveReport;
-import org.apache.tools.ant.BuildFileTest;
 
-public class IvyAntSettingsBuildFileTest extends BuildFileTest {
+import org.apache.tools.ant.BuildFileRule;
 
-    protected void setUp() throws Exception {
-        configureProject("test/java/org/apache/ivy/ant/IvyAntSettingsBuildFile.xml");
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IvyAntSettingsBuildFileTest {
+
+    @Rule
+    public final BuildFileRule buildRule = new BuildFileRule();
+
+    @Before
+    public void setUp() {
+        buildRule.configureProject("test/java/org/apache/ivy/ant/IvyAntSettingsBuildFile.xml");
     }
 
+    @Test
     public void testOverrideNotSpecified() {
-        executeTarget("testOverrideNotSpecified");
-        ResolveReport report = (ResolveReport) getProject().getReference("ivy.resolved.report");
+        buildRule.executeTarget("testOverrideNotSpecified");
+        ResolveReport report = buildRule.getProject().getReference("ivy.resolved.report");
         assertNotNull(report);
         assertFalse(report.hasError());
         assertEquals(1, report.getDependencies().size());
     }
 
+    @Test
     public void testOverrideSetToFalse() {
-        executeTarget("testOverrideSetToFalse");
-        ResolveReport report = (ResolveReport) getProject().getReference("ivy.resolved.report");
+        buildRule.executeTarget("testOverrideSetToFalse");
+        ResolveReport report = buildRule.getProject().getReference("ivy.resolved.report");
         assertNotNull(report);
         assertFalse(report.hasError());
         assertEquals(1, report.getDependencies().size());
     }
 
+    @Test
     public void testUnnecessaryDefaultIvyInstance() {
-        executeTarget("testUnnecessaryDefaultIvyInstance");
-        assertNull("Default ivy.instance settings shouldn't have been loaded", getProject()
-                .getReference("ivy.instance"));
+        buildRule.executeTarget("testUnnecessaryDefaultIvyInstance");
+        assertNull("Default ivy.instance settings shouldn't have been loaded",
+                buildRule.getProject().getReference("ivy.instance"));
     }
 
+    @Test
     public void testSettingsWithIdIvyInstance() {
         // IVY-925
-        executeTarget("testSettingsWithPropertyAsId");
-        ResolveReport report = (ResolveReport) getProject().getReference("ivy.resolved.report");
+        buildRule.executeTarget("testSettingsWithPropertyAsId");
+        ResolveReport report = buildRule.getProject().getReference("ivy.resolved.report");
         assertNotNull(report);
         assertFalse(report.hasError());
         assertEquals(1, report.getDependencies().size());
     }
 
+    @Test
     public void testStackOverflow() {
         // IVY-924
-        configureProject("test/java/org/apache/ivy/ant/IvyAntSettingsBuildFileStackOverflow.xml");
-        executeTarget("testStackOverflow");
-        ResolveReport report = (ResolveReport) getProject().getReference("ivy.resolved.report");
+        buildRule.configureProject("test/java/org/apache/ivy/ant/IvyAntSettingsBuildFileStackOverflow.xml");
+        buildRule.executeTarget("testStackOverflow");
+        ResolveReport report = buildRule.getProject().getReference("ivy.resolved.report");
         assertNotNull(report);
         assertFalse(report.hasError());
         assertEquals(1, report.getDependencies().size());

--- a/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
@@ -91,16 +91,16 @@ public class IvyArtifactPropertyTest {
             new File(val).getCanonicalPath());
     }
 
-    @Test
+    /**
+     * Test must fail because no resolve was performed
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
     public void testWithResolveIdWithoutResolve() throws Exception {
-        try {
-            prop.setName("[module].[artifact]-[revision]");
-            prop.setValue("${cache.dir}/[module]/[artifact]-[revision].[type]");
-            prop.setResolveId("abc");
-            prop.execute();
-            fail("Task should have failed because no resolve was performed!");
-        } catch (BuildException e) {
-            // this is expected!
-        }
+        prop.setName("[module].[artifact]-[revision]");
+        prop.setValue("${cache.dir}/[module]/[artifact]-[revision].[type]");
+        prop.setResolveId("abc");
+        prop.execute();
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactPropertyTest.java
@@ -20,18 +20,26 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyArtifactPropertyTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class IvyArtifactPropertyTest {
 
     private IvyArtifactProperty prop;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -41,10 +49,12 @@ public class IvyArtifactPropertyTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         prop.setName("[module].[artifact]-[revision]");
@@ -56,6 +66,7 @@ public class IvyArtifactPropertyTest extends TestCase {
             new File(val).getCanonicalPath());
     }
 
+    @Test
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -80,6 +91,7 @@ public class IvyArtifactPropertyTest extends TestCase {
             new File(val).getCanonicalPath());
     }
 
+    @Test
     public void testWithResolveIdWithoutResolve() throws Exception {
         try {
             prop.setName("[module].[artifact]-[revision]");

--- a/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyArtifactReportTest.java
@@ -20,17 +20,23 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyArtifactReportTest extends TestCase {
+import static org.junit.Assert.assertTrue;
+
+public class IvyArtifactReportTest {
 
     private IvyArtifactReport prop;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -40,10 +46,12 @@ public class IvyArtifactReportTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         prop.setTofile(new File("build/test-artifact-report.xml"));
         prop.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));

--- a/test/java/org/apache/ivy/ant/IvyBuildListTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildListTest.java
@@ -24,16 +24,23 @@ import java.util.List;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 // CheckStyle:MagicNumber| OFF
 // The test very often use MagicNumber. Using a constant is less expressive.
 
-public class IvyBuildListTest extends TestCase {
+public class IvyBuildListTest {
 
     private File cache;
 
@@ -41,7 +48,8 @@ public class IvyBuildListTest extends TestCase {
 
     private IvyBuildList buildlist;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
 
         project = TestHelper.newProject();
@@ -53,7 +61,8 @@ public class IvyBuildListTest extends TestCase {
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         cleanCache();
     }
 
@@ -92,6 +101,7 @@ public class IvyBuildListTest extends TestCase {
      * C B has no dependency C -> B D -> A , B E has no dependency F -> G G -> F
      */
 
+    @Test
     public void testSimple() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -108,6 +118,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B", "C", "A", "D", "E"}, files);
     }
 
+    @Test
     public void testReverse() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -125,6 +136,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"E", "D", "A", "C", "B"}, files);
     }
 
+    @Test
     public void testWithRoot() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -142,6 +154,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B", "C"}, files);
     }
 
+    @Test
     public void testWithRootCircular() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -156,6 +169,7 @@ public class IvyBuildListTest extends TestCase {
         assertEquals(2, files.length); // F and G should be in the list
     }
 
+    @Test
     public void testWithTwoRoots() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -173,6 +187,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B", "C", "E"}, files);
     }
 
+    @Test
     public void testWithRootExclude() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -191,6 +206,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B"}, files);
     }
 
+    @Test
     public void testWithRootAndOnlyDirectDep() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -209,6 +225,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"C", "A"}, files);
     }
 
+    @Test
     public void testWithLeaf() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -226,6 +243,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"C", "A", "D"}, files);
     }
 
+    @Test
     public void testWithLeafCircular() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -240,6 +258,7 @@ public class IvyBuildListTest extends TestCase {
         assertEquals(2, files.length);
     }
 
+    @Test
     public void testWithTwoLeafs() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -257,6 +276,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"C", "A", "D", "E"}, files);
     }
 
+    @Test
     public void testWithLeafExclude() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -275,6 +295,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"A", "D"}, files);
     }
 
+    @Test
     public void testWithLeafAndOnlyDirectDep() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -293,6 +314,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"C", "A"}, files);
     }
 
+    @Test
     public void testRestartFrom() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -310,6 +332,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"C", "A", "D", "E"}, files);
     }
 
+    @Test
     public void testOnMissingDescriptor() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -326,6 +349,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B", "C", "A", "D", "E", "H"}, files);
     }
 
+    @Test
     public void testOnMissingDescriptor2() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -342,6 +366,7 @@ public class IvyBuildListTest extends TestCase {
         assertListOfFiles("test/buildlist/", new String[] {"B", "C", "A", "D", "E"}, files);
     }
 
+    @Test
     public void testWithModuleWithSameNameAndDifferentOrg() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlist"));
@@ -368,6 +393,7 @@ public class IvyBuildListTest extends TestCase {
             other.get(1));
     }
 
+    @Test
     public void testNoParents() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlists/testNoParents"));
@@ -385,6 +411,7 @@ public class IvyBuildListTest extends TestCase {
                 "ireland", "germany", "master-parent", "croatia"}, files);
     }
 
+    @Test
     public void testOneParent() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlists/testOneParent"));
@@ -402,6 +429,7 @@ public class IvyBuildListTest extends TestCase {
                 "master-parent", "croatia", "ireland", "germany"}, files);
     }
 
+    @Test
     public void testTwoParents() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlists/testTwoParents"));
@@ -419,6 +447,7 @@ public class IvyBuildListTest extends TestCase {
                 "master-parent", "croatia", "ireland", "germany"}, files);
     }
 
+    @Test
     public void testRelativePathToParent() {
         FileSet fs = new FileSet();
         fs.setDir(new File("test/buildlists/testRelativePathToParent"));
@@ -436,6 +465,7 @@ public class IvyBuildListTest extends TestCase {
                 "bootstrap-parent", "master-parent", "croatia", "ireland", "germany"}, files);
     }
 
+    @Test
     public void testAbsolutePathToParent() {
         project.setProperty("master-parent.dir", new File(
                 "test/buildlists/testAbsolutePathToParent/master-parent").getAbsolutePath());

--- a/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
+++ b/test/java/org/apache/ivy/ant/IvyBuildNumberTest.java
@@ -18,15 +18,21 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyBuildNumberTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class IvyBuildNumberTest {
 
     private IvyBuildNumber buildNumber;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -35,10 +41,12 @@ public class IvyBuildNumberTest extends TestCase {
         buildNumber.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testDefault() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("newmod");
@@ -49,6 +57,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("0", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testDefault2() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("newmod");
@@ -60,6 +69,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testDefault3() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("newmod");
@@ -71,6 +81,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals(null, buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testLatest() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.1");
@@ -81,6 +92,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testLatest2() throws Exception {
         buildNumber.setOrganisation("orgbn");
         buildNumber.setModule("buildnumber");
@@ -91,6 +103,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testPrefix() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.1");
@@ -102,6 +115,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("test.new.build.number"));
     }
 
+    @Test
     public void testBuildNumber() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.1");
@@ -113,6 +127,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("2", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testBuildNumber2() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.5");
@@ -124,6 +139,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testBuildNumber3() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.1");
@@ -135,6 +151,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testBuildNumber4() throws Exception {
         buildNumber.setOrganisation("org1");
         buildNumber.setModule("mod1.1");
@@ -146,6 +163,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("0", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testWithBadChecksum() throws Exception {
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-checksums.xml");
@@ -162,6 +180,7 @@ public class IvyBuildNumberTest extends TestCase {
         assertEquals("1", buildNumber.getProject().getProperty("ivy.new.build.number"));
     }
 
+    @Test
     public void testChainResolver() throws Exception {
         // IVY-1037
         Project project = TestHelper.newProject();

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -20,21 +20,32 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 import org.apache.tools.ant.types.FileSet;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-public class IvyCacheFilesetTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyCacheFilesetTest {
 
     private IvyCacheFileset fileset;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
+
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -44,10 +55,12 @@ public class IvyCacheFilesetTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         fileset.setSetid("simple-setid");
@@ -76,6 +89,7 @@ public class IvyCacheFilesetTest extends TestCase {
             revision, artifact, type, ext);
     }
 
+    @Test
     public void testEmptyConf() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-108.xml");
         fileset.setSetid("emptyconf-setid");
@@ -90,30 +104,24 @@ public class IvyCacheFilesetTest extends TestCase {
         assertEquals(0, directoryScanner.getIncludedFiles().length);
     }
 
+    @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
-        try {
-            project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
-            fileset.setSetid("failure-setid");
-            fileset.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raised an exception
-        }
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
+        fileset.setSetid("failure-setid");
+        fileset.execute();
+        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    @Test(expected = BuildException.class)
     public void testInvalidPattern() throws Exception {
-        try {
-            project.setProperty("ivy.settings.file",
-                "test/repositories/ivysettings-invalidcachepattern.xml");
-            project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
-            fileset.setSetid("simple-setid");
-            fileset.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raise an exception
-        }
+        project.setProperty("ivy.settings.file", "test/repositories/ivysettings-invalidcachepattern.xml");
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
+        fileset.setSetid("simple-setid");
+        fileset.execute();
+        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    @Test
     public void testHaltOnFailure() throws Exception {
         try {
             project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
@@ -125,6 +133,7 @@ public class IvyCacheFilesetTest extends TestCase {
         }
     }
 
+    @Test
     public void testWithoutPreviousResolveAndNonDefaultCache() throws Exception {
         File cache2 = new File("build/cache2");
         cache2.mkdirs();
@@ -152,6 +161,7 @@ public class IvyCacheFilesetTest extends TestCase {
         }
     }
 
+    @Test
     public void testGetBaseDir() {
         File base = null;
         base = fileset.getBaseDir(base, new File("x/aa/b/c"));

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -104,21 +104,29 @@ public class IvyCacheFilesetTest {
         assertEquals(0, directoryScanner.getIncludedFiles().length);
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
         fileset.setSetid("failure-setid");
         fileset.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testInvalidPattern() throws Exception {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-invalidcachepattern.xml");
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         fileset.setSetid("simple-setid");
         fileset.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyCachePathTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCachePathTest.java
@@ -132,12 +132,16 @@ public class IvyCachePathTest {
         assertEquals(0, p.size());
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
         path.setPathid("failure-pathid");
         path.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyCachePathTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCachePathTest.java
@@ -20,19 +20,25 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Path;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyCachePathTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyCachePathTest {
 
     private IvyCachePath path;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -42,10 +48,12 @@ public class IvyCachePathTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         path.setPathid("simple-pathid");
@@ -59,6 +67,7 @@ public class IvyCachePathTest extends TestCase {
                 .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
     }
 
+    @Test
     public void testInline1() throws Exception {
         // we first resolve another ivy file
         IvyResolve resolve = new IvyResolve();
@@ -84,6 +93,7 @@ public class IvyCachePathTest extends TestCase {
                 .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
     }
 
+    @Test
     public void testInline2() throws Exception {
         // we first resolve a dependency directly
         path.setOrganisation("org1");
@@ -109,6 +119,7 @@ public class IvyCachePathTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testEmptyConf() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-108.xml");
         path.setPathid("emptyconf-pathid");
@@ -121,17 +132,15 @@ public class IvyCachePathTest extends TestCase {
         assertEquals(0, p.size());
     }
 
+    @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
-        try {
-            project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
-            path.setPathid("failure-pathid");
-            path.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raised an exception
-        }
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
+        path.setPathid("failure-pathid");
+        path.execute();
+        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    @Test
     public void testHaltOnFailure() throws Exception {
         try {
             project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
@@ -143,6 +152,7 @@ public class IvyCachePathTest extends TestCase {
         }
     }
 
+    @Test
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -169,6 +179,7 @@ public class IvyCachePathTest extends TestCase {
                 .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
     }
 
+    @Test
     public void testWithResolveIdWithoutResolve() throws Exception {
         Project otherProject = TestHelper.newProject();
         otherProject.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -199,6 +210,7 @@ public class IvyCachePathTest extends TestCase {
                 .getAbsolutePath(), new File(p.list()[0]).getAbsolutePath());
     }
 
+    @Test
     public void testWithResolveIdAndMissingConfs() throws Exception {
         Project otherProject = TestHelper.newProject();
         otherProject.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -225,6 +237,7 @@ public class IvyCachePathTest extends TestCase {
         path.execute();
     }
 
+    @Test
     public void testUnpack() throws Exception {
         project.setProperty("ivy.dep.file",
             "test/repositories/1/packaging/module1/ivys/ivy-1.0.xml");
@@ -238,6 +251,7 @@ public class IvyCachePathTest extends TestCase {
         assertTrue(new File(p.list()[0]).isDirectory());
     }
 
+    @Test
     public void testOSGi() throws Exception {
         project.setProperty("ivy.dep.file",
             "test/repositories/1/packaging/module5/ivys/ivy-1.0.xml");
@@ -257,6 +271,7 @@ public class IvyCachePathTest extends TestCase {
         assertEquals(new File(unpacked, "lib/ant-apache-log4j.jar"), new File(p.list()[3]));
     }
 
+    @Test
     public void testOSGi2() throws Exception {
         project.setProperty("ivy.dep.file",
             "test/repositories/1/packaging/module6/ivys/ivy-1.0.xml");
@@ -273,6 +288,7 @@ public class IvyCachePathTest extends TestCase {
         assertEquals(unpacked, new File(p.list()[0]));
     }
 
+    @Test
     public void testPackedOSGi() throws Exception {
         project.setProperty("ivy.dep.file",
             "test/repositories/1/packaging/module8/ivys/ivy-1.0.xml");

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -105,6 +105,11 @@ public class IvyCleanCacheTest {
         assertTrue(repoCache2.exists());
     }
 
+    /**
+     * clean cache must fail with unknown cache
+     *
+     * @throws Exception
+     */
     @Test
     public void testUnknownCache() throws Exception {
         expExc.expect(BuildException.class);
@@ -112,6 +117,5 @@ public class IvyCleanCacheTest {
         cleanCache.setResolution(false);
         cleanCache.setCache("yourcache");
         cleanCache.perform();
-        fail("clean cache should have raised an exception with unknown cache");
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -20,12 +20,21 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-public class IvyCleanCacheTest extends TestCase {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class IvyCleanCacheTest {
     private IvyCleanCache cleanCache;
 
     private File cacheDir;
@@ -36,7 +45,11 @@ public class IvyCleanCacheTest extends TestCase {
 
     private File resolutionCache;
 
-    protected void setUp() throws Exception {
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
         Project p = TestHelper.newProject();
         cacheDir = new File("build/cache");
         p.setProperty("cache", cacheDir.getAbsolutePath());
@@ -56,6 +69,7 @@ public class IvyCleanCacheTest extends TestCase {
         repoCache2.mkdirs();
     }
 
+    @Test
     public void testCleanAll() throws Exception {
         cleanCache.perform();
         assertFalse(resolutionCache.exists());
@@ -63,6 +77,7 @@ public class IvyCleanCacheTest extends TestCase {
         assertFalse(repoCache2.exists());
     }
 
+    @Test
     public void testResolutionOnly() throws Exception {
         cleanCache.setCache(IvyCleanCache.NONE);
         cleanCache.perform();
@@ -71,6 +86,7 @@ public class IvyCleanCacheTest extends TestCase {
         assertTrue(repoCache2.exists());
     }
 
+    @Test
     public void testRepositoryOnly() throws Exception {
         cleanCache.setResolution(false);
         cleanCache.perform();
@@ -79,6 +95,7 @@ public class IvyCleanCacheTest extends TestCase {
         assertFalse(repoCache2.exists());
     }
 
+    @Test
     public void testOneRepositoryOnly() throws Exception {
         cleanCache.setResolution(false);
         cleanCache.setCache("mycache");
@@ -88,14 +105,13 @@ public class IvyCleanCacheTest extends TestCase {
         assertTrue(repoCache2.exists());
     }
 
+    @Test
     public void testUnknownCache() throws Exception {
+        expExc.expect(BuildException.class);
+        expExc.expectMessage("unknown cache 'yourcache'");
         cleanCache.setResolution(false);
         cleanCache.setCache("yourcache");
-        try {
-            cleanCache.perform();
-            fail("clean cache should have raised an exception with unkown cache");
-        } catch (BuildException e) {
-            assertTrue(e.getMessage().indexOf("yourcache") != -1);
-        }
+        cleanCache.perform();
+        fail("clean cache should have raised an exception with unknown cache");
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyConfigureTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConfigureTest.java
@@ -25,18 +25,23 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.IvyRepResolver;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Reference;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyConfigureTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyConfigureTest {
     private IvyConfigure configure;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         project = TestHelper.newProject();
         project.setProperty("myproperty", "myvalue");
 
@@ -44,6 +49,7 @@ public class IvyConfigureTest extends TestCase {
         configure.setProject(project);
     }
 
+    @SuppressWarnings("deprecation")
     private Ivy getIvyInstance() {
         IvyTask task = new IvyTask() {
             public void doExecute() throws BuildException {
@@ -58,6 +64,7 @@ public class IvyConfigureTest extends TestCase {
         return task.getIvyInstance();
     }
 
+    @Test
     public void testDefaultCacheDir() {
         // test with an URL
         configure.setUrl(getClass().getResource("ivysettings-defaultCacheDir.xml"));
@@ -90,6 +97,7 @@ public class IvyConfigureTest extends TestCase {
         assertNotNull(project.getProperty("ivy.cache.dir.test3"));
     }
 
+    @Test
     public void testDefault() throws Exception {
         // by default settings look in the current directory for an ivysettings.xml file...
         // but Ivy itself has one, and we don't want to use it
@@ -106,6 +114,7 @@ public class IvyConfigureTest extends TestCase {
         assertTrue(ibiblio.isM2compatible());
     }
 
+    @Test
     public void testDefault14() throws Exception {
         // by default settings look in the current directory for an ivysettings.xml file...
         // but Ivy itself has one, and we don't want to use it
@@ -120,6 +129,7 @@ public class IvyConfigureTest extends TestCase {
         assertTrue(publicResolver instanceof IvyRepResolver);
     }
 
+    @Test
     public void testFile() throws Exception {
         configure.setFile(new File("test/repositories/ivysettings.xml"));
 
@@ -141,6 +151,7 @@ public class IvyConfigureTest extends TestCase {
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
 
+    @Test
     public void testURL() throws Exception {
         String confUrl = new File("test/repositories/ivysettings-url.xml").toURI().toURL()
                 .toExternalForm();
@@ -160,6 +171,7 @@ public class IvyConfigureTest extends TestCase {
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
 
+    @Test
     public void testAntProperties() throws Exception {
         String confUrl = IvyConfigureTest.class.getResource("ivysettings-test.xml")
                 .toExternalForm();
@@ -174,6 +186,7 @@ public class IvyConfigureTest extends TestCase {
         assertEquals("myvalue", settings.getDefaultResolver().getName());
     }
 
+    @Test
     public void testOverrideVariables() throws Exception {
         String confUrl = IvyConfigureTest.class.getResource("ivysettings-props.xml")
                 .toExternalForm();
@@ -188,6 +201,7 @@ public class IvyConfigureTest extends TestCase {
             settings.getVariables().getVariable("ivy.retrieve.pattern"));
     }
 
+    @Test
     public void testExposeAntProperties() throws Exception {
         String confUrl = IvyConfigureTest.class.getResource("ivysettings-props.xml")
                 .toExternalForm();
@@ -202,6 +216,7 @@ public class IvyConfigureTest extends TestCase {
         assertEquals("value", configure.getProject().getProperty("ivy.test.variable.this.id"));
     }
 
+    @Test
     public void testIncludeTwice() throws Exception {
         // IVY-601
         configure.setFile(new File("test/java/org/apache/ivy/ant/ivysettings-include-twice.xml"));
@@ -211,6 +226,7 @@ public class IvyConfigureTest extends TestCase {
         assertNotNull(getIvyInstance());
     }
 
+    @Test
     public void testOverrideTrue() throws Exception {
         configure.setFile(new File("test/repositories/ivysettings.xml"));
         configure.execute();
@@ -228,6 +244,7 @@ public class IvyConfigureTest extends TestCase {
         assertTrue(ivy != getIvyInstance());
     }
 
+    @Test
     public void testOverrideFalse() throws Exception {
         configure.setFile(new File("test/repositories/ivysettings.xml"));
         configure.execute();
@@ -244,6 +261,7 @@ public class IvyConfigureTest extends TestCase {
         assertTrue(ivy == getIvyInstance());
     }
 
+    @Test
     public void testOverrideNotAllowed() throws Exception {
         configure.setFile(new File("test/repositories/ivysettings.xml"));
         configure.execute();
@@ -261,17 +279,18 @@ public class IvyConfigureTest extends TestCase {
             fail("calling settings twice with the same id with "
                     + "override=notallowed should raise an exception");
         } catch (BuildException e) {
-            assertTrue(e.getMessage().indexOf("notallowed") != -1);
-            assertTrue(e.getMessage().indexOf(configure.getSettingsId()) != -1);
+            assertTrue(e.getMessage().contains("notallowed"));
+            assertTrue(e.getMessage().contains(configure.getSettingsId()));
         }
     }
 
+    @Test
     public void testInvalidOverride() throws Exception {
         try {
             configure.setOverride("unknown");
             fail("settings override with invalid value should raise an exception");
         } catch (Exception e) {
-            assertTrue(e.getMessage().indexOf("unknown") != -1);
+            assertTrue(e.getMessage().contains("unknown"));
         }
     }
 

--- a/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConvertPomTest.java
@@ -21,9 +21,10 @@ import java.io.File;
 
 import org.apache.ivy.TestHelper;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class IvyConvertPomTest extends TestCase {
+public class IvyConvertPomTest {
+    @Test
     public void testSimple() throws Exception {
         IvyConvertPom task = new IvyConvertPom();
         task.setProject(TestHelper.newProject());

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -425,8 +425,7 @@ public class IvyDeliverTest {
         String[] files = list.list();
         HashSet actualFileSet = new HashSet(Arrays.asList(files));
         HashSet expectedFileSet = new HashSet();
-        for (int i = 0; i < dds.length; i++) {
-            DependencyDescriptor dd = dds[i];
+        for (DependencyDescriptor dd : dds) {
             String name = dd.getDependencyId().getName();
             String rev = dd.getDependencyRevisionId().getRevision();
             String ext = "jar";
@@ -473,8 +472,7 @@ public class IvyDeliverTest {
         String[] files = list.list();
         HashSet actualFileSet = new HashSet(Arrays.asList(files));
         HashSet expectedFileSet = new HashSet();
-        for (int i = 0; i < dds.length; i++) {
-            DependencyDescriptor dd = dds[i];
+        for (DependencyDescriptor dd : dds) {
             String name = dd.getDependencyId().getName();
             String rev = dd.getDependencyRevisionId().getRevision();
             String ext = "jar";

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -35,18 +35,25 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyDeliverTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IvyDeliverTest {
 
     private IvyDeliver deliver;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         cleanTestDir();
         cleanRetrieveDir();
         cleanRep();
@@ -61,7 +68,8 @@ public class IvyDeliverTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
         cleanTestDir();
         cleanRetrieveDir();
@@ -89,6 +97,7 @@ public class IvyDeliverTest extends TestCase {
         del.execute();
     }
 
+   @Test
     public void testMergeParent() throws IOException, ParseException {
         // publish the parent descriptor first, so that it can be found while
         // we are reading the child descriptor.
@@ -148,6 +157,7 @@ public class IvyDeliverTest extends TestCase {
         }
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -173,6 +183,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDynamicConstraintDependencyRevisionId());
     }
 
+    @Test
     public void testNotGenerateRevConstraint() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -199,6 +210,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDynamicConstraintDependencyRevisionId());
     }
 
+    @Test
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -230,6 +242,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testWithResolveIdInAnotherBuild() throws Exception {
         // create a new build
         Project other = TestHelper.newProject();
@@ -267,6 +280,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testReplaceBranchInfo() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -287,6 +301,7 @@ public class IvyDeliverTest extends TestCase {
             md.getModuleRevisionId());
     }
 
+    @Test
     public void testWithBranch() throws Exception {
         // test case for IVY-404
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest-branch.xml");
@@ -311,6 +326,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testReplaceBranch() throws Exception {
         IvyConfigure settings = new IvyConfigure();
         settings.setProject(project);
@@ -346,6 +362,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDynamicConstraintDependencyRevisionId());
     }
 
+    @Test
     public void testWithExtraAttributes() throws Exception {
         // test case for IVY-415
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest-extra.xml");
@@ -374,6 +391,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testWithDynEvicted() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml");
         IvyResolve res = new IvyResolve();
@@ -419,6 +437,7 @@ public class IvyDeliverTest extends TestCase {
             expectedFileSet, actualFileSet);
     }
 
+    @Test
     public void testWithDynEvicted2() throws Exception {
         // same as previous but dynamic dependency is placed after the one causing the conflict
         // test case for IVY-707
@@ -467,6 +486,7 @@ public class IvyDeliverTest extends TestCase {
         list.delete();
     }
 
+    @Test
     public void testReplaceImportedConfigurations() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-import-confs.xml");
         IvyResolve res = new IvyResolve();
@@ -483,11 +503,12 @@ public class IvyDeliverTest extends TestCase {
         String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
                 deliveredIvyFile)));
         assertTrue("import not replaced: import can still be found in file",
-            deliveredFileContent.indexOf("import") == -1);
+                !deliveredFileContent.contains("import"));
         assertTrue("import not replaced: conf1 cannot be found in file",
-            deliveredFileContent.indexOf("conf1") != -1);
+                deliveredFileContent.contains("conf1"));
     }
 
+    @Test
     public void testReplaceVariables() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-with-variables.xml");
         IvyResolve res = new IvyResolve();
@@ -506,11 +527,12 @@ public class IvyDeliverTest extends TestCase {
         String deliveredFileContent = FileUtil.readEntirely(new BufferedReader(new FileReader(
                 deliveredIvyFile)));
         assertTrue("variable not replaced: myvar can still be found in file",
-            deliveredFileContent.indexOf("myvar") == -1);
+                !deliveredFileContent.contains("myvar"));
         assertTrue("variable not replaced: myvalue cannot be found in file",
-            deliveredFileContent.indexOf("myvalue") != -1);
+                deliveredFileContent.contains("myvalue"));
     }
 
+    @Test
     public void testNoReplaceDynamicRev() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -535,6 +557,7 @@ public class IvyDeliverTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testDifferentRevisionsForSameModule() throws Exception {
         project.setProperty("ivy.dep.file",
             "test/java/org/apache/ivy/ant/ivy-different-revisions.xml");

--- a/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
@@ -21,8 +21,15 @@ import java.io.File;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.ant.testutil.AntTaskTestCase;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 public class IvyDependencyTreeTest extends AntTaskTestCase {
 
@@ -30,7 +37,8 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = configureProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -40,10 +48,12 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         dependencyTree.execute();
@@ -51,6 +61,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         assertLogContaining("\\- org1#mod1.2;2.0");
     }
 
+    @Test
     public void testEmpty() throws Exception {
         dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-empty.xml"));
         dependencyTree.execute();
@@ -58,6 +69,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         assertLogNotContaining("\\-");
     }
 
+    @Test
     public void testWithResolveId() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -76,6 +88,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         assertLogContaining("\\- org1#mod1.2;latest.integration");
     }
 
+    @Test
     public void testWithResolveIdWithoutResolve() throws Exception {
         try {
             dependencyTree.execute();
@@ -85,6 +98,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         }
     }
 
+    @Test
     public void testWithEvictedModule() throws Exception {
         dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
         dependencyTree.execute();
@@ -95,6 +109,7 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         assertLogContaining("\\- org1#mod1.2;2.2");
     }
 
+    @Test
     public void testShowEvictedModule() throws Exception {
         dependencyTree.setFile(new File("test/java/org/apache/ivy/ant/ivy-dyn-evicted.xml"));
         dependencyTree.setShowEvicted(true);

--- a/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyTreeTest.java
@@ -88,14 +88,14 @@ public class IvyDependencyTreeTest extends AntTaskTestCase {
         assertLogContaining("\\- org1#mod1.2;latest.integration");
     }
 
-    @Test
+    /**
+     * Task must fail because no resolve was performed.
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
     public void testWithResolveIdWithoutResolve() throws Exception {
-        try {
-            dependencyTree.execute();
-            fail("Task should have failed because no resolve was performed!");
-        } catch (BuildException e) {
-            // this is expected!
-        }
+        dependencyTree.execute();
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
@@ -28,13 +28,18 @@ import org.apache.tools.ant.Project;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
     private IvyDependencyUpdateChecker dependencyUpdateChecker;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -90,7 +95,6 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
     @Test
     public void testResolveWithoutIvyFile() throws Exception {
         // depends on org="org1" name="mod1.2" rev="2.0"
-
         dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         dependencyUpdateChecker.setConf("default");
         dependencyUpdateChecker.setHaltonfailure(false);
@@ -111,9 +115,13 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
         assertLogContaining("Dependencies updates available :");
         assertLogContaining("org1#mod1.2\t2.0 -> 2.2");
-
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testInlineForNonExistingModule() throws Exception {
         dependencyUpdateChecker.setOrganisation("org1XXYZ");
@@ -122,44 +130,58 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
         dependencyUpdateChecker.setInline(true);
         dependencyUpdateChecker.setHaltonfailure(true);
         dependencyUpdateChecker.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
         dependencyUpdateChecker
                 .setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
         dependencyUpdateChecker.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    /**
+     * Test must fail because of missing configurations.
+     *
+     * @throws Exception
+     */
     @Test
     public void testFailureWithMissingConfigurations() throws Exception {
-        try {
-            dependencyUpdateChecker
-                    .setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
-            dependencyUpdateChecker.setConf("default,unknown");
-            dependencyUpdateChecker.execute();
-            fail("missing configurations didn't raised an exception");
-        } catch (BuildException ex) {
-            assertTrue(ex.getMessage().contains("unknown"));
-        }
+        expExc.expect(BuildException.class);
+        expExc.expectMessage("unknown");
+
+        dependencyUpdateChecker
+                .setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        dependencyUpdateChecker.setConf("default,unknown");
+        dependencyUpdateChecker.execute();
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailureOnBadDependencyIvyFile() throws Exception {
         dependencyUpdateChecker.setFile(new File(
                 "test/java/org/apache/ivy/ant/ivy-failure2.xml"));
         dependencyUpdateChecker.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailureOnBadStatusInDependencyIvyFile() throws Exception {
         dependencyUpdateChecker.setFile(new File(
                 "test/java/org/apache/ivy/ant/ivy-failure3.xml"));
         dependencyUpdateChecker.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
+++ b/test/java/org/apache/ivy/ant/IvyFindRevisionTest.java
@@ -18,15 +18,21 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyFindRevisionTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class IvyFindRevisionTest {
 
     private IvyFindRevision findRevision;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -35,10 +41,12 @@ public class IvyFindRevisionTest extends TestCase {
         findRevision.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testProperty() throws Exception {
         findRevision.setOrganisation("org1");
         findRevision.setModule("mod1.1");
@@ -48,6 +56,7 @@ public class IvyFindRevisionTest extends TestCase {
         assertEquals("1.0", findRevision.getProject().getProperty("test.revision"));
     }
 
+    @Test
     public void testLatest() throws Exception {
         findRevision.setOrganisation("org1");
         findRevision.setModule("mod1.1");
@@ -56,6 +65,7 @@ public class IvyFindRevisionTest extends TestCase {
         assertEquals("2.0", findRevision.getProject().getProperty("ivy.revision"));
     }
 
+    @Test
     public void testLatestSubversion() throws Exception {
         findRevision.setOrganisation("org1");
         findRevision.setModule("mod1.1");

--- a/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoRepositoryTest.java
@@ -18,15 +18,21 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyInfoRepositoryTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class IvyInfoRepositoryTest {
 
     private IvyInfo info;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -35,10 +41,12 @@ public class IvyInfoRepositoryTest extends TestCase {
         info.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testProperty() throws Exception {
         info.setOrganisation("org1");
         info.setModule("mod1.1");
@@ -52,6 +60,7 @@ public class IvyInfoRepositoryTest extends TestCase {
         assertEquals("default", info.getProject().getProperty("test.configurations"));
     }
 
+    @Test
     public void testLatest() throws Exception {
         info.setOrganisation("org1");
         info.setModule("mod1.1");
@@ -64,6 +73,7 @@ public class IvyInfoRepositoryTest extends TestCase {
         assertEquals("default", info.getProject().getProperty("ivy.configurations"));
     }
 
+    @Test
     public void testLatestSubversion() throws Exception {
         info.setOrganisation("org1");
         info.setModule("mod1.1");

--- a/test/java/org/apache/ivy/ant/IvyInfoTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInfoTest.java
@@ -20,20 +20,28 @@ package org.apache.ivy.ant;
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyInfoTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class IvyInfoTest {
     private IvyInfo info;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         Project project = TestHelper.newProject();
 
         info = new IvyInfo();
         info.setProject(project);
     }
 
+    @Test
     public void testSimple() throws Exception {
         info.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         info.execute();
@@ -45,6 +53,7 @@ public class IvyInfoTest extends TestCase {
         assertEquals("default", info.getProject().getProperty("ivy.public.configurations"));
     }
 
+    @Test
     public void testAll() throws Exception {
         info.setFile(new File("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
         info.execute();
@@ -66,6 +75,7 @@ public class IvyInfoTest extends TestCase {
         assertNull(info.getProject().getProperty("ivy.configuration.private.desc"));
     }
 
+    @Test
     public void testIVY726() throws Exception {
         info.setFile(new File("test/java/org/apache/ivy/ant/ivy-info-all.xml"));
         info.execute();
@@ -73,6 +83,7 @@ public class IvyInfoTest extends TestCase {
         assertTrue(info.getProject().getProperty("ivy.extra.branch") == null);
     }
 
+    @Test
     public void testIVY395() throws Exception {
         info.setFile(new File("test/java/org/apache/ivy/ant/ivy-artifact-info.xml"));
         info.execute();

--- a/test/java/org/apache/ivy/ant/IvyInstallTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInstallTest.java
@@ -288,8 +288,13 @@ public class IvyInstallTest {
         assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
-    @Test
-    public void testInstallWithNamespace2() {
+    /**
+     * Installing a module with namespace coordinates instead of system one should fail.
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
+    public void testInstallWithNamespace2() throws Exception {
         project.setProperty("ivy.settings.file", "test/repositories/namespace/ivysettings.xml");
         install.setOrganisation("A");
         install.setModule("B");
@@ -297,13 +302,7 @@ public class IvyInstallTest {
         install.setTransitive(true);
         install.setFrom("ns");
         install.setTo("install");
-
-        try {
-            install.execute();
-            fail("installing module with namespace coordinates instead of system one should fail");
-        } catch (BuildException ex) {
-            // expected
-        }
+        install.execute();
     }
 
     @Test
@@ -322,21 +321,20 @@ public class IvyInstallTest {
         assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
-    @Test
-    public void testDependencyNotFoundFailure() {
+    /**
+     * Fail on unknown dependency when haltonfailure=true.
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
+    public void testDependencyNotFoundFailure() throws Exception {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
         install.setOrganisation("xxx");
         install.setModule("yyy");
         install.setRevision("zzz");
         install.setFrom("test");
         install.setTo("install");
-
-        try {
-            install.execute();
-            fail("unknown dependency, failure expected (haltonfailure=true)");
-        } catch (BuildException be) {
-            // success
-        }
+        install.execute();
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyInstallTest.java
+++ b/test/java/org/apache/ivy/ant/IvyInstallTest.java
@@ -21,19 +21,28 @@ import java.io.File;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyInstallTest extends TestCase {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class IvyInstallTest {
     private File cache;
 
     private IvyInstall install;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
         cleanInstall();
 
@@ -49,7 +58,8 @@ public class IvyInstallTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         cleanCache();
         cleanInstall();
     }
@@ -63,6 +73,7 @@ public class IvyInstallTest extends TestCase {
         FileUtil.forceDelete(new File("build/test/install2"));
     }
 
+    @Test
     public void testInstallDummyDefault() {
         project.setProperty("ivy.settings.file",
             "test/repositories/ivysettings-dummydefaultresolver.xml");
@@ -84,6 +95,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
+    @Test
     public void testInstallWithAnyType() {
         project.setProperty("ivy.settings.file",
             "test/repositories/ivysettings-dummydefaultresolver.xml");
@@ -99,6 +111,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/org8/mod8.1/a-1.1.txt").exists());
     }
 
+    @Test
     public void testInstallWithMultipleType() {
         project.setProperty("ivy.settings.file",
             "test/repositories/ivysettings-dummydefaultresolver.xml");
@@ -117,6 +130,7 @@ public class IvyInstallTest extends TestCase {
     /**
      * Normal case; no confs set (should use the default->* configuration).
      */
+    @Test
     public void testInstallWithConfsDefaultSettings() {
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1313/ivysettings.xml");
         install.setOrganisation("org1");
@@ -136,6 +150,7 @@ public class IvyInstallTest extends TestCase {
     /**
      * Test retrieving artifacts under only the master and runtime configuration.
      */
+    @Test
     public void testInstallWithConfsRuntimeOnly() {
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1313/ivysettings.xml");
         install.setOrganisation("org1");
@@ -153,6 +168,7 @@ public class IvyInstallTest extends TestCase {
         assertFalse(new File("build/test/install/org1/mod3/jars/mod3-1.0.jar").exists());
     }
 
+    @Test
     public void testInstallWithClassifiers() throws Exception {
         // IVY-1324
         project.setProperty("ivy.settings.url", new File("test/repositories/m2/ivysettings.xml")
@@ -175,6 +191,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/org.apache/test-sources/ivy-1.0.xml").exists());
     }
 
+    @Test
     public void testInstallWithUnusedType() {
         project.setProperty("ivy.settings.file",
             "test/repositories/ivysettings-dummydefaultresolver.xml");
@@ -190,6 +207,7 @@ public class IvyInstallTest extends TestCase {
         assertFalse(new File("build/test/install/org8/mod8.1/a-1.1.txt").exists());
     }
 
+    @Test
     public void testInstallWithOriginalMetadata() {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
         install.setOrganisation("org.apache");
@@ -219,6 +237,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
     }
 
+    @Test
     public void testIVY843() {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-IVY843.xml");
         install.setOrganisation("org1");
@@ -238,6 +257,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install2/org1/mod1.4/ivy-1.0.1.xml").exists());
     }
 
+    @Test
     public void testInstallWithBranch() {
         project.setProperty("ivy.settings.file", "test/repositories/branches/ivysettings.xml");
         install.setOrganisation("foo");
@@ -252,6 +272,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/foo/foo1/branch1/ivy-2.xml").exists());
     }
 
+    @Test
     public void testInstallWithNamespace() {
         project.setProperty("ivy.settings.file", "test/repositories/namespace/ivysettings.xml");
         install.setOrganisation("systemorg");
@@ -267,6 +288,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
+    @Test
     public void testInstallWithNamespace2() {
         project.setProperty("ivy.settings.file", "test/repositories/namespace/ivysettings.xml");
         install.setOrganisation("A");
@@ -284,6 +306,7 @@ public class IvyInstallTest extends TestCase {
         }
     }
 
+    @Test
     public void testInstallWithNamespace3() {
         project.setProperty("ivy.settings.file", "test/repositories/namespace/ivysettings.xml");
         install.setOrganisation("*");
@@ -299,6 +322,7 @@ public class IvyInstallTest extends TestCase {
         assertTrue(new File("build/test/install/systemorg/systemmod/ivy-1.0.xml").exists());
     }
 
+    @Test
     public void testDependencyNotFoundFailure() {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
         install.setOrganisation("xxx");
@@ -315,6 +339,7 @@ public class IvyInstallTest extends TestCase {
         }
     }
 
+    @Test
     public void testDependencyNotFoundSuccess() {
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
         install.setOrganisation("xxx");

--- a/test/java/org/apache/ivy/ant/IvyListModulesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyListModulesTest.java
@@ -18,15 +18,21 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyListModulesTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class IvyListModulesTest {
 
     private IvyListModules findModules;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -35,10 +41,12 @@ public class IvyListModulesTest extends TestCase {
         findModules.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testExact() throws Exception {
         findModules.setOrganisation("org1");
         findModules.setModule("mod1.1");
@@ -49,6 +57,7 @@ public class IvyListModulesTest extends TestCase {
         assertEquals("org1/mod1.1/1.0", findModules.getProject().getProperty("found"));
     }
 
+    @Test
     public void testAllRevs() throws Exception {
         findModules.setOrganisation("org1");
         findModules.setModule("mod1.1");

--- a/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPostResolveTaskTest.java
@@ -22,19 +22,25 @@ import java.io.File;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.util.CacheCleaner;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyPostResolveTaskTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyPostResolveTaskTest {
     private File cache;
 
     private IvyPostResolveTask task;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -53,10 +59,12 @@ public class IvyPostResolveTaskTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testWithPreviousResolveInSameBuildAndLessConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -75,6 +83,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             reportAfter);
     }
 
+    @Test
     public void testWithPreviousResolveInSameBuildAndSameConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -93,6 +102,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             reportAfter);
     }
 
+    @Test
     public void testWithPreviousResolveInSameBuildAndWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -111,6 +121,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             reportAfter);
     }
 
+    @Test
     public void testWithPreviousResolveInSameBuildAndBothWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -129,6 +140,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             reportAfter);
     }
 
+    @Test
     public void testWithPreviousResolveInSameBuildAndMoreConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -150,6 +162,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testWithoutKeep() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -172,6 +185,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testInlineWithoutKeep() throws Exception {
         task.setOrganisation("org1");
         task.setModule("mod1.1");
@@ -187,6 +201,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testInlineWithKeep() throws Exception {
         task.setOrganisation("org1");
         task.setModule("mod1.1");
@@ -203,6 +218,7 @@ public class IvyPostResolveTaskTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testWithResolveIdAndPreviousResolveInSameBuildAndLessConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -237,6 +253,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             report2);
     }
 
+    @Test
     public void testWithResolveIdAndPreviousResolveInSameBuildAndSameConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -271,6 +288,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             report2);
     }
 
+    @Test
     public void testWithResolveIdAndPreviousResolveInSameBuildAndWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -305,6 +323,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             report2);
     }
 
+    @Test
     public void testWithResolveIdAndPreviousResolveInSameBuildAndBothWildcard() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);
@@ -339,6 +358,7 @@ public class IvyPostResolveTaskTest extends TestCase {
             report2);
     }
 
+    @Test
     public void testWithResolveIdAndPreviousResolveInSameBuildAndMoreConfs() throws Exception {
         IvyResolve resolve = new IvyResolve();
         resolve.setProject(project);

--- a/test/java/org/apache/ivy/ant/IvyPublishTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPublishTest.java
@@ -31,21 +31,27 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 import org.apache.tools.ant.taskdefs.Echo;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyPublishTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyPublishTest {
     private File cache;
 
     private IvyPublish publish;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         cleanTestDir();
         cleanRep();
         createCache();
@@ -66,7 +72,8 @@ public class IvyPublishTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         cleanCache();
         cleanTestDir();
         cleanRep();
@@ -88,6 +95,7 @@ public class IvyPublishTest extends TestCase {
         del.execute();
     }
 
+    @Test
     public void testMergeParent() throws IOException, ParseException {
         // publish the parent descriptor first, so that it can be found while
         // we are reading the child descriptor.
@@ -126,6 +134,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
@@ -134,7 +143,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -147,6 +156,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testMergeParentWithoutPublishingParent() throws IOException, ParseException {
         // here we directly publish a module extending ivy-multiconf.xml,
         // the module parent is not published not yet in cache
@@ -174,6 +184,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
@@ -182,7 +193,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -195,8 +206,9 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
-    public void testMergeParentWithoutPublishingParentForceDeliver() throws IOException,
-            ParseException {
+    @Test
+    public void testMergeParentWithoutPublishingParentForceDeliver()
+            throws IOException, ParseException {
         // here we directly publish a module extending ivy-multiconf.xml,
         // the module parent is not published not yet in cache
         // See : IVY-1248
@@ -228,6 +240,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-merged.xml")));
@@ -236,7 +249,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -249,6 +262,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testMergeParentWithoutLocationAttribute() throws IOException, ParseException {
         // See : IVY-XXX
 
@@ -276,6 +290,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("extends/child1/ivy-child1-merged.xml")));
@@ -284,7 +299,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -297,6 +312,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testMinimalMerge() throws IOException, ParseException {
         // publish the parent descriptor first, so that it can be found while
         // we are reading the child descriptor.
@@ -334,6 +350,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-minimal-merged.xml")));
@@ -342,7 +359,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -355,6 +372,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testMergeExtraAttributes() throws IOException, ParseException {
         // publish the parent descriptor first, so that it can be found while
         // we are reading the child descriptor.
@@ -398,6 +416,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-extra-attributes-merged.xml")));
@@ -406,7 +425,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -419,6 +438,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testMergeExtraAttributesFromParent() throws IOException, ParseException {
         // publish the parent descriptor first, so that it can be found while
         // we are reading the child descriptor.
@@ -463,6 +483,7 @@ public class IvyPublishTest extends TestCase {
 
         int lineNo = 1;
 
+        @SuppressWarnings("resource")
         BufferedReader merged = new BufferedReader(new FileReader(published));
         BufferedReader expected = new BufferedReader(new InputStreamReader(getClass()
                 .getResourceAsStream("ivy-extends-extra-attributes-merged.xml")));
@@ -471,7 +492,7 @@ public class IvyPublishTest extends TestCase {
                 .readLine()) {
 
             // strip timestamps for the comparison
-            if (mergeLine.indexOf("<info") >= 0) {
+            if (mergeLine.contains("<info")) {
                 mergeLine = mergeLine.replaceFirst("\\s?publication=\"\\d+\"", "");
             }
             // discard whitespace-only lines
@@ -484,6 +505,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
         IvyResolve res = new IvyResolve();
@@ -512,6 +534,7 @@ public class IvyPublishTest extends TestCase {
         assertEquals("1.2", md.getModuleRevisionId().getRevision());
     }
 
+    @Test
     public void testHaltOnMissing() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
         IvyResolve res = new IvyResolve();
@@ -525,8 +548,8 @@ public class IvyPublishTest extends TestCase {
             publish.execute();
             fail("publish with haltonmissing and a missing artifact should raise an exception");
         } catch (BuildException ex) {
-            assertTrue(ex.getMessage().indexOf("missing") != -1);
-            assertTrue(ex.getMessage().indexOf("resolve-simple.jar") != -1);
+            assertTrue(ex.getMessage().contains("missing"));
+            assertTrue(ex.getMessage().contains("resolve-simple.jar"));
             // should have do the ivy delivering
             assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
 
@@ -539,6 +562,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testHaltOnMissing2() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-multi.xml");
         IvyResolve res = new IvyResolve();
@@ -556,8 +580,8 @@ public class IvyPublishTest extends TestCase {
             publish.execute();
             fail("publish with haltonmissing and a missing artifact should raise an exception");
         } catch (BuildException ex) {
-            assertTrue(ex.getMessage().indexOf("missing") != -1);
-            assertTrue(ex.getMessage().indexOf("multi2.jar") != -1);
+            assertTrue(ex.getMessage().contains("missing"));
+            assertTrue(ex.getMessage().contains("multi2.jar"));
 
             // should have do the ivy delivering
             assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
@@ -567,6 +591,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testHaltOnMissing3() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-multi.xml");
         IvyResolve res = new IvyResolve();
@@ -584,8 +609,8 @@ public class IvyPublishTest extends TestCase {
             publish.execute();
             fail("publish with haltonmissing and a missing artifact should raise an exception");
         } catch (BuildException ex) {
-            assertTrue(ex.getMessage().indexOf("missing") != -1);
-            assertTrue(ex.getMessage().indexOf("multi2.jar") != -1);
+            assertTrue(ex.getMessage().contains("missing"));
+            assertTrue(ex.getMessage().contains("multi2.jar"));
 
             // should have do the ivy delivering
             assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
@@ -595,6 +620,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testPublishNotAllConfigs() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
         IvyResolve res = new IvyResolve();
@@ -630,6 +656,7 @@ public class IvyPublishTest extends TestCase {
         assertEquals("Compile configuration not present", "compile", configs[0]);
     }
 
+    @Test
     public void testMultiPatterns() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-multi.xml");
         IvyResolve res = new IvyResolve();
@@ -655,6 +682,7 @@ public class IvyPublishTest extends TestCase {
         assertTrue(new File("test/repositories/1/apache/multi/jars/multi2-1.2.jar").exists());
     }
 
+    @Test
     public void testPublishPublicConfigsByWildcard() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-public.xml");
         IvyResolve res = new IvyResolve();
@@ -678,6 +706,7 @@ public class IvyPublishTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testCustom() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-custom.xml");
         IvyResolve res = new IvyResolve();
@@ -720,6 +749,7 @@ public class IvyPublishTest extends TestCase {
 
     }
 
+    @Test
     public void testNoDeliver() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -754,6 +784,7 @@ public class IvyPublishTest extends TestCase {
                 .getRevision());
     }
 
+    @Test
     public void testNoDeliverWithBranch() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -791,6 +822,7 @@ public class IvyPublishTest extends TestCase {
                 .getRevision());
     }
 
+    @Test
     public void testForceDeliver() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -822,6 +854,7 @@ public class IvyPublishTest extends TestCase {
         assertEquals("1.3", md.getModuleRevisionId().getRevision());
     }
 
+    @Test
     public void testBadNoDeliver() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -845,6 +878,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testReadonly() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         IvyResolve res = new IvyResolve();
@@ -885,6 +919,7 @@ public class IvyPublishTest extends TestCase {
         }
     }
 
+    @Test
     public void testOverwrite() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         IvyResolve res = new IvyResolve();
@@ -920,6 +955,7 @@ public class IvyPublishTest extends TestCase {
         reader.close();
     }
 
+    @Test
     public void testOverwriteReadOnly() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         IvyResolve res = new IvyResolve();

--- a/test/java/org/apache/ivy/ant/IvyPublishTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPublishTest.java
@@ -854,7 +854,12 @@ public class IvyPublishTest {
         assertEquals("1.3", md.getModuleRevisionId().getRevision());
     }
 
-    @Test
+    /**
+     * Test must not publish ivy file with bad revision.
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
     public void testBadNoDeliver() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest.xml");
         IvyResolve res = new IvyResolve();
@@ -870,12 +875,8 @@ public class IvyPublishTest {
 
         File art = new File("build/test/publish/resolve-latest-1.3.jar");
         FileUtil.copy(new File("test/repositories/1/org1/mod1.1/jars/mod1.1-1.0.jar"), art, null);
-        try {
-            publish.execute();
-            fail("shouldn't publish ivy file with bad revision");
-        } catch (BuildException ex) {
-            // normal
-        }
+
+        publish.execute();
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyReportTest.java
@@ -22,17 +22,23 @@ import java.util.Locale;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyReportTest extends TestCase {
+import static org.junit.Assert.assertTrue;
+
+public class IvyReportTest {
 
     private IvyReport report;
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -43,10 +49,12 @@ public class IvyReportTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -70,6 +78,7 @@ public class IvyReportTest extends TestCase {
         }
     }
 
+    @Test
     public void testWithLatest() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -99,6 +108,7 @@ public class IvyReportTest extends TestCase {
         }
     }
 
+    @Test
     public void testCopyCssIfTodirNotSet() {
         Locale oldLocale = Locale.getDefault();
 
@@ -123,6 +133,7 @@ public class IvyReportTest extends TestCase {
         }
     }
 
+    @Test
     public void testNoRevisionInOutputPattern() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -147,6 +158,7 @@ public class IvyReportTest extends TestCase {
         }
     }
 
+    @Test
     public void testMultipleConfigurations() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -171,6 +183,7 @@ public class IvyReportTest extends TestCase {
         }
     }
 
+    @Test
     public void testRegularCircular() throws Exception {
         Locale oldLocale = Locale.getDefault();
 

--- a/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRepositoryReportTest.java
@@ -23,15 +23,21 @@ import java.io.FileReader;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.util.FileUtil;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyRepositoryReportTest extends TestCase {
+import static org.junit.Assert.assertTrue;
+
+public class IvyRepositoryReportTest {
 
     private IvyRepositoryReport report;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-1.xml");
@@ -41,10 +47,12 @@ public class IvyRepositoryReportTest extends TestCase {
         System.setProperty("ivy.cache.dir", TestHelper.cache.getAbsolutePath());
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSimple() throws Exception {
         report.setOrganisation("org1");
         report.setOutputname("testsimple");
@@ -56,14 +64,15 @@ public class IvyRepositoryReportTest extends TestCase {
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 
         // check presence of the modules
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.1\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.2\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.3\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.4\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.5\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.6\"") != -1);
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.1\""));
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.2\""));
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.3\""));
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.4\""));
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.5\""));
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.6\""));
     }
 
+    @Test
     public void testBranchBeforeModule() throws Exception {
         report.getProject().setProperty("ivy.settings.file",
             "test/repositories/IVY-716/ivysettings.xml");
@@ -76,13 +85,14 @@ public class IvyRepositoryReportTest extends TestCase {
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 
         // check presence of the modules
-        assertTrue(g.indexOf("<module organisation=\"org1\" name=\"mod1.1\"") != -1);
+        assertTrue(g.contains("<module organisation=\"org1\" name=\"mod1.1\""));
 
         // check presence of the branches
-        assertTrue(g.indexOf("<revision name=\"1.0\" branch=\"branch1\"") != -1);
-        assertTrue(g.indexOf("<revision name=\"1.0\" branch=\"branch2\"") != -1);
+        assertTrue(g.contains("<revision name=\"1.0\" branch=\"branch1\""));
+        assertTrue(g.contains("<revision name=\"1.0\" branch=\"branch2\""));
     }
 
+    @Test
     public void testPatternWithoutOrganisation() throws Exception {
         report.getProject().setProperty("ivy.settings.file",
             "test/repositories/IVY-729/ivysettings.xml");
@@ -95,8 +105,8 @@ public class IvyRepositoryReportTest extends TestCase {
         String g = FileUtil.readEntirely(new BufferedReader(new FileReader(reportFile)));
 
         // check presence of the modules
-        assertTrue(g.indexOf("<module organisation=\"null\" name=\"a\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"null\" name=\"b\"") != -1);
-        assertTrue(g.indexOf("<module organisation=\"null\" name=\"c\"") != -1);
+        assertTrue(g.contains("<module organisation=\"null\" name=\"a\""));
+        assertTrue(g.contains("<module organisation=\"null\" name=\"b\""));
+        assertTrue(g.contains("<module organisation=\"null\" name=\"c\""));
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -23,19 +23,26 @@ import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Parallel;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
-public class IvyResolveTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class IvyResolveTest {
 
     private Project project;
 
     private IvyResolve resolve;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -45,10 +52,12 @@ public class IvyResolveTest extends TestCase {
         resolve.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testIVY1455() throws Exception {
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1455/ivysettings.xml");
         resolve.setFile(new File("test/repositories/IVY-1455/ivy.xml"));
@@ -56,7 +65,9 @@ public class IvyResolveTest extends TestCase {
     }
 
     /* disabled: Ivy is not thread-safe, and this usage is not supported at this time */
-    public void disabledIVY1454() throws Exception {
+    @Test
+    @Ignore
+    public void disabledIVY1454() {
         // run init in parent thread, then resolve in children
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings-with-nio.xml");
         project.setProperty("ivy.log.locking", "true");
@@ -71,6 +82,7 @@ public class IvyResolveTest extends TestCase {
         parallel.execute();
     }
 
+    @Test
     public void testIVY779() throws Exception {
         Project project = TestHelper.newProject();
         project.setProperty("ivy.local.default.root",
@@ -90,6 +102,7 @@ public class IvyResolveTest extends TestCase {
         assertEquals(1, report.getArtifacts().size());
     }
 
+    @Test
     public void testSimple() throws Exception {
         // depends on org="org1" name="mod1.2" rev="2.0"
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
@@ -104,6 +117,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithoutIvyFile() throws Exception {
         // IVY-630
         resolve.getProject().setProperty("ivy.settings.file",
@@ -133,6 +147,7 @@ public class IvyResolveTest extends TestCase {
         return getIvy().getResolutionCacheManager().getResolvedIvyFileInCache(id);
     }
 
+    @Test
     public void testInline() throws Exception {
         // same as before, but expressing dependency directly without ivy file
         resolve.setOrganisation("org1");
@@ -147,6 +162,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testInlineWithResolveId() throws Exception {
         // same as before, but expressing dependency directly without ivy file
         resolve.setOrganisation("org1");
@@ -163,6 +179,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testInlineForNonExistingModule() throws Exception {
         resolve.setOrganisation("org1XX");
         resolve.setModule("mod1.2");
@@ -174,10 +191,10 @@ public class IvyResolveTest extends TestCase {
 
         // the resolve must have failed -> the failure property must be set
         String failure = resolve.getProject().getProperty("failure.property");
-        assertTrue("Failure property must have been specified!", Boolean.valueOf(failure)
-                .booleanValue());
+        assertTrue("Failure property must have been specified!", Boolean.valueOf(failure));
     }
 
+    @Test
     public void testWithSlashes() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/core/resolve/ivy-198.xml"));
         resolve.execute();
@@ -197,6 +214,7 @@ public class IvyResolveTest extends TestCase {
             "jar", "jar").exists());
     }
 
+    @Test
     public void testDepsChanged() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.execute();
@@ -208,6 +226,7 @@ public class IvyResolveTest extends TestCase {
         assertEquals("false", getIvy().getVariable("ivy.deps.changed"));
     }
 
+    @Test
     public void testDontCheckIfChanged() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setCheckIfChanged(false);
@@ -219,6 +238,7 @@ public class IvyResolveTest extends TestCase {
         // but this would require a too big refactoring to inject a mock object
     }
 
+    @Test
     public void testConflictingDepsChanged() throws Exception {
         resolve.setFile(new File("test/repositories/2/mod4.1/ivy-4.1.xml"));
         resolve.execute();
@@ -230,6 +250,7 @@ public class IvyResolveTest extends TestCase {
         assertEquals("false", getIvy().getVariable("ivy.deps.changed"));
     }
 
+    @Test
     public void testDouble() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.execute();
@@ -244,6 +265,7 @@ public class IvyResolveTest extends TestCase {
         assertEquals("1.1", getIvy().getVariable("ivy.revision"));
     }
 
+    @Test
     public void testFailure() throws Exception {
         try {
             resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
@@ -254,6 +276,7 @@ public class IvyResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testIvyLogModulesInUseWithFailure() throws Exception {
         resolve.getProject().setProperty("ivy.log.modules.in.use", "true");
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
@@ -263,6 +286,7 @@ public class IvyResolveTest extends TestCase {
         // we did manage to get here, so no NPE has been thrown (IVY-961)
     }
 
+    @Test
     public void testFailureWithMissingConfigurations() throws Exception {
         try {
             resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
@@ -270,10 +294,11 @@ public class IvyResolveTest extends TestCase {
             resolve.execute();
             fail("missing configurations didn't raised an exception");
         } catch (BuildException ex) {
-            assertTrue(ex.getMessage().indexOf("unknown") != -1);
+            assertTrue(ex.getMessage().contains("unknown"));
         }
     }
 
+    @Test
     public void testFailureOnBadDependencyIvyFile() throws Exception {
         try {
             resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure2.xml"));
@@ -284,6 +309,7 @@ public class IvyResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testFailureOnBadStatusInDependencyIvyFile() throws Exception {
         try {
             resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure3.xml"));
@@ -294,6 +320,7 @@ public class IvyResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testHaltOnFailure() throws Exception {
         try {
             resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
@@ -305,6 +332,7 @@ public class IvyResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testWithResolveId() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
@@ -343,6 +371,7 @@ public class IvyResolveTest extends TestCase {
         assertNotNull(project.getReference("ivy.resolved.configurations.ref.testWithResolveId"));
     }
 
+    @Test
     public void testDoubleResolveWithResolveId() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
@@ -376,6 +405,7 @@ public class IvyResolveTest extends TestCase {
         assertNotNull(project.getReference("ivy.resolved.configurations.ref.testWithResolveId"));
     }
 
+    @Test
     public void testDifferentResolveWithSameResolveId() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setResolveId("testWithResolveId");
@@ -410,6 +440,7 @@ public class IvyResolveTest extends TestCase {
         assertNotNull(project.getReference("ivy.resolved.configurations.ref.testWithResolveId"));
     }
 
+    @Test
     public void testExcludedConf() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-multiconf.xml"));
         resolve.setConf("*,!default");
@@ -422,9 +453,10 @@ public class IvyResolveTest extends TestCase {
 
         // test the properties
         Project project = resolve.getProject();
-        assertFalse(project.getProperty("ivy.resolved.configurations").indexOf("default") > -1);
+        assertFalse(project.getProperty("ivy.resolved.configurations").contains("default"));
     }
 
+    @Test
     public void testResolveWithAbsoluteFile() {
         // IVY-396
         File ivyFile = new File("test/java/org/apache/ivy/ant/ivy-simple.xml");
@@ -435,6 +467,7 @@ public class IvyResolveTest extends TestCase {
             ModuleRevisionId.newInstance("apache", "resolve-simple", "1.0")).exists());
     }
 
+    @Test
     public void testResolveWithRelativeFile() {
         // IVY-396
         resolve.getProject().setProperty("ivy.dep.file",
@@ -449,6 +482,7 @@ public class IvyResolveTest extends TestCase {
         return resolve.getIvyInstance();
     }
 
+    @Test
     public void testChildsSimple() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -460,6 +494,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsMultiple() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -480,6 +515,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.1", "1.0", "mod1.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsMultipleWithConf() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -499,6 +535,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.7", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsMultipleWithConf2() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -519,6 +556,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.1", "1.0", "mod1.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsExclude() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -542,6 +580,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.7", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsDependencyExclude() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -564,6 +603,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.7", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsDependencyInclude() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -584,6 +624,7 @@ public class IvyResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.2", "0.9", "art22-1", "jar", "jar").exists());
     }
 
+    @Test
     public void testChildsFail() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
@@ -598,6 +639,7 @@ public class IvyResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testSimpleExtends() throws Exception {
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-extends-multiconf.xml"));
         resolve.execute();

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -28,10 +28,8 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Parallel;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
@@ -40,6 +38,9 @@ public class IvyResolveTest {
     private Project project;
 
     private IvyResolve resolve;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -265,15 +266,10 @@ public class IvyResolveTest {
         assertEquals("1.1", getIvy().getVariable("ivy.revision"));
     }
 
-    @Test
+    @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
-        try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
-            resolve.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raise an exception
-        }
+        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure.xml"));
+        resolve.execute();
     }
 
     @Test
@@ -288,36 +284,24 @@ public class IvyResolveTest {
 
     @Test
     public void testFailureWithMissingConfigurations() throws Exception {
-        try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
-            resolve.setConf("default,unknown");
-            resolve.execute();
-            fail("missing configurations didn't raised an exception");
-        } catch (BuildException ex) {
-            assertTrue(ex.getMessage().contains("unknown"));
-        }
+        expExc.expect(BuildException.class);
+        expExc.expectMessage("unknown");
+
+        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
+        resolve.setConf("default,unknown");
+        resolve.execute();
     }
 
-    @Test
+    @Test(expected = BuildException.class)
     public void testFailureOnBadDependencyIvyFile() throws Exception {
-        try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure2.xml"));
-            resolve.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raise an exception
-        }
+        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure2.xml"));
+        resolve.execute();
     }
 
-    @Test
+    @Test(expected = BuildException.class)
     public void testFailureOnBadStatusInDependencyIvyFile() throws Exception {
-        try {
-            resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure3.xml"));
-            resolve.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raise an exception
-        }
+        resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-failure3.xml"));
+        resolve.execute();
     }
 
     @Test
@@ -624,19 +608,18 @@ public class IvyResolveTest {
         assertTrue(getArchiveFileInCache("org2", "mod2.2", "0.9", "art22-1", "jar", "jar").exists());
     }
 
-    @Test
+    /**
+     * Test a failing resolve.
+     *
+     * @throws Exception
+     */
+    @Test(expected = BuildException.class)
     public void testChildsFail() throws Exception {
         IvyDependency dependency = resolve.createDependency();
         dependency.setOrg("org1");
         dependency.setName("noexisting");
         dependency.setRev("2.0");
-
-        try {
-            resolve.execute();
-            fail("A fail resolved should have raised a build exception");
-        } catch (BuildException e) {
-            // ok
-        }
+        resolve.execute();
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyResourcesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResourcesTest.java
@@ -24,17 +24,25 @@ import java.util.List;
 
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.resources.FileResource;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyResourcesTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class IvyResourcesTest {
 
     private IvyResources resources;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
         Project project = TestHelper.newProject();
         project.setProperty("ivy.settings.file", "test/repositories/ivysettings.xml");
@@ -44,7 +52,8 @@ public class IvyResourcesTest extends TestCase {
         resources.setProject(project);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
@@ -69,6 +78,7 @@ public class IvyResourcesTest extends TestCase {
         return resources;
     }
 
+    @Test
     public void testSimple() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -81,6 +91,7 @@ public class IvyResourcesTest extends TestCase {
             files.get(0));
     }
 
+    @Test
     public void testMultiple() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -106,6 +117,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testMultipleWithConf() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -128,6 +140,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testMultipleWithConf2() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -152,6 +165,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testExclude() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -178,6 +192,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testDependencyExclude() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -203,6 +218,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testDependencyInclude() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
@@ -225,6 +241,7 @@ public class IvyResourcesTest extends TestCase {
             "jar")));
     }
 
+    @Test
     public void testFail() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");

--- a/test/java/org/apache/ivy/ant/IvyResourcesTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResourcesTest.java
@@ -241,19 +241,13 @@ public class IvyResourcesTest {
             "jar")));
     }
 
-    @Test
+    @Test(expected = BuildException.class)
     public void testFail() throws Exception {
         IvyDependency dependency = resources.createDependency();
         dependency.setOrg("org1");
         dependency.setName("noexisting");
         dependency.setRev("2.0");
-
-        try {
-            resources.iterator();
-            fail("A fail resolved should have raised a build exception");
-        } catch (BuildException e) {
-            // ok
-        }
+        resources.iterator();
     }
 
 }

--- a/test/java/org/apache/ivy/ant/IvyRetrieveBuildFileTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveBuildFileTest.java
@@ -18,17 +18,30 @@
 package org.apache.ivy.ant;
 
 import org.apache.ivy.core.report.ResolveReport;
-import org.apache.tools.ant.BuildFileTest;
 
-public class IvyRetrieveBuildFileTest extends BuildFileTest {
+import org.apache.tools.ant.BuildFileRule;
 
-    protected void setUp() throws Exception {
-        configureProject("test/java/org/apache/ivy/ant/IvyRetrieveBuildFile.xml");
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class IvyRetrieveBuildFileTest {
+    @Rule
+    public final BuildFileRule buildRule = new BuildFileRule();
+
+    @Before
+    public void setUp() {
+        buildRule.configureProject("test/java/org/apache/ivy/ant/IvyRetrieveBuildFile.xml");
     }
 
+    @Test
     public void testMultipleInlineRetrievesWithCacheCleaning() {
-        executeTarget("testMultipleInlineRetrievesWithCacheCleaning");
-        ResolveReport report = (ResolveReport) getProject().getReference("ivy.resolved.report");
+        buildRule.executeTarget("testMultipleInlineRetrievesWithCacheCleaning");
+        ResolveReport report = buildRule.getProject().getReference("ivy.resolved.report");
         assertNotNull(report);
         assertFalse(report.hasError());
         assertEquals(1, report.getDependencies().size());

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -279,21 +279,28 @@ public class IvyRetrieveTest {
         assertTrue(new File("build/test/lib/default/mod1.2-2.2.jar").exists());
     }
 
+    /**
+     * Retrieve without previous resolve must fail.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailureWithoutAPreviousResolve() throws Exception {
-        // we do a retrieve with the module information whereas no resolve has been previously done
         retrieve.setOrganisation("apache");
         retrieve.setModule("resolve-simple");
         retrieve.setConf("default");
         retrieve.execute();
-        fail("retrieve without previous resolve should have thrown an exception");
     }
 
+    /**
+     * Test must fail with default haltonfailure setting.
+     *
+     * @throws Exception
+     */
     @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
         retrieve.execute();
-        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
     @Test
@@ -302,7 +309,6 @@ public class IvyRetrieveTest {
             project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
             retrieve.setHaltonfailure(false);
             retrieve.execute();
-
         } catch (BuildException ex) {
             fail("failure raised an exception with haltonfailure set to false");
         }

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -23,12 +23,19 @@ import java.io.IOException;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.util.CacheCleaner;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IvyRetrieveTest extends TestCase {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class IvyRetrieveTest {
     private static final String IVY_RETRIEVE_PATTERN = "build/test/lib/[organisation]/[module]/ivy-[revision].xml";
 
     private static final String RETRIEVE_PATTERN = "build/test/lib/[conf]/[artifact]-[revision].[type]";
@@ -39,7 +46,8 @@ public class IvyRetrieveTest extends TestCase {
 
     private Project project;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         createCache();
         CacheCleaner.deleteDir(new File("build/test/lib"));
         project = TestHelper.newProject();
@@ -56,11 +64,13 @@ public class IvyRetrieveTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
         CacheCleaner.deleteDir(new File("build/test/lib"));
     }
 
+    @Test
     public void testSimple() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
         retrieve.execute();
@@ -68,6 +78,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar")).exists());
     }
 
+    @Test
     public void testRetrievePrivateWithWildcard() throws Exception {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-381.xml");
         retrieve.setConf("*");
@@ -78,6 +89,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod3.2", "jar", "jar", "private")).exists());
     }
 
+    @Test
     public void testValidateInIvySettings() throws Exception {
         // cfr IVY-992
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-latest-extra.xml");
@@ -88,6 +100,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar", "default")).exists());
     }
 
+    @Test
     public void testInline() throws Exception {
         // we first resolve another ivy file
         IvyResolve resolve = new IvyResolve();
@@ -107,6 +120,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar")).exists());
     }
 
+    @Test
     public void testWithConf() throws Exception {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
         retrieve.execute();
@@ -119,6 +133,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar", "extension")).exists());
     }
 
+    @Test
     public void testSync() throws Exception {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
         retrieve.setSync(true);
@@ -133,8 +148,8 @@ public class IvyRetrieveTest extends TestCase {
                 new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org6", "mod6.1", "unknown",
                     "mod6.1", "jar", "jar", "default")), // unknown revision
         };
-        for (int i = 0; i < old.length; i++) {
-            touch(old[i]);
+        for (File of : old) {
+            touch(of);
         }
         retrieve.execute();
 
@@ -144,13 +159,14 @@ public class IvyRetrieveTest extends TestCase {
             "mod6.1", "jar", "jar", "extension")).exists());
         assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.1",
             "mod1.2", "jar", "jar", "extension")).exists());
-        for (int i = 0; i < old.length; i++) {
-            assertFalse(old[i] + " should have been deleted by sync", old[i].exists());
+        for (File of : old) {
+            assertFalse(of + " should have been deleted by sync", of.exists());
         }
         assertFalse(new File("build/test/lib/unknown").exists()); // even conf directory should
         // have been deleted
     }
 
+    @Test
     public void testSyncWithIgnoreList() throws Exception {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
         retrieve.setSync(true);
@@ -164,6 +180,7 @@ public class IvyRetrieveTest extends TestCase {
         assertTrue(new File("build/test/lib/.svn/test.txt").exists());
     }
 
+    @Test
     public void testWithAPreviousResolve() throws Exception {
         // first we do a resolve in another project
         Project project = TestHelper.newProject();
@@ -183,6 +200,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar")).exists());
     }
 
+    @Test
     public void testWithAPreviousResolveAndResolveId() throws Exception {
         // first we do a resolve in another project
         Project project = TestHelper.newProject();
@@ -204,6 +222,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar")).exists());
     }
 
+    @Test
     public void testUseOrigin() throws Exception {
         // test case for IVY-304
         // first we do a resolve with useOrigin=true in another project
@@ -227,6 +246,7 @@ public class IvyRetrieveTest extends TestCase {
             "mod1.2", "jar", "jar")).exists());
     }
 
+    @Test
     public void testUseOriginWithIvyPattern() throws Exception {
         // mod2.5 depends on virtual mod2.3 which depends on mod2.1 which depends on mod1.1 which
         // depends on mod1.2
@@ -248,6 +268,7 @@ public class IvyRetrieveTest extends TestCase {
             "ivy", "ivy", "xml")).exists());
     }
 
+    @Test
     public void testRetrieveWithOriginalNamePattern() throws Exception {
         retrieve.setFile(new File("test/java/org/apache/ivy/ant/ivy-631.xml"));
         retrieve.setConf("default");
@@ -258,29 +279,24 @@ public class IvyRetrieveTest extends TestCase {
         assertTrue(new File("build/test/lib/default/mod1.2-2.2.jar").exists());
     }
 
+    @Test(expected = BuildException.class)
     public void testFailureWithoutAPreviousResolve() throws Exception {
         // we do a retrieve with the module information whereas no resolve has been previously done
-        try {
-            retrieve.setOrganisation("apache");
-            retrieve.setModule("resolve-simple");
-            retrieve.setConf("default");
-            retrieve.execute();
-            fail("retrieve without previous resolve should have thrown an exception");
-        } catch (Exception ex) {
-            // OK
-        }
+        retrieve.setOrganisation("apache");
+        retrieve.setModule("resolve-simple");
+        retrieve.setConf("default");
+        retrieve.execute();
+        fail("retrieve without previous resolve should have thrown an exception");
     }
 
+    @Test(expected = BuildException.class)
     public void testFailure() throws Exception {
-        try {
-            project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
-            retrieve.execute();
-            fail("failure didn't raised an exception with default haltonfailure setting");
-        } catch (BuildException ex) {
-            // ok => should raised an exception
-        }
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
+        retrieve.execute();
+        fail("failure didn't raised an exception with default haltonfailure setting");
     }
 
+    @Test
     public void testHaltOnFailure() throws Exception {
         try {
             project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-failure.xml");
@@ -292,6 +308,7 @@ public class IvyRetrieveTest extends TestCase {
         }
     }
 
+    @Test
     public void testCustomIvyPattern() throws Exception {
         // mod2.5 depends on virtual mod2.3 which depends on mod2.1 which depends on mod1.1 which
         // depends on mod1.2
@@ -312,6 +329,7 @@ public class IvyRetrieveTest extends TestCase {
             "ivy", "ivy", "xml")).exists());
     }
 
+    @Test
     public void testCustomIvyPatternWithConf() throws Exception {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
 
@@ -328,6 +346,7 @@ public class IvyRetrieveTest extends TestCase {
             "ivy", "ivy", "xml", "extension")).exists());
     }
 
+    @Test
     public void testSyncWithIvyPattern() throws Exception {
         project.setProperty("ivy.dep.file", "test/repositories/1/org6/mod6.2/ivys/ivy-0.4.xml");
 
@@ -347,8 +366,8 @@ public class IvyRetrieveTest extends TestCase {
                 new File(IvyPatternHelper.substitute(ivyPattern, "unknown", "mod6.1", "0.4", "ivy",
                     "ivy", "xml", "default")), // unknown organisation for ivy
         };
-        for (int i = 0; i < old.length; i++) {
-            touch(old[i]);
+        for (File of : old) {
+            touch(of);
         }
 
         retrieve.execute();
@@ -359,14 +378,15 @@ public class IvyRetrieveTest extends TestCase {
             "ivy", "xml", "extension")).exists());
         assertFalse(new File(IvyPatternHelper.substitute(ivyPattern, "org1", "mod1.2", "2.1",
             "ivy", "ivy", "xml", "extension")).exists());
-        for (int i = 0; i < old.length; i++) {
-            assertFalse(old[i] + " should have been deleted by sync", old[i].exists());
+        for (File of : old) {
+            assertFalse(of + " should have been deleted by sync", of.exists());
         }
         assertFalse(new File("build/test/lib/unknown").exists());
         assertFalse(new File("build/test/lib/unk").exists());
         assertFalse(new File("build/test/lib/default/unknown").exists());
     }
 
+    @Test
     public void testDoubleRetrieveWithDifferentConfigurations() {
         // IVY-315
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-doubleretrieve.xml");

--- a/test/java/org/apache/ivy/ant/IvyTaskTest.java
+++ b/test/java/org/apache/ivy/ant/IvyTaskTest.java
@@ -23,14 +23,19 @@ import java.net.MalformedURLException;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.settings.IvySettings;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Reference;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class IvyTaskTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+public class IvyTaskTest {
+
+    @Test
     public void testDefaultSettings() throws MalformedURLException {
         Project p = TestHelper.newProject();
         p.setBasedir("test/repositories");
@@ -60,6 +65,8 @@ public class IvyTaskTest extends TestCase {
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
     public void testReferencedSettings() throws MalformedURLException {
         Project p = TestHelper.newProject();
         p.setProperty("myproperty", "myvalue");
@@ -92,6 +99,7 @@ public class IvyTaskTest extends TestCase {
         assertEquals("myvalue", settings.getVariables().getVariable("myproperty"));
     }
 
+    @Test
     public void testIvyVersionAsAntProperty() {
         Project p = TestHelper.newProject();
         p.setBasedir("test/repositories");

--- a/test/java/org/apache/ivy/ant/IvyVarTest.java
+++ b/test/java/org/apache/ivy/ant/IvyVarTest.java
@@ -20,9 +20,13 @@ package org.apache.ivy.ant;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class IvyVarTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class IvyVarTest {
+    @Test
     public void testSimple() {
         IvyVar task = new IvyVar();
         task.setProject(TestHelper.newProject());
@@ -34,6 +38,7 @@ public class IvyVarTest extends TestCase {
         assertEquals("myvalue", ivy.getVariable("mytest"));
     }
 
+    @Test
     public void testPrefix() {
         IvyVar task = new IvyVar();
         task.setProject(TestHelper.newProject());
@@ -46,6 +51,7 @@ public class IvyVarTest extends TestCase {
         assertEquals("myvalue", ivy.getVariable("myprefix.mytest"));
     }
 
+    @Test
     public void testURL() {
         IvyVar task = new IvyVar();
         task.setProject(TestHelper.newProject());
@@ -57,6 +63,7 @@ public class IvyVarTest extends TestCase {
         assertEquals("myvalue2", ivy.getVariable("mytest2"));
     }
 
+    @Test
     public void testURLPrefix() {
         IvyVar task = new IvyVar();
         task.setProject(TestHelper.newProject());

--- a/test/java/org/apache/ivy/ant/testutil/AntTaskTestCase.java
+++ b/test/java/org/apache/ivy/ant/testutil/AntTaskTestCase.java
@@ -18,11 +18,13 @@
 package org.apache.ivy.ant.testutil;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.Project;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class AntTaskTestCase extends TestCase {
+public class AntTaskTestCase {
 
     private AntTestListener antTestListener;
 

--- a/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
+++ b/test/java/org/apache/ivy/core/NormalRelativeUrlResolverTest.java
@@ -17,31 +17,37 @@
  */
 package org.apache.ivy.core;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class NormalRelativeUrlResolverTest extends TestCase {
+public class NormalRelativeUrlResolverTest {
 
     private NormalRelativeUrlResolver t = new NormalRelativeUrlResolver();
 
+    @Test
     public void testRelativeHttpURL() throws MalformedURLException {
         URL base = new URL("http://xxx/file.txt");
         assertEquals(new URL("http://xxx/file2.txt"), t.getURL(base, "file2.txt"));
     }
 
+    @Test
     public void testRelativeFileURL() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
         assertEquals(new URL("file://xxx/file2.txt"), t.getURL(base, "file2.txt"));
     }
 
+    @Test
     public void testRelativeMixedURL() throws MalformedURLException {
         URL base = new URL("http://xxx/file.txt");
         assertEquals(new URL("file://file2.txt"), t.getURL(base, "file://file2.txt"));
     }
 
+    @Test
     public void testFileAndUrlWithAbsoluteFile() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
         File absFile = new File(".").getAbsoluteFile();
@@ -50,6 +56,7 @@ public class NormalRelativeUrlResolverTest extends TestCase {
         assertEquals(absFile.toURI().toURL(), t.getURL(base, absFile.toString(), "somthing.txt"));
     }
 
+    @Test
     public void testFileAndUrlWithRelativeFile() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
         assertEquals(new URL("file://xxx/file2.txt"), t.getURL(base, "file2.txt", null));
@@ -58,6 +65,7 @@ public class NormalRelativeUrlResolverTest extends TestCase {
             t.getURL(base, "sub/file2.txt", "something"));
     }
 
+    @Test
     public void testFileAndUrlWithAbsoluteUrl() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
         URL otherBase = new URL("http://localhost:80/otherfile.txt");
@@ -66,6 +74,7 @@ public class NormalRelativeUrlResolverTest extends TestCase {
         assertEquals(new URL(absUrl), t.getURL(otherBase, null, absUrl));
     }
 
+    @Test
     public void testFileAndUrlWithRelativeUrl() throws MalformedURLException {
         URL base = new URL("file://xxx/file.txt");
         URL otherBase = new URL("http://localhost:80/otherfile.txt");

--- a/test/java/org/apache/ivy/core/TestPerformance.java
+++ b/test/java/org/apache/ivy/core/TestPerformance.java
@@ -34,6 +34,9 @@ import org.apache.ivy.plugins.resolver.FileSystemResolver;
 import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Not a Junit test, performance depends on the machine on which the test is run...
@@ -56,11 +59,13 @@ public class TestPerformance {
         ivy.getSettings().setDefaultResolver("def");
     }
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
@@ -118,6 +123,7 @@ public class TestPerformance {
         }
     }
 
+    @Test
     public void testPerfs() throws Exception {
         generateModules(70, 2, 5, 2, 15);
 

--- a/test/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManagerTest.java
+++ b/test/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManagerTest.java
@@ -45,20 +45,26 @@ import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @see DefaultResolutionCacheManager
  */
-public class DefaultRepositoryCacheManagerTest extends TestCase {
+public class DefaultRepositoryCacheManagerTest {
     
     private DefaultRepositoryCacheManager cacheManager;
     private Artifact artifact;
     private ArtifactOrigin origin;
     private Ivy ivy;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         File f = File.createTempFile("ivycache", ".dir");
         ivy = new Ivy();
         ivy.configureDefault();
@@ -81,7 +87,8 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         cacheManager.saveArtifactOrigin(artifact, origin);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         IvyContext.popContext();
         Delete del = new Delete();
         del.setProject(new Project());
@@ -89,6 +96,7 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         del.execute();
     }
 
+    @Test
     public void testArtifactOrigin() {
         ArtifactOrigin found = cacheManager.getSavedArtifactOrigin(artifact);
         assertEquals(origin, found);
@@ -99,6 +107,7 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         assertTrue(ArtifactOrigin.isUnknown(found));
     }
 
+    @Test
     public void testUniqueness() {
         cacheManager.saveArtifactOrigin(artifact, origin);
 
@@ -127,8 +136,9 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         assertTrue(ArtifactOrigin.isUnknown(found));
     }
 
-    //TODO
-    public void disableTestLatestIntegrationIsCachedPerResolver() throws Exception {
+    @Test
+    @Ignore
+    public void testLatestIntegrationIsCachedPerResolver() throws Exception {
         // given a module org#module
         ModuleId mi = new ModuleId("org", "module");
 
@@ -140,10 +150,10 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         CacheMetadataOptions options = new CacheMetadataOptions().setCheckTTL(false);
 
         // setup resolver1 to download the static content so we can call cacheModuleDescriptor
-        MockResolver resolver1 = new MockResolver();
-        resolver1.setName("resolver1");
-        resolver1.setSettings(ivy.getSettings());
-        ivy.getSettings().addResolver(resolver1);
+        MockResolver resolver = new MockResolver();
+        resolver.setName("resolver1");
+        resolver.setSettings(ivy.getSettings());
+        ivy.getSettings().addResolver(resolver);
         ResourceDownloader downloader = new ResourceDownloader() {
             public void download(Artifact artifact, Resource resource, File dest)
                     throws IOException {
@@ -170,8 +180,8 @@ public class DefaultRepositoryCacheManagerTest extends TestCase {
         ResolvedResource mdRef11 = new ResolvedResource(resource11, "1.1");
 
         // tell the cache about 1.1
-        ResolvedModuleRevision rmr11 = cacheManager.cacheModuleDescriptor(resolver1, mdRef11, dd11, artifact11, downloader, options);
-        cacheManager.originalToCachedModuleDescriptor(resolver1, mdRef11, artifact11, rmr11, writer);
+        ResolvedModuleRevision rmr11 = cacheManager.cacheModuleDescriptor(resolver, mdRef11, dd11, artifact11, downloader, options);
+        cacheManager.originalToCachedModuleDescriptor(resolver, mdRef11, artifact11, rmr11, writer);
         // and use the new overload that passes in resolver name
         cacheManager.saveResolvedRevision("resolver1", mridLatest, "1.1");
 

--- a/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
+++ b/test/java/org/apache/ivy/core/cache/ModuleDescriptorMemoryCacheTest.java
@@ -26,11 +26,13 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.ParserSettings;
+import org.junit.Test;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class ModuleDescriptorMemoryCacheTest extends TestCase {
+
+public class ModuleDescriptorMemoryCacheTest {
 
     ModuleDescriptorMemoryCache cache = new ModuleDescriptorMemoryCache(2);
 
@@ -38,11 +40,11 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
 
     IvySettings ivySettings2 = new IvySettings();
 
-    File url1 = new File("file://cached/file.txt");;
+    File url1 = new File("file://cached/file.txt");
 
-    File url2 = new File("file://cached/file2.txt");;
+    File url2 = new File("file://cached/file2.txt");
 
-    File url3 = new File("file://cached/file3.txt");;
+    File url3 = new File("file://cached/file3.txt");
 
     ModuleRevisionId mrid1 = ModuleRevisionId.newInstance("org", "name", "rev");
 
@@ -56,6 +58,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
 
     ModuleDescriptor md3 = DefaultModuleDescriptor.newDefaultInstance(mrid3);
 
+    @Test
     public void testUseModuleDescriptorProviderWhenModuleNotCached() throws ParseException,
             IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
@@ -63,6 +66,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         providerMock.assertCalled();
     }
 
+    @Test
     public void testCacheResultOfModuleDescriptorProvider() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = null;
@@ -70,15 +74,16 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         assertEquals(md1, cache.get(url1, ivySettings, false, providerMock2));
     }
 
+    @Test
     public void testValidationClearInvalidatedCache() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = new ModuleDescriptorProviderMock(md1);
-        ;
         assertEquals(md1, cache.get(url1, ivySettings, false, providerMock));
         assertEquals(md1, cache.get(url1, ivySettings, true, providerMock2));
         providerMock2.assertCalled();
     }
 
+    @Test
     public void testValidationDontClearvalidatedCache() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = null;
@@ -86,7 +91,8 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         assertEquals(md1, cache.get(url1, ivySettings, false, providerMock2));
     }
 
-    public void testSizeIsLimitied() throws ParseException, IOException {
+    @Test
+    public void testSizeIsLimited() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock1b = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = new ModuleDescriptorProviderMock(md2);
@@ -98,6 +104,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         providerMock1b.assertCalled();
     }
 
+    @Test
     public void testLastRecentlyUsedIsFlushedWhenSizeExceed() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = new ModuleDescriptorProviderMock(md2);
@@ -112,6 +119,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         providerMock2b.assertCalled();
     }
 
+    @Test
     public void testVariableChangeInvalidateEntry() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = new ModuleDescriptorProviderMock(md1);
@@ -121,6 +129,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         providerMock2.assertCalled();
     }
 
+    @Test
     public void testGetStaleDontReadFromCache() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = new ModuleDescriptorProviderMock(md2);
@@ -129,6 +138,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         providerMock2.assertCalled();
     }
 
+    @Test
     public void testGetStaleStoreResultInCache() throws ParseException, IOException {
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
         ModuleDescriptorProviderMock providerMock2 = null;
@@ -136,6 +146,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         assertEquals(md1, cache.get(url1, ivySettings, false, providerMock2));
     }
 
+    @Test
     public void testASizeOf0MeansNoCache() throws ParseException, IOException {
         cache = new ModuleDescriptorMemoryCache(0);
         ModuleDescriptorProviderMock providerMock = new ModuleDescriptorProviderMock(md1);
@@ -165,7 +176,7 @@ public class ModuleDescriptorMemoryCacheTest extends TestCase {
         }
 
         public void assertCalled() {
-            Assert.assertTrue(called);
+            assertTrue(called);
         }
     }
 

--- a/test/java/org/apache/ivy/core/deliver/DeliverTest.java
+++ b/test/java/org/apache/ivy/core/deliver/DeliverTest.java
@@ -28,17 +28,21 @@ import org.apache.ivy.ant.IvyDeliver;
 import org.apache.ivy.ant.IvyResolve;
 import org.apache.ivy.util.FileUtil;
 import org.apache.tools.ant.Project;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
 
-public class DeliverTest extends TestCase {
+public class DeliverTest {
     private File cache;
 
     private File deliverDir;
 
     private IvyDeliver ivyDeliver;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         cache = new File("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
@@ -55,7 +59,8 @@ public class DeliverTest extends TestCase {
                 + "/[type]s/[artifact]-[revision](-[classifier]).[ext]");
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(cache);
         FileUtil.forceDelete(deliverDir);
     }
@@ -64,6 +69,7 @@ public class DeliverTest extends TestCase {
         cache.mkdirs();
     }
 
+    @Test
     public void testIVY1111() throws Exception {
         Project project = ivyDeliver.getProject();
         project.setProperty("ivy.settings.file", "test/repositories/IVY-1111/ivysettings.xml");
@@ -75,8 +81,8 @@ public class DeliverTest extends TestCase {
         ivyDeliver.doExecute();
 
         String deliverContent = readFile(deliverDir.getAbsolutePath() + "/ivys/ivy-1.0.xml");
-        assertTrue(deliverContent.indexOf("rev=\"latest.integration\"") == -1);
-        assertTrue(deliverContent.indexOf("name=\"b\" rev=\"1.5\"") >= 0);
+        assertTrue(!deliverContent.contains("rev=\"latest.integration\""));
+        assertTrue(deliverContent.contains("name=\"b\" rev=\"1.5\""));
     }
 
     private void resolve(File ivyFile) {
@@ -87,14 +93,14 @@ public class DeliverTest extends TestCase {
     }
 
     private String readFile(String fileName) throws IOException {
-        StringBuffer retval = new StringBuffer();
+        StringBuilder retval = new StringBuilder();
 
         File ivyFile = new File(fileName);
         BufferedReader reader = new BufferedReader(new FileReader(ivyFile));
 
         String line = null;
         while ((line = reader.readLine()) != null) {
-            retval.append(line + "\n");
+            retval.append(line).append("\n");
         }
 
         reader.close();

--- a/test/java/org/apache/ivy/core/event/IvyEventFilterTest.java
+++ b/test/java/org/apache/ivy/core/event/IvyEventFilterTest.java
@@ -25,10 +25,13 @@ import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class IvyEventFilterTest extends TestCase {
+public class IvyEventFilterTest {
 
     private ModuleDescriptor md = null;
 
@@ -38,6 +41,7 @@ public class IvyEventFilterTest extends TestCase {
 
     private ModuleDescriptor md4 = null;
 
+    @Before
     public void setUp() throws Exception {
         md = new DefaultModuleDescriptor(ModuleRevisionId.newInstance("foo", "bar", "1.0"),
                 "integration", new Date());
@@ -49,6 +53,7 @@ public class IvyEventFilterTest extends TestCase {
                 "integration", new Date());
     }
 
+    @Test
     public void testSimple() {
         IvyEventFilter f = new IvyEventFilter("pre-resolve", null, null);
 
@@ -57,6 +62,7 @@ public class IvyEventFilterTest extends TestCase {
                 new ResolveReport(md))));
     }
 
+    @Test
     public void testSimpleExpression() {
         IvyEventFilter f = new IvyEventFilter("pre-resolve", "organisation = foo", null);
 
@@ -79,6 +85,7 @@ public class IvyEventFilterTest extends TestCase {
         assertTrue(f.accept(new StartResolveEvent(md4, new String[] {"default"})));
     }
 
+    @Test
     public void testAndExpression() {
         IvyEventFilter f = new IvyEventFilter("pre-resolve", "organisation = foo AND module = bar",
                 null);
@@ -95,6 +102,7 @@ public class IvyEventFilterTest extends TestCase {
         assertFalse(f.accept(new StartResolveEvent(md4, new String[] {"default"})));
     }
 
+    @Test
     public void testOrExpression() {
         IvyEventFilter f = new IvyEventFilter("pre-resolve", "organisation = foo3 OR module = bar",
                 null);
@@ -105,6 +113,7 @@ public class IvyEventFilterTest extends TestCase {
         assertFalse(f.accept(new StartResolveEvent(md4, new String[] {"default"})));
     }
 
+    @Test
     public void testNotExpression() {
         IvyEventFilter f = new IvyEventFilter("pre-resolve", "NOT organisation = foo", null);
 

--- a/test/java/org/apache/ivy/core/install/InstallTest.java
+++ b/test/java/org/apache/ivy/core/install/InstallTest.java
@@ -26,11 +26,16 @@ import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class InstallTest extends TestCase {
+public class InstallTest {
 
+    @Test
     public void testSimple() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -42,6 +47,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
+    @Test
     public void testValidate() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -54,10 +60,12 @@ public class InstallTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testMaven() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
 
+        @SuppressWarnings("unused")
         ResolveReport rr = ivy.install(ModuleRevisionId.newInstance("org.apache", "test", "1.0"),
             ivy.getSettings().getDefaultResolver().getName(), "install", new InstallOptions());
 
@@ -75,6 +83,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org.apache/test/test-1.0.pom").exists());
     }
 
+    @Test
     public void testNoValidate() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -87,6 +96,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/orgfailure/modfailure/modfailure-1.0.jar").exists());
     }
 
+    @Test
     public void testSimpleWithoutDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings-nodefaultresolver.xml"));
@@ -98,6 +108,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
+    @Test
     public void testDependencies() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -112,6 +123,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
+    @Test
     public void testLatestDependenciesNoDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings-nodefaultresolver.xml"));
@@ -128,6 +140,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
+    @Test
     public void testLatestDependenciesDummyDefaultResolver() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings-dummydefaultresolver.xml"));
@@ -144,6 +157,7 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.2/mod1.2-2.2.jar").exists());
     }
 
+    @Test
     public void testNotTransitive() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -159,6 +173,7 @@ public class InstallTest extends TestCase {
         assertFalse(new File("build/test/install/org1/mod1.2/mod1.2-2.0.jar").exists());
     }
 
+    @Test
     public void testRegexpMatcher() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -185,11 +200,13 @@ public class InstallTest extends TestCase {
         assertTrue(new File("build/test/install/org1/mod1.4/ivy-1.0.1.xml").exists());
     }
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestHelper.createCache();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
         cleanInstall();
     }

--- a/test/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptorTest.java
+++ b/test/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptorTest.java
@@ -18,18 +18,23 @@
 
 package org.apache.ivy.core.module.descriptor;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
 
-public class DefaultDependencyDescriptorTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DefaultDependencyDescriptorTest {
 
     public static void main(String[] args) {
-        junit.textui.TestRunner.run(DefaultDependencyDescriptorTest.class);
+        JUnitCore.runClasses(DefaultDependencyDescriptorTest.class);
     }
 
     /*
      * Test method for
      * 'org.apache.ivy.DefaultDependencyDescriptor.replaceSelfFallbackPattern(String, String)'
      */
+    @Test
     public void testReplaceSelfFallbackPattern() {
         String replacedConf = DefaultDependencyDescriptor.replaceSelfFallbackPattern("@(default)",
             "compile");
@@ -47,6 +52,7 @@ public class DefaultDependencyDescriptorTest extends TestCase {
      * Test method for
      * 'org.apache.ivy.DefaultDependencyDescriptor.replaceThisFallbackPattern(String, String)'
      */
+    @Test
     public void testReplaceThisFallbackPattern() {
         String replacedConf = DefaultDependencyDescriptor.replaceThisFallbackPattern("#(default)",
             "compile");

--- a/test/java/org/apache/ivy/core/module/id/ModuleIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleIdTest.java
@@ -34,8 +34,7 @@ public class ModuleIdTest {
     }
 
     @Test
-    public void testModuleIdIllegalArgumentException() {
-        String org = "apache";
+    public void testModuleIdIllegalArgumentException1() {
         String name = "some-new-module";
 
         try {
@@ -43,13 +42,12 @@ public class ModuleIdTest {
         } catch (IllegalArgumentException iae) {
             fail("A null should be allowed for argument 'org'.");
         }
+    }
 
-        try {
-            new ModuleId(org, null);
-            fail("A IllegalArgumentException should have been thrown for the argument 'name'.");
-        } catch (IllegalArgumentException iae) {
-            // success
-        }
+    @Test(expected = IllegalArgumentException.class)
+    public void testModuleIdIllegalArgumentException2() {
+        String org = "apache";
+        new ModuleId(org, null);
     }
 
     @Test
@@ -95,18 +93,12 @@ public class ModuleIdTest {
         assertEquals(moduleId, moduleId2);
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testCompareToNullObject() {
         String org = "apache";
         String name = "some-new-module";
         ModuleId moduleId = new ModuleId(org, name);
-
-        try {
-            moduleId.compareTo(null);
-            fail("A NullPointerException was expected.");
-        } catch (NullPointerException npe) {
-            // success
-        }
+        moduleId.compareTo(null);
     }
 
     @Test

--- a/test/java/org/apache/ivy/core/module/id/ModuleIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleIdTest.java
@@ -17,10 +17,13 @@
  */
 package org.apache.ivy.core.module.id;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class ModuleIdTest extends TestCase {
+import static org.junit.Assert.*;
 
+public class ModuleIdTest {
+
+    @Test
     public void testModuleId() {
         String org = "apache";
         String name = "some-new-module";
@@ -30,6 +33,7 @@ public class ModuleIdTest extends TestCase {
         assertEquals(name, moduleId.getName());
     }
 
+    @Test
     public void testModuleIdIllegalArgumentException() {
         String org = "apache";
         String name = "some-new-module";
@@ -48,6 +52,7 @@ public class ModuleIdTest extends TestCase {
         }
     }
 
+    @Test
     public void testEqualsObjectTrue() {
         String org = "apache";
         String name = "some-new-module";
@@ -59,6 +64,7 @@ public class ModuleIdTest extends TestCase {
         assertTrue(moduleId2.equals(moduleId));
     }
 
+    @Test
     public void testEqualsObjectFalse() {
         String org = "apache";
         String name = "some-new-module";
@@ -70,6 +76,7 @@ public class ModuleIdTest extends TestCase {
         assertFalse(moduleId2.equals(moduleId));
     }
 
+    @Test
     public void testEncodeToString() {
         String org = "apache";
         String name = "some-new-module";
@@ -78,6 +85,7 @@ public class ModuleIdTest extends TestCase {
         assertEquals(org + ModuleId.ENCODE_SEPARATOR + name, moduleId.encodeToString());
     }
 
+    @Test
     public void testDecode() {
         String org = "apache";
         String name = "some-new-module";
@@ -87,6 +95,7 @@ public class ModuleIdTest extends TestCase {
         assertEquals(moduleId, moduleId2);
     }
 
+    @Test
     public void testCompareToNullObject() {
         String org = "apache";
         String name = "some-new-module";
@@ -100,6 +109,7 @@ public class ModuleIdTest extends TestCase {
         }
     }
 
+    @Test
     public void testCompareToEqual() {
         String org = "apache";
         String name = "some-new-module";
@@ -108,6 +118,7 @@ public class ModuleIdTest extends TestCase {
         assertTrue(moduleId.compareTo(new ModuleId(org, name)) == 0);
     }
 
+    @Test
     public void testCompareToLessThan() {
         String org = "apache";
         String name = "some-new-module";
@@ -119,7 +130,8 @@ public class ModuleIdTest extends TestCase {
         assertTrue(moduleId.compareTo(moduleId2) < 0);
     }
 
-    public void testCompareToGreatherThan() {
+    @Test
+    public void testCompareToGreaterThan() {
         String org = "apache";
         String name = "some-new-module";
         ModuleId moduleId = new ModuleId(org, name);

--- a/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
@@ -17,13 +17,18 @@
  */
 package org.apache.ivy.core.module.id;
 
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class ModuleRevisionIdTest extends TestCase {
+public class ModuleRevisionIdTest {
 
+    @Test
     public void testParse() throws Exception {
         testParse("#A;1.0");
         testParse("org#module;2.0");
@@ -44,10 +49,11 @@ public class ModuleRevisionIdTest extends TestCase {
             ModuleRevisionId.parse(mrid);
             fail("ModuleRevisionId.parse is supposed to raise an exception with " + mrid);
         } catch (IllegalArgumentException ex) {
-            assertTrue(ex.getMessage().indexOf(mrid) != -1);
+            assertTrue(ex.getMessage().contains(mrid));
         }
     }
 
+    @Test
     public void testEncodeDecodeToString() {
         testEncodeDecodeToString(ModuleRevisionId.newInstance("org", "name", "revision"));
         testEncodeDecodeToString(ModuleRevisionId.newInstance("org", "name", ""));

--- a/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.ivy.core.module.id;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +30,9 @@ import static org.junit.Assert.fail;
 
 public class ModuleRevisionIdTest {
 
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
+
     @Test
     public void testParse() throws Exception {
         testParse("#A;1.0");
@@ -37,20 +42,37 @@ public class ModuleRevisionIdTest {
         testParse("org#module#branch;working@test");
         testParse(" org#module#branch;[1.2,1.3] ");
         testParse(" org#module#branch;[1.2,1.3) ");
+    }
 
+    private void testParse(String mrid) {
+        assertEquals(mrid.trim(), ModuleRevisionId.parse(mrid).toString());
+    }
+
+    @Test
+    public void testParseFailure1() throws Exception {
         testParseFailure("bad");
+    }
+
+    @Test
+    public void testParseFailure2() throws Exception {
         testParseFailure("org#mod");
+    }
+
+    @Test
+    public void testParseFailure3() throws Exception {
         testParseFailure("#;1");
+    }
+
+    @Test
+    public void testParseFailure4() throws Exception {
         testParseFailure("#A%;1.0");
     }
 
     private void testParseFailure(String mrid) {
-        try {
-            ModuleRevisionId.parse(mrid);
-            fail("ModuleRevisionId.parse is supposed to raise an exception with " + mrid);
-        } catch (IllegalArgumentException ex) {
-            assertTrue(ex.getMessage().contains(mrid));
-        }
+        expExc.expect(IllegalArgumentException.class);
+        expExc.expectMessage(mrid);
+
+        ModuleRevisionId.parse(mrid);
     }
 
     @Test
@@ -77,7 +99,4 @@ public class ModuleRevisionIdTest {
         assertEquals(mrid, ModuleRevisionId.decode(mrid.encodeToString()));
     }
 
-    private void testParse(String mrid) {
-        assertEquals(mrid.trim(), ModuleRevisionId.parse(mrid).toString());
-    }
 }

--- a/test/java/org/apache/ivy/core/module/id/ModuleRulesTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleRulesTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ivy.core.module.id;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,15 +28,16 @@ import org.apache.ivy.plugins.matcher.MapMatcher;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.ivy.util.filter.Filter;
 import org.apache.ivy.util.filter.NoFilter;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class ModuleRulesTest extends TestCase {
+public class ModuleRulesTest {
     private ModuleRules rules;
 
     private Object[] rule;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         rules = new ModuleRules();
         rule = new Object[10];
         for (int i = 0; i < rule.length; i++) {
@@ -42,8 +45,7 @@ public class ModuleRulesTest extends TestCase {
         }
     }
 
-    // tests
-
+    @Test
     public void testGetRule() throws Exception {
         // fixture
         rules.defineRule(mapMatcher().organization("apache").build(), rule[0]);
@@ -56,6 +58,7 @@ public class ModuleRulesTest extends TestCase {
         assertRule(null, "unknown#module1;1.5");
     }
 
+    @Test
     public void testGetRuleWithFilter() throws Exception {
         // fixture
         rules.defineRule(mapMatcher().organization("apache").build(), rule[0]);

--- a/test/java/org/apache/ivy/core/publish/PublishEngineTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEngineTest.java
@@ -37,18 +37,27 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
 import org.apache.ivy.util.FileUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class PublishEngineTest extends TestCase {
-    protected void setUp() throws Exception {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class PublishEngineTest {
+    @Before
+    public void setUp() {
         System.setProperty("ivy.cache.dir", new File("build/test/publish/cache").getAbsolutePath());
         FileUtil.forceDelete(new File("build/test/publish"));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(new File("build/test/publish"));
     }
 
+    @Test
     public void testAtomicity() throws Exception {
         IvySettings settings = new IvySettings();
         final PublishEngine engine = new PublishEngine(settings, new EventManager());

--- a/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
+++ b/test/java/org/apache/ivy/core/publish/PublishEventsTest.java
@@ -38,9 +38,13 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser;
 import org.apache.ivy.plugins.resolver.MockResolver;
 import org.apache.ivy.plugins.trigger.AbstractTrigger;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class PublishEventsTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class PublishEventsTest {
 
     // maps ArtifactRevisionId to PublishTestCase instance.
     private HashMap expectedPublications;
@@ -82,9 +86,8 @@ public class PublishEventsTest extends TestCase {
 
     private PublishEngine publishEngine;
 
-    protected void setUp() throws Exception {
-        super.setUp();
-
+    @Before
+    public void setUp() throws Exception {
         // reset test case state.
         resetCounters();
 
@@ -134,9 +137,8 @@ public class PublishEventsTest extends TestCase {
         IvyContext.getContext().push(PublishEventsTest.class.getName(), this);
     }
 
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
+    @After
+    public void tearDown() {
         // reset test state.
         resetCounters();
 
@@ -173,6 +175,7 @@ public class PublishEventsTest extends TestCase {
     /**
      * Test a simple artifact publish, without errors or overwrite settings.
      */
+    @Test
     public void testPublishNoOverwrite() throws IOException {
         // no modifications to input required for this case -- call out to the resolver, and verify
         // that
@@ -191,6 +194,7 @@ public class PublishEventsTest extends TestCase {
     /**
      * Test a simple artifact publish, with overwrite set to true.
      */
+    @Test
     public void testPublishWithOverwrite() throws IOException {
         // we expect the overwrite settings to be passed through the event listeners and into the
         // publisher.
@@ -213,6 +217,7 @@ public class PublishEventsTest extends TestCase {
     /**
      * Test an attempted publish with an invalid data file path.
      */
+    @Test
     public void testPublishMissingFile() throws IOException {
         // delete the datafile. the publish should fail
         // and the ivy artifact should still publish successfully.
@@ -237,6 +242,7 @@ public class PublishEventsTest extends TestCase {
     /**
      * Test an attempted publish in which the target resolver throws an IOException.
      */
+    @Test
     public void testPublishWithException() {
         // set an error to be thrown during publication of the data file.
         this.publishError = new IOException("boom!");
@@ -347,9 +353,8 @@ public class PublishEventsTest extends TestCase {
                     assertEquals("event declares correct value for " + attributes[i], values[i],
                         event.getAttributes().get(attributes[i]));
                 }
-                // we test file separately, since it is hard to guaranteean exact path match, but we
-                // want
-                // to make sure that both paths point to the same canonical location on the
+                // we test file separately, since it is hard to guarantee an exact path match, but we
+                // want to make sure that both paths point to the same canonical location on the
                 // filesystem
                 String filePath = event.getAttributes().get("file").toString();
                 assertEquals("event declares correct value for file",

--- a/test/java/org/apache/ivy/core/report/ResolveReportTest.java
+++ b/test/java/org/apache/ivy/core/report/ResolveReportTest.java
@@ -31,9 +31,13 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.FileUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class ResolveReportTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class ResolveReportTest {
 
     private Ivy ivy;
 
@@ -43,7 +47,8 @@ public class ResolveReportTest extends TestCase {
 
     private File workDir;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         cache = new File("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
@@ -62,7 +67,8 @@ public class ResolveReportTest extends TestCase {
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
         FileUtil.forceDelete(deliverDir);
         FileUtil.forceDelete(workDir);
@@ -84,6 +90,7 @@ public class ResolveReportTest extends TestCase {
             new HashSet<String>(Arrays.asList(dep.getDependencyConfigurations(conf))));
     }
 
+    @Test
     public void testFixedMdSimple() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
@@ -103,6 +110,7 @@ public class ResolveReportTest extends TestCase {
             new String[] {"*"});
     }
 
+    @Test
     public void testFixedMdTransitiveDependencies() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -126,6 +134,7 @@ public class ResolveReportTest extends TestCase {
             new String[] {"*"});
     }
 
+    @Test
     public void testFixedMdMultipleExtends() throws Exception {
         // mod6.2 has two confs default and extension
         // mod6.2 depends on mod6.1 in conf (default->extension)
@@ -158,6 +167,7 @@ public class ResolveReportTest extends TestCase {
             new String[] {"default"});
     }
 
+    @Test
     public void testFixedMdRange() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
@@ -180,6 +190,7 @@ public class ResolveReportTest extends TestCase {
             new String[] {"default"});
     }
 
+    @Test
     public void testFixedMdKeep() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
@@ -203,6 +214,7 @@ public class ResolveReportTest extends TestCase {
             "compile", new String[] {"default"});
     }
 
+    @Test
     public void testFixedMdTransitiveKeep() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org2/mod2.9/ivys/ivy-0.6.xml"),

--- a/test/java/org/apache/ivy/core/repository/RepositoryManagementEngineTest.java
+++ b/test/java/org/apache/ivy/core/repository/RepositoryManagementEngineTest.java
@@ -25,24 +25,31 @@ import org.apache.ivy.core.search.SearchEngine;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class RepositoryManagementEngineTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class RepositoryManagementEngineTest {
     private RepositoryManagementEngine repository;
 
     private TestFixture fixture;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         fixture = new TestFixture();
         IvySettings settings = fixture.getSettings();
         repository = new RepositoryManagementEngine(settings, new SearchEngine(settings),
                 new ResolveEngine(settings, new EventManager(), new SortEngine(settings)));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         fixture.clean();
     }
 
+    @Test
     public void testLoad() throws Exception {
         fixture.addMD("o1#A;1").addMD("o1#A;2").addMD("o1#A;3").addMD("o1#B;1")
                 .addMD("o1#B;2->o1#A;2").addMD("o2#C;1->{o1#B;1 o1#A;1}").init();
@@ -52,6 +59,7 @@ public class RepositoryManagementEngineTest extends TestCase {
         assertEquals(6, repository.getRevisionsNumber());
     }
 
+    @Test
     public void testOrphans() throws Exception {
         fixture.addMD("o1#A;1").addMD("o1#A;2").addMD("o1#A;3").addMD("o1#B;1")
                 .addMD("o1#B;2->o1#A;2").addMD("o2#C;1->{o1#B;1 o1#A;1}").init();

--- a/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveEngineTest.java
@@ -30,15 +30,22 @@ import org.apache.ivy.core.report.DownloadStatus;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.util.CacheCleaner;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class ResolveEngineTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ResolveEngineTest {
 
     private Ivy ivy;
 
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         cache = new File("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
@@ -47,10 +54,12 @@ public class ResolveEngineTest extends TestCase {
         ivy.configure(new File("test/repositories/ivysettings.xml"));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testInlineResolveWithNonExistingModule() throws Exception {
         ResolveEngine engine = new ResolveEngine(ivy.getSettings(), ivy.getEventManager(),
                 ivy.getSortEngine());
@@ -65,6 +74,7 @@ public class ResolveEngineTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testLocateThenDownload() throws Exception {
         ResolveEngine engine = new ResolveEngine(ivy.getSettings(), ivy.getEventManager(),
                 ivy.getSortEngine());

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -68,15 +68,20 @@ import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.MockMessageLogger;
 import org.apache.ivy.util.StringUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
 /**
  *
  */
-public class ResolveTest extends TestCase {
+public class ResolveTest {
     private Ivy ivy;
 
     private File cache;
@@ -85,11 +90,8 @@ public class ResolveTest extends TestCase {
 
     private File workDir;
 
-    public ResolveTest() {
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         cache = new File("build/cache");
         System.setProperty("ivy.cache.dir", cache.getAbsolutePath());
         createCache();
@@ -108,13 +110,14 @@ public class ResolveTest extends TestCase {
         cache.mkdirs();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
         FileUtil.forceDelete(deliverDir);
         FileUtil.forceDelete(workDir);
     }
 
+    @Test
     public void testResolveWithRetainingArtifactName() throws Exception {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setArtifactPattern(ivy.substitute("[module]/[originalname].[ext]"));
@@ -147,6 +150,7 @@ public class ResolveTest extends TestCase {
             cachePath.endsWith("mod14.1-1.1.jar"));
     }
 
+    @Test
     public void testResolveWithRetainingArtifactNameAndExtraAttributes() throws Exception {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setArtifactPattern(ivy.substitute("[module]/[originalname].[ext]"));
@@ -181,6 +185,7 @@ public class ResolveTest extends TestCase {
             cachePath.endsWith("mod14.1-1.1.jar"));
     }
 
+    @Test
     public void testArtifactOrigin() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"),
@@ -230,6 +235,7 @@ public class ResolveTest extends TestCase {
             reportOrigin.getLocation());
     }
 
+    @Test
     public void testUseOrigin() throws Exception {
         ((DefaultRepositoryCacheManager) ivy.getSettings().getDefaultRepositoryCacheManager())
                 .setUseOrigin(true);
@@ -260,6 +266,7 @@ public class ResolveTest extends TestCase {
             getArchiveFileInCache(artifact).getAbsolutePath());
     }
 
+    @Test
     public void testResolveSimple() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -279,6 +286,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveBadStatus() throws Exception {
         // mod1.4 depends on modfailure, modfailure has a bad status
         ResolveReport report = ivy.resolve(new File(
@@ -288,6 +296,7 @@ public class ResolveTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testResolveWithXmlEntities() throws Exception {
         Ivy ivy = new Ivy();
         Throwable th = null;
@@ -303,6 +312,7 @@ public class ResolveTest extends TestCase {
         assertNull(th);
     }
 
+    @Test
     public void testResolveNoRevisionInPattern() throws Exception {
         // module1 depends on latest version of module2, for which there is no revision in the
         // pattern
@@ -314,6 +324,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testResolveLatestWithNoRevisionInPattern() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/norev/ivysettings.xml"));
@@ -323,6 +334,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testResolveNoRevisionInDep() throws Exception {
         // mod1.4 depends on mod1.6, in which the ivy file has no revision
         ResolveReport report = ivy.resolve(new File(
@@ -332,6 +344,7 @@ public class ResolveTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testResolveNoRevisionNowhere() throws Exception {
         // test case for IVY-258
         // module1 depends on latest version of module2, which contains no revision in its ivy file,
@@ -348,6 +361,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testResolveWithConflictManagerPerModule() throws Exception {
         // test case for IVY-448
         // all modules from myorg
@@ -371,6 +385,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveWithConflictManagerDefinedInModule() throws Exception {
         // test case for IVY-465
         // #M1;1.0 -> #M2;1.0
@@ -389,6 +404,7 @@ public class ResolveTest extends TestCase {
         assertEquals("2.0", adrs[1].getArtifact().getId().getRevision());
     }
 
+    @Test
     public void testResolveRequiresDescriptor() throws Exception {
         // mod1.1 depends on mod1.2, mod1.2 has no ivy file
         Ivy ivy = new Ivy();
@@ -402,6 +418,7 @@ public class ResolveTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testResolveOtherConfiguration() throws Exception {
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-other.xml"),
             getResolveOptions(new String[] {"test"}));
@@ -413,6 +430,7 @@ public class ResolveTest extends TestCase {
                 .getArtifactsNumber());
     }
 
+    @Test
     public void testResolveWithSlashes() throws Exception {
         // test case for IVY-198
         // module depends on mod1.2
@@ -437,6 +455,7 @@ public class ResolveTest extends TestCase {
             "jar", "jar").exists());
     }
 
+    @Test
     public void testFromCache() throws Exception {
         // mod1.1 depends on mod1.2
 
@@ -468,6 +487,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testFromCache2() throws Exception {
         // mod1.1 depends on mod1.2
 
@@ -505,6 +525,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testDynamicFromCache() throws Exception {
         // mod1.4;1.0.2 depends on mod1.2;[1.0,2.0[
 
@@ -523,8 +544,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
         FileUtil.forceDelete(new File("build/testCache2"));
@@ -535,10 +556,11 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
     }
 
+    @Test
     public void testDynamicFromCacheWithMD() throws Exception {
         // same as above, but this time the dependency has a module descriptor
         // mod1.4;1.0.2 depends on mod1.2;[1.0,2.0[
@@ -560,8 +582,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
         FileUtil.forceDelete(new File("build/testCache2"));
@@ -572,10 +594,11 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
     }
 
+    @Test
     public void testDynamicFromCacheWithMDAfterOneTTLExpiration() throws Exception {
         // same as above, but this time we make a second resolve after ttl expiration before trying
         // to use the cached resolved information
@@ -598,8 +621,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // now we wait for ttl expiration
         Thread.sleep(700);
@@ -610,8 +633,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // now we clean the repository to simulate repo not available (network pb for instance)
         FileUtil.forceDelete(new File("build/testCache2"));
@@ -622,10 +645,11 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
     }
 
+    @Test
     public void testDynamicFromCacheWithTTL0() throws Exception {
         // mod1.4;1.0.2 depends on mod1.2;[1.0,2.0[
 
@@ -644,8 +668,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // now we update the repository
         FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), new File(
@@ -657,10 +681,11 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
     }
 
+    @Test
     public void testDynamicFromCacheWithTTL() throws Exception {
         // mod1.4;1.0.2 depends on mod1.2;[1.0,2.0[
         Ivy ivy = ivyTestCache();
@@ -690,8 +715,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // wait for org1 TTL to expire
         Thread.sleep(700);
@@ -702,10 +727,11 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
     }
 
+    @Test
     public void testRefreshDynamicFromCache() throws Exception {
         // mod1.4;1.0.2 depends on mod1.2;[1.0,2.0[
         Ivy ivy = ivyTestCache();
@@ -732,8 +758,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.5"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         // resolve again with refresh: it should find the new version
         report = ivy.resolve(new File("test/repositories/1/org1/mod1.4/ivys/ivy-1.0.2.xml"),
@@ -741,8 +767,8 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
 
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org1",
-                "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org1",
+                    "mod1.2", "1.6"))), report.getConfigurationReport("default").getModuleRevisionIds());
 
         FileUtil.forceDelete(new File("build/testCache2"));
     }
@@ -773,6 +799,7 @@ public class ResolveTest extends TestCase {
         return ivy;
     }
 
+    @Test
     public void testFromCacheOnly() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/bugIVY-56/ivysettings.xml"));
@@ -796,6 +823,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testChangeCacheLayout() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -826,6 +854,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File(cache, "mod1.2.jar").exists());
     }
 
+    @Test
     public void testChangeCacheLayout2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
@@ -852,7 +881,7 @@ public class ResolveTest extends TestCase {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance("org1", "mod1.1", "1.0");
         assertEquals(mrid, md.getModuleRevisionId());
 
-        assertTrue(getResolvedIvyFileInCache(ivy, mrid).toString().indexOf("workspace") != -1);
+        assertTrue(getResolvedIvyFileInCache(ivy, mrid).toString().contains("workspace"));
         assertTrue(getResolvedIvyFileInCache(ivy, mrid).exists());
         assertTrue(getConfigurationResolveReportInCache(ivy, report.getResolveId(), "default")
                 .exists());
@@ -866,6 +895,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File(cache, "repository/mod1.2.jar").exists());
     }
 
+    @Test
     public void testMultipleCache() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/ivysettings-multicache.xml"));
@@ -898,6 +928,7 @@ public class ResolveTest extends TestCase {
                 .getArchiveFileInCache(depArtifact).getCanonicalFile());
     }
 
+    @Test
     public void testForceLocal() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         // a local build for mod1.2 is available
@@ -926,6 +957,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testForceLocal2() throws Exception {
         // mod2.3 -> mod2.1;[0.0,0.4] -> mod1.1 -> mod1.2
         // a local build for mod2.1 and mod1.2 is available
@@ -961,6 +993,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testForceLocal3() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         // a local build for mod1.2 is available
@@ -993,6 +1026,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveExtends() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
         ResolveReport report = ivy.resolve(new File(
@@ -1012,6 +1046,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveExtended() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
         ResolveReport report = ivy.resolve(new File(
@@ -1031,6 +1066,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveExtendedAndExtends() throws Exception {
         // mod6.1 depends on mod1.2 2.0 in conf default, and conf extension extends default
         ResolveReport report = ivy.resolve(new File(
@@ -1055,6 +1091,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMultipleExtends() throws Exception {
         // mod6.2 has two confs default and extension
         // mod6.2 depends on mod6.1 in conf (default->extension)
@@ -1089,6 +1126,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMultipleExtendsAndConfs() throws Exception {
         // Test case for IVY-240
         //
@@ -1124,6 +1162,7 @@ public class ResolveTest extends TestCase {
         assertContainsArtifact("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar", crr);
     }
 
+    @Test
     public void testResolveMultipleConfsWithLatest() throws Exception {
         // Test case for IVY-188
         //
@@ -1150,6 +1189,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMultipleConfsWithConflicts() throws Exception {
         // Test case for IVY-173
         //
@@ -1194,6 +1234,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMultipleExtends2() throws Exception {
         // same as before, except that mod6.2 depends on mod1.2 2.1 extension->default
         // so mod1.2 2.0 should be evicted in conf extension
@@ -1237,6 +1278,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveSeveralDefaultWithArtifacts() throws Exception {
         // test case for IVY-261
         // mod1.6 depends on
@@ -1254,6 +1296,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveConflictsWithArtifacts() throws Exception {
         // test case for IVY-537
         // #mod2.6;0.12 -> {#mod1.6;1.0.4 #mod2.5;0.6.2 }
@@ -1273,6 +1316,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveSeveralDefaultWithArtifactsAndConfs() throws Exception {
         // test case for IVY-283
         Ivy ivy = new Ivy();
@@ -1295,6 +1339,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveSeveralDefaultWithArtifactsAndConfs2() throws Exception {
         // second test case for IVY-283
         Ivy ivy = new Ivy();
@@ -1330,6 +1375,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveWithStartPublicConf() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1353,6 +1399,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.3", "3.0", "mod1.3", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithPrivateConf() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1375,6 +1422,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.3", "3.0", "mod1.3", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveDefaultWithArtifactsConf1() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1398,6 +1446,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.3", "3.0", "mod1.3", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveDefaultWithArtifactsConf2() throws Exception {
         // mod2.2 depends on mod1.3 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1420,6 +1469,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.3", "3.0", "mod1.3", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveDefaultWithArtifactsAndConfMapping() throws Exception {
         // mod2.2 depends on mod1.3 and specify its artifacts and a conf mapping
         ResolveReport report = ivy.resolve(new File(
@@ -1443,6 +1493,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.3", "3.0", "mod1.3", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithIncludeArtifactsConf1() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts in myconf1
         ResolveReport report = ivy.resolve(new File(
@@ -1463,6 +1514,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithIncludeArtifactsConf2() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts in myconf1
         ResolveReport report = ivy.resolve(new File(
@@ -1483,6 +1535,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithIncludeArtifactsWithoutConf() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1503,6 +1556,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithIncludeArtifactsTransitive() throws Exception {
         // test case for IVY-541
         // mod2.6 depends on mod2.3 and mod2.1
@@ -1518,6 +1572,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithExcludesArtifacts() throws Exception {
         // mod2.3 depends on mod2.1 and selects its artifacts
         ResolveReport report = ivy.resolve(new File(
@@ -1538,6 +1593,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithExcludesArtifacts2() throws Exception {
         // mod2.3 depends on mod2.1 and badly excludes artifacts with incorrect matcher
         ResolveReport report = ivy.resolve(new File(
@@ -1558,6 +1614,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithExcludesArtifacts3() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with exact matcher
         ResolveReport report = ivy.resolve(new File(
@@ -1578,6 +1635,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithExcludesArtifacts4() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with regexp matcher
         ResolveReport report = ivy.resolve(new File(
@@ -1598,6 +1656,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithExcludesArtifacts5() throws Exception {
         // mod2.3 depends on mod2.1 and excludes artifacts with glob matcher
         ResolveReport report = ivy.resolve(new File(
@@ -1618,6 +1677,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org2", "mod2.1", "0.3", "mod2.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveDependencies() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -1641,6 +1701,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveDependenciesWithOverride() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -1667,6 +1728,7 @@ public class ResolveTest extends TestCase {
     /**
      * Testcase for IVY-1131.
      */
+    @Test
     public void testResolveTransitiveDependenciesWithOverrideAndDynamicResolveMode()
             throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
@@ -1692,6 +1754,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "1.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveDisabled() throws Exception {
         // mod2.1 depends on mod1.1 which depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -1715,6 +1778,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testDependenciesOrder() throws Exception {
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-225.xml"),
             getResolveOptions(new String[] {"default"}));
@@ -1735,6 +1799,7 @@ public class ResolveTest extends TestCase {
             mod32Index < mod51Index);
     }
 
+    @Test
     public void testDisableTransitivityPerConfiguration() throws Exception {
         // mod2.1 (compile, runtime) depends on mod1.1 which depends on mod1.2
         // compile conf is not transitive
@@ -1770,6 +1835,7 @@ public class ResolveTest extends TestCase {
         assertEquals(2, r.getConfigurationReport("runtime").getArtifactsNumber());
     }
 
+    @Test
     public void testDisableTransitivityPerConfiguration2() throws Exception {
         // mod2.1 (compile, runtime) depends on mod1.1 which depends on mod1.2
         // compile conf is not transitive
@@ -1806,6 +1872,7 @@ public class ResolveTest extends TestCase {
         assertEquals(2, r.getConfigurationReport("runtime").getArtifactsNumber());
     }
 
+    @Test
     public void testDisableTransitivityPerConfiguration3() throws Exception {
         // mod2.1 (compile, runtime) depends on mod1.1 which depends on mod1.2
         // compile conf is not transitive
@@ -1842,6 +1909,7 @@ public class ResolveTest extends TestCase {
         assertEquals(2, r.getConfigurationReport("runtime").getArtifactsNumber());
     }
 
+    @Test
     public void testDisableTransitivityPerConfiguration4() throws Exception {
         // mod2.2 (A,B,compile) depends on mod 2.1 (A->runtime;B->compile)
         // compile is not transitive and extends A and B
@@ -1870,10 +1938,11 @@ public class ResolveTest extends TestCase {
 
         // here we should get only mod2.1 cause compile is not transitive
         assertEquals(
-            new HashSet<ModuleRevisionId>(Arrays.asList(ModuleRevisionId.newInstance("org2",
-                "mod2.1", "0.3.2"))), r.getConfigurationReport("compile").getModuleRevisionIds());
+            new HashSet<ModuleRevisionId>(Collections.singletonList(ModuleRevisionId.newInstance("org2",
+                    "mod2.1", "0.3.2"))), r.getConfigurationReport("compile").getModuleRevisionIds());
     }
 
+    @Test
     public void testDisableTransitivityPerConfiguration5() throws Exception {
         // mod2.2 (A,B,compile) depends on
         // mod 2.1 (A->runtime;B->compile)
@@ -1910,6 +1979,7 @@ public class ResolveTest extends TestCase {
             r.getConfigurationReport("compile").getModuleRevisionIds());
     }
 
+    @Test
     public void testResolveDiamond() throws Exception {
         // mod4.1 depends on
         // - mod1.1 which depends on mod1.2
@@ -1938,6 +2008,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org3", "mod3.1", "1.0", "mod3.1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveConflict() throws Exception {
         // mod4.1 v 4.1 depends on
         // - mod1.1 v 1.0 which depends on mod1.2 v 2.0
@@ -1991,6 +2062,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveConflict2() throws Exception {
         // mod4.1 v 4.14 depends on
         // - mod1.1 v 1.0 which depends on mod1.2 v 2.0
@@ -2039,6 +2111,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveConflict3() throws Exception {
         // test case for IVY-264
         // a depends on x latest, y latest, z latest
@@ -2067,6 +2140,7 @@ public class ResolveTest extends TestCase {
             "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMergeTransitiveAfterConflict() throws Exception {
         // mod20.4 -> mod20.3;1.0 mod20.2;1.0
         // mod20.3;1.0 -> mod20.1;1.0
@@ -2091,6 +2165,7 @@ public class ResolveTest extends TestCase {
     /**
      * Test IVY-618.
      */
+    @Test
     public void testResolveConflictFromPoms() throws Exception {
         ResolveReport report = ivy.resolve(new File("test/repositories/2/mod17.1/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -2098,6 +2173,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testTransitiveEviction() throws Exception {
         // mod7.3 depends on mod7.2 v1.0 and on mod7.1 v2.0
         // mod7.2 v1.0 depends on mod7.1 v1.0 (which then should be evicted)
@@ -2127,6 +2203,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testTransitiveEviction2() throws Exception {
         // IVY-199
         // mod4.1 v 4.13 depends on
@@ -2145,6 +2222,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testTransitiveEvictionWithExtendingConf() throws Exception {
         // IVY-590
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-590.xml"),
@@ -2162,13 +2240,14 @@ public class ResolveTest extends TestCase {
         assertNotNull(evicted);
 
         Collection<ModuleRevisionId> evictedModules = new ArrayList<ModuleRevisionId>();
-        for (int i = 0; i < evicted.length; i++) {
-            evictedModules.add(evicted[i].getId());
+        for (IvyNode anEvicted : evicted) {
+            evictedModules.add(anEvicted.getId());
         }
 
         assertTrue(evictedModules.contains(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0")));
     }
 
+    @Test
     public void testResolveConflictInConf() throws Exception {
         // conflicts in separate confs are not conflicts
 
@@ -2199,6 +2278,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testEvictWithConf() throws Exception {
         // bug 105 - test #1
 
@@ -2238,6 +2318,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testEvictWithConf2() throws Exception {
         // same as preceding one but with inverse order, so that
         // eviction is done after download
@@ -2277,6 +2358,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testEvictWithConf3() throws Exception {
         // same as first one but the conf requested in evicted module is no longer present in
         // selected revision
@@ -2304,6 +2386,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testFailWithMissingConf() throws Exception {
         // test case for IVY-861
 
@@ -2312,10 +2395,10 @@ public class ResolveTest extends TestCase {
         ResolveReport report = ivy.resolve(new File("test/repositories/2/mod6.1/ivy-1.5.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("missing conf should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "'unknown'") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("'unknown'"));
     }
 
+    @Test
     public void testEvictWithConfInMultiConf() throws Exception {
         // same as preceding ones but the conflict appears in several root confs
         // bug 105 - test #3
@@ -2365,6 +2448,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testEvictWithConfInMultiConf2() throws Exception {
         // same as preceding one but the conflict appears in a root conf and not in another
         // which should keep the evicted
@@ -2419,6 +2503,7 @@ public class ResolveTest extends TestCase {
             crr.getDownloadReports(ModuleRevisionId.newInstance("org5", "mod5.1", "4.2")).length);
     }
 
+    @Test
     public void testMultipleEviction() throws Exception {
 
         ResolveReport report = ivy.resolve(new File(
@@ -2427,6 +2512,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testResolveForce() throws Exception {
         // mod4.1 v 4.2 depends on
         // - mod1.2 v 2.0 and forces it
@@ -2455,6 +2541,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceAfterConflictSolved() throws Exception {
         // IVY-193
         // mod4.1 v 4.9 depends on
@@ -2479,6 +2566,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceAfterDependencyExist() throws Exception {
         // IVY-193
         // mod4.1 v 4.10 depends on
@@ -2496,6 +2584,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceInDepOnly() throws Exception {
         // IVY-193
         // mod4.1 v 4.11 depends on
@@ -2517,6 +2606,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "1.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceInDepOnly2() throws Exception {
         // IVY-193
         // mod4.1 v 4.12 depends on
@@ -2538,6 +2628,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithDynamicRevisionsAndArtifactLockStrategy() throws Exception {
         // mod4.1 v 4.5 depends on
         // - mod1.2 v 1+ and forces it
@@ -2554,15 +2645,16 @@ public class ResolveTest extends TestCase {
 
     private void findLockFiles(File dir, List<File> result) {
         File[] files = dir.listFiles();
-        for (int i = 0; i < files.length; i++) {
-            if (files[i].isDirectory()) {
-                findLockFiles(files[i], result);
-            } else if (files[i].getName().endsWith(".lck")) {
-                result.add(files[i]);
+        for (File file : files) {
+            if (file.isDirectory()) {
+                findLockFiles(file, result);
+            } else if (file.getName().endsWith(".lck")) {
+                result.add(file);
             }
         }
     }
 
+    @Test
     public void testResolveForceWithDynamicRevisions() throws Exception {
         // mod4.1 v 4.5 depends on
         // - mod1.2 v 1+ and forces it
@@ -2591,6 +2683,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceWithDynamicRevisionsAndSeveralConfs() throws Exception {
         // mod4.1 v 4.6 (conf compile, runtime extends compile, test extends runtime) depends on
         // - mod1.2 v 1+ and forces it in conf compile
@@ -2619,6 +2712,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceWithDynamicRevisionsAndSeveralConfs2() throws Exception {
         // mod4.1 v 4.7 (conf compile, test extends compile) depends on
         // - mod1.2 v 1+ and forces it in conf compile
@@ -2649,6 +2743,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveForceWithDynamicRevisionsAndCyclicDependencies() throws Exception {
         // IVY-182
         // * has no revision
@@ -2681,6 +2776,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveContradictoryConflictResolution() throws Exception {
         // mod10.1 v 1.0 depends on
         // - mod1.2 v 2.0 and forces it
@@ -2708,6 +2804,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveContradictoryConflictResolution2() throws Exception {
         // BUG IVY-130 : only mod1.2 v2.0 should be resolved and not v2.1 (because of force)
         // mod10.1 v 1.1 depends on
@@ -2729,6 +2826,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.1", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveContradictoryConflictResolution3() throws Exception {
         // mod 1.2 v2.0 should be selected (despite conflict manager in 4.1, because of force in
         // 10.1)
@@ -2747,6 +2845,7 @@ public class ResolveTest extends TestCase {
             evicted[0].getResolvedId());
     }
 
+    @Test
     public void testExtends() throws Exception {
         // mod 5.2 depends on mod5.1 conf B
         // mod5.1 conf B publishes art51B
@@ -2769,6 +2868,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51A", "jar", "jar").exists());
     }
 
+    @Test
     public void testMultiConfs() throws Exception {
         // mod 5.2 depends on mod5.1 conf B in its conf B and conf A in its conf A
         // mod5.1 conf B publishes art51B
@@ -2810,6 +2910,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.1", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testThisConfiguration() throws Exception {
         ResolveReport report = ivy.resolve(new File("test/repositories/2/mod14.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"compile"}));
@@ -2859,6 +2960,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testLatest() throws Exception {
         // mod1.4 depends on latest mod1.2
         ResolveReport report = ivy.resolve(new File(
@@ -2899,6 +3001,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testLatestMultiple() throws Exception {
         // mod1.5 depends on
         // latest mod1.4, which depends on mod1.2 2.2
@@ -2917,6 +3020,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testLatestWhenReleased() throws Exception {
         // The test verify that latest.integration dependencies can be resolved with released
         // version also.
@@ -2929,6 +3033,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testLatestWithMultiplePatterns() throws Exception {
         // The test verify that latest.integration dependencies can be resolved
         // when using a resolver with multiple patterns, when only the first pattern
@@ -2947,6 +3052,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org6", "mod6.2", "2.0", "mod6.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveModeDynamic1() throws Exception {
         // mod1.1;1.0.1 -> mod1.2;2.0|latest.integration
         ResolveReport report = ivy.resolve(
@@ -2964,6 +3070,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveModeDynamic2() throws Exception {
         // same as ResolveModeDynamic1, but resolve mode is set in settings
         Map<String, String> attributes = new HashMap<String, String>();
@@ -2985,6 +3092,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.2", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveModeDynamicWithBranch1() throws Exception {
         // bar1;5 -> foo1#branch1|;2|[0,4]
         Ivy ivy = new Ivy();
@@ -2999,6 +3107,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#trunk;3", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveModeDynamicWithBranch2() throws Exception {
         // bar1;5 -> foo1#trunk|branch1;3|[0,4]
         Ivy ivy = new Ivy();
@@ -3013,8 +3122,9 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#branch1;4", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveModeDefaultOverrideSettings() throws Exception {
-        // same as ResolveModeDynamic2, but resolve mode is set in settings, and overriden when
+        // same as ResolveModeDynamic2, but resolve mode is set in settings, and overridden when
         // calling resolve
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("organisation", "org1");
@@ -3036,6 +3146,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testVersionRange1() throws Exception {
         // mod 1.4 depends on mod1.2 [1.0,2.0[
         ResolveReport report = ivy.resolve(new File(
@@ -3053,6 +3164,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getIvyFileInCache(depId).exists());
     }
 
+    @Test
     public void testVersionRange2() throws Exception {
         // mod 1.4 depends on mod1.2 [1.5,2.0[
         Ivy ivy = new Ivy();
@@ -3063,6 +3175,7 @@ public class ResolveTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testLatestMilestone() throws Exception {
         // mod9.2 depends on latest.milestone of mod6.4
         ResolveReport report = ivy.resolve(new File(
@@ -3080,6 +3193,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getIvyFileInCache(depId).exists());
     }
 
+    @Test
     public void testLatestMilestone2() throws Exception {
         // mod9.2 depends on latest.milestone of mod6.2, but there is no milestone
         // test case for IVY-318
@@ -3096,6 +3210,7 @@ public class ResolveTest extends TestCase {
         assertEquals(0, crr.getArtifactsNumber());
     }
 
+    @Test
     public void testIVY56() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/bugIVY-56/ivysettings.xml"));
@@ -3109,6 +3224,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testIVY214() throws Exception {
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-214.xml"),
             getResolveOptions(new String[] {"compile"}));
@@ -3120,6 +3236,7 @@ public class ResolveTest extends TestCase {
                 .getArtifactsNumber());
     }
 
+    @Test
     public void testIVY218() throws Exception {
         ResolveReport report = ivy.resolve(ResolveTest.class.getResource("ivy-218.xml"),
             getResolveOptions(new String[] {"test"}));
@@ -3131,6 +3248,7 @@ public class ResolveTest extends TestCase {
                 .getArtifactsNumber());
     }
 
+    @Test
     public void testIVY729() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-729/ivysettings.xml"));
@@ -3140,6 +3258,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testCircular() throws Exception {
         // mod6.3 depends on mod6.2, which itself depends on mod6.3
 
@@ -3171,6 +3290,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testCircular2() throws Exception {
         // mod 9.1 (no revision) depends on mod9.2, which depends on mod9.1 2.+
 
@@ -3190,6 +3310,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testCircular3() throws Exception {
         // test case for IVY-400
         // mod6.3 depends on mod6.2, which itself depends on mod6.3,
@@ -3229,6 +3350,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testRegularCircular() throws Exception {
         // mod11.1 depends on mod11.2 but excludes itself
         // mod11.2 depends on mod11.1
@@ -3251,6 +3373,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveDualChain() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(ResolveTest.class.getResource("dualchainresolverconf.xml"));
@@ -3280,6 +3403,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File("build/cache/xerces/xerces/jars/xercesImpl-2.6.2.jar").exists());
     }
 
+    @Test
     public void testBug148() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/bug148/ivysettings.xml"));
@@ -3295,6 +3419,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testBug148b() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/bug148/ivysettings.xml"));
@@ -3310,6 +3435,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testIVY1178() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1178/ivysettings.xml"));
@@ -3336,6 +3462,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("myorg", "modE", "1.1", "modE", "jar", "jar").exists());
     }
 
+    @Test
     public void testIVY1236() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1236/ivysettings.xml"));
@@ -3353,6 +3480,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("myorg", "modB", "1.0", "modB-A", "jar", "jar").exists());
     }
 
+    @Test
     public void testIVY1233() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1233/ivysettings.xml"));
@@ -3368,6 +3496,7 @@ public class ResolveTest extends TestCase {
         assertTrue(modRevIds.contains(ModuleRevisionId.newInstance("test", "c", "3.0")));
     }
 
+    @Test
     public void testIVY1333() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1333/ivysettings.xml"));
@@ -3387,6 +3516,7 @@ public class ResolveTest extends TestCase {
             "1.0.0.m4", extra)));
     }
 
+    @Test
     public void testIVY1347() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1347/ivysettings.xml"));
@@ -3406,6 +3536,7 @@ public class ResolveTest extends TestCase {
         assertEquals(ModuleRevisionId.newInstance("foo", "parent", "1.0"), parent);
     }
 
+    @Test
     public void testIVY999() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-999/ivysettings.xml"));
@@ -3420,6 +3551,7 @@ public class ResolveTest extends TestCase {
         assertFalse(modRevIds.contains(ModuleRevisionId.newInstance("junit", "junit", "3.8")));
     }
 
+    @Test
     public void testIVY1366() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-1366/ivysettings.xml"));
@@ -3435,6 +3567,7 @@ public class ResolveTest extends TestCase {
         assertEquals("test#b;1!b.jar", artifacts.get(2).toString());
     }
 
+    @Test
     public void testBadFiles() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/badfile/ivysettings.xml"));
@@ -3443,34 +3576,30 @@ public class ResolveTest extends TestCase {
             new File("test/repositories/badfile/ivys/ivy-badorg.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad org should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "'badorg'") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("'badorg'"));
 
         report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badmodule.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad module should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "'badmodule'") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("'badmodule'"));
 
         report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badbranch.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad branch should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "'badbranch'") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("'badbranch'"));
 
         report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badrevision.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad revision should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "'badrevision'") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("'badrevision'"));
 
         report = ivy.resolve(new File("test/repositories/badfile/ivys/ivy-badxml.xml"),
             getResolveOptions(new String[] {"*"}));
         assertTrue("bad xml should have raised an error in report", report.hasError());
-        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").indexOf(
-            "badatt") != -1);
+        assertTrue(StringUtils.join(report.getAllProblemMessages().toArray(), "\n").contains("badatt"));
     }
 
+    @Test
     public void testTransitiveSetting() throws Exception {
         // mod2.4 depends on mod1.1 with transitive set to false
         // mod1.1 depends on mod1.2, which should not be resolved because of the transitive setting
@@ -3495,6 +3624,7 @@ public class ResolveTest extends TestCase {
         assertTrue(!getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testTransitiveSetting2() throws Exception {
         // test case for IVY-105
         // mod2.7 depends on mod1.1 and mod2.4
@@ -3515,6 +3645,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolverDirectlyUsingCache() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(ResolveTest.class.getResource("badcacheconf.xml"));
@@ -3542,6 +3673,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testVisibility1() throws Exception {
         ivy.resolve(new File("test/repositories/2/mod8.2/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -3550,6 +3682,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testVisibility2() throws Exception {
         ivy.resolve(new File("test/repositories/2/mod8.3/ivy-1.0.xml"),
             getResolveOptions(new String[] {"private"}));
@@ -3559,6 +3692,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org8", "mod8.1", "1.0", "a", "txt", "txt").exists());
     }
 
+    @Test
     public void testVisibility3() throws Exception {
         ivy.resolve(new File("test/repositories/2/mod8.4/ivy-1.0.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -3568,6 +3702,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org8", "mod8.1", "1.0", "a", "txt", "txt").exists());
     }
 
+    @Test
     public void testVisibility4() throws Exception {
         ivy.resolve(new File("test/repositories/2/mod8.4/ivy-1.1.xml"),
             getResolveOptions(new String[] {"*"}));
@@ -3582,6 +3717,7 @@ public class ResolveTest extends TestCase {
     // about configuration mapping and eviction
     // /////////////////////////////////////////////////////////
 
+    @Test
     public void testConfigurationMapping1() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3598,6 +3734,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.2", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3614,6 +3751,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping3() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3630,6 +3768,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping4() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3646,6 +3785,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping5() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3662,6 +3802,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping6() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3678,6 +3819,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testConfigurationMapping7() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/IVY-84/ivysettings.xml"));
@@ -3694,6 +3836,7 @@ public class ResolveTest extends TestCase {
         assertDoesntContainArtifact("test", "c", "1.0.1", "c-bt", "txt", "txt", conf);
     }
 
+    @Test
     public void testIVY97() throws Exception {
         // mod9.2 depends on mod9.1 and mod1.2
         // mod9.1 depends on mod1.2
@@ -3718,6 +3861,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMultipleSameDependency() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/multiple-same-deps/mod1/ivys/ivy-1.0.xml"),
@@ -3746,6 +3890,7 @@ public class ResolveTest extends TestCase {
             ModuleRevisionId.parse("multiple-same-deps#mod33;1.0"));
     }
 
+    @Test
     public void testResolveTransitiveExcludesSimple() throws Exception {
         // mod2.5 depends on mod2.3 and excludes one artifact from mod2.1
         // mod2.3 depends on mod2.1
@@ -3770,6 +3915,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveExcludesDiamond1() throws Exception {
         // mod2.6 depends on mod2.3 and mod2.5
         // mod2.3 depends on mod2.1 and excludes art21B
@@ -3781,6 +3927,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveExcludesDiamond2() throws Exception {
         // mod2.6 depends on mod2.3 and mod2.5
         // mod2.3 depends on mod2.1 and excludes art21B
@@ -3792,6 +3939,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveExcludesDiamond3() throws Exception {
         // mod2.6 depends on mod2.3 and mod2.5 and on mod2.1 for which it excludes art21A
         // mod2.3 depends on mod2.1 and excludes art21B
@@ -3803,6 +3951,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveTransitiveExcludes2() throws Exception {
         // mod2.6 depends on mod2.3 for which it excludes art21A
         // mod2.3 depends on mod2.1 and excludes art21B
@@ -3817,6 +3966,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org2", "mod2.1", "0.3", "art21B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveExcludesModule() throws Exception {
         // mod2.6 depends on mod2.1 and excludes mod1.1
         // mod2.1 depends on mod1.1 which depends on mod1.2
@@ -3835,6 +3985,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveExcludesModuleWide() throws Exception {
         // mod2.6 depends on mod2.1 and excludes mod1.1 module wide
         // mod2.1 depends on mod1.1 which depends on mod1.2
@@ -3853,6 +4004,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveExcludesConf() throws Exception {
         // mod2.6 depends on mod2.3 in conf default and mod2.5 in conf exclude
         // mod2.5 depends on mod2.3
@@ -3868,6 +4020,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveExcludesConf2() throws Exception {
         // same as testResolveExcludesConf
         ResolveReport report = ivy.resolve(new File(
@@ -3881,6 +4034,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveExcludesConf3() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/org2/mod2.6/ivys/ivy-0.14.xml"),
@@ -3893,6 +4047,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveExceptConfiguration() throws Exception {
         // mod10.2 depends on mod5.1 conf *, !A
         ivy.resolve(new File("test/repositories/2/mod10.2/ivy-2.0.xml"),
@@ -3902,6 +4057,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.1", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveIntersectConfiguration1() throws Exception {
         // mod5.2;3.0 -> mod5.1;4.4 (*->@)
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
@@ -3916,6 +4072,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.4", "art51B", "so", "so").exists());
     }
 
+    @Test
     public void testResolveIntersectConfiguration2() throws Exception {
         // mod5.2;3.0 -> mod5.1;4.4 (*->@)
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
@@ -3936,6 +4093,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.5", "art21AB", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveIntersectConfiguration3() throws Exception {
         // mod5.2;3.0 -> mod5.1;4.4 (*->@)
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
@@ -3957,6 +4115,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org2", "mod2.1", "0.5", "art21AB", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveIntersectConfiguration4() throws Exception {
         // mod5.2;3.0 -> mod5.1;4.4 (*->@)
         // mod5.1;4.4 -> mod1.2;2.0 (B,xplatform->default)
@@ -3988,6 +4147,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testConfigurationGroups() throws Exception {
         // mod5.2;3.1 -> mod5.1;4.5 (*->@)
         // mod5.1;4.5 -> mod1.2;2.0 (B,*[axis=platform]->default)
@@ -4019,6 +4179,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveFallbackConfiguration() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(default)
         ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.0.xml"),
@@ -4027,6 +4188,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51A", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveFallbackConfiguration2() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(*)
         ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.1.xml"),
@@ -4036,6 +4198,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveFallbackConfiguration3() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime(*),compile(*)
         ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.2.xml"),
@@ -4045,6 +4208,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveFallbackConfiguration4() throws Exception {
         // mod10.2 depends on mod5.1 conf runtime()
         ResolveReport report = ivy.resolve(new File("test/repositories/2/mod10.2/ivy-1.3.xml"),
@@ -4055,6 +4219,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org5", "mod5.1", "4.0", "art51B", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2() throws Exception {
         // test3 depends on test2 which depends on test
         Ivy ivy = new Ivy();
@@ -4082,6 +4247,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testResolveMaven2WithConflict() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4106,6 +4272,7 @@ public class ResolveTest extends TestCase {
             getArtifact("org.apache", "test", "1.1", "test", "jar", "jar"));
     }
 
+    @Test
     public void testResolveMaven2WithConflict2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4121,6 +4288,7 @@ public class ResolveTest extends TestCase {
             getArtifact("org.apache", "test", "1.2", "test", "jar", "jar"));
     }
 
+    @Test
     public void testResolveMaven2RelocationOfGroupId() throws Exception {
         // Same as testResolveMaven2 but with a relocated module pointing to the module
         // used in testResolveMaven2.
@@ -4148,6 +4316,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveMaven2FullRelocation() throws Exception {
         // Same as testResolveMaven2 but with a relocated module pointing to the module
         // used in testResolveMaven2.
@@ -4175,6 +4344,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveVesionRelocationChainedWithGroupRelocation() throws Exception {
         ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4200,6 +4370,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveTransitivelyToRelocatedPom() throws Exception {
         ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4226,6 +4397,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveTransitivelyToPomRelocatedToNewVersion() throws Exception {
         ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4252,6 +4424,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveMaven2Classifiers() throws Exception {
         // test case for IVY-418
         // test-classifier depends on test-classified with classifier asl
@@ -4279,6 +4452,7 @@ public class ResolveTest extends TestCase {
         , "1.0", "test-classified", "jar", "jar", cmap).exists());
     }
 
+    @Test
     public void testResolveMaven2ClassifiersWithoutPOM() throws Exception {
         // test case for IVY-1041
         // test-classifier depends on test-classified with classifier asl
@@ -4306,6 +4480,7 @@ public class ResolveTest extends TestCase {
         , "2.0", "test-classified", "jar", "jar", cmap).exists());
     }
 
+    @Test
     public void testResolveMaven2GetSources() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4327,6 +4502,7 @@ public class ResolveTest extends TestCase {
         assertTrue(jarFileInCache.length() != sourceFileInCache.length());
     }
 
+    @Test
     public void testResolveMaven2GetSourcesWithSrcClassifier() throws Exception {
         // IVY-1138
         Ivy ivy = new Ivy();
@@ -4347,6 +4523,7 @@ public class ResolveTest extends TestCase {
         assertTrue(jarFileInCache.length() != sourceFileInCache.length());
     }
 
+    @Test
     public void testResolveMaven2GetSourcesAndJavadocAuto() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4373,6 +4550,7 @@ public class ResolveTest extends TestCase {
         assertTrue(jarFileInCache.length() != javadocFileInCache.length());
     }
 
+    @Test
     public void testResolveMaven2WithVersionProperty() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml"));
@@ -4394,6 +4572,7 @@ public class ResolveTest extends TestCase {
             "test-classifier", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2ParentPomChainResolver() throws Exception {
         // test has a dependency on test2 but there is no version listed. test has a parent of
         // parent(2.0)
@@ -4454,6 +4633,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2ParentPomWithNamespace() throws Exception {
         // Cfr IVY-1186
         Ivy ivy = new Ivy();
@@ -4503,12 +4683,13 @@ public class ResolveTest extends TestCase {
             "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2ParentPomDualResolver() throws Exception {
         // test has a dependency on test2 but there is no version listed. test has a parent of
         // parent(2.0)
         // then parent2. Both parents have a dependencyManagement element for test2, and each list
         // the version as
-        // ${pom.version}. The parent version should take precidence over parent2,
+        // ${pom.version}. The parent version should take precedence over parent2,
         // so the version should be test2 version 2.0. Test3 is also a dependency of parent, and
         // it's version is listed
         // as 1.0 in parent2. (dependencies inherited from parent comes after)
@@ -4565,12 +4746,13 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2ParentPomDependencyManagementOverrideTransitiveVersion()
             throws Exception {
         // test;2.0 has a dependency on test2;3.0.
         // test has a parent of parent(2.0) then parent2.
         // Both parents have a dependencyManagement element for test2, and each list the version as
-        // ${pom.version}. The version for test2 in test should take precedance,
+        // ${pom.version}. The version for test2 in test should take precedence,
         // so the version should be test2 version 3.0.
         // test2;3.0 -> test4;2.0, but parent has a dependencyManagement section specifying
         // test4;1.0.
@@ -4610,6 +4792,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2ParentPomDependencyManagementWithImport() throws Exception {
         // IVY-1376
         Ivy ivy = new Ivy();
@@ -4637,6 +4820,7 @@ public class ResolveTest extends TestCase {
             "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2Snapshot1() throws Exception {
         // test case for IVY-501
         // here we test maven SNAPSHOT versions handling,
@@ -4657,6 +4841,7 @@ public class ResolveTest extends TestCase {
             "test-SNAPSHOT1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2Snapshot1AsLatestIntegration() throws Exception {
         // test case for IVY-1036
         // here we test maven SNAPSHOT versions handling,
@@ -4678,6 +4863,7 @@ public class ResolveTest extends TestCase {
             "test-SNAPSHOT1", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2Snapshot2() throws Exception {
         // test case for IVY-501
         // here we test maven SNAPSHOT versions handling,
@@ -4698,6 +4884,7 @@ public class ResolveTest extends TestCase {
             "test-SNAPSHOT2", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveMaven2Snapshot2AsLatestIntegration() throws Exception {
         // test case for IVY-1036
         // here we test maven SNAPSHOT versions handling,
@@ -4719,6 +4906,7 @@ public class ResolveTest extends TestCase {
             "test-SNAPSHOT2", "jar", "jar").exists());
     }
 
+    @Test
     public void testNamespaceMapping() throws Exception {
         // the dependency is in another namespace
         Ivy ivy = new Ivy();
@@ -4747,6 +4935,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testNamespaceMapping2() throws Exception {
         // the dependency is in another namespace and has itself a dependency on a module available
         // in the same namespace
@@ -4774,6 +4963,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testNamespaceMapping3() throws Exception {
         // same as 2 but with poms
         Ivy ivy = new Ivy();
@@ -4800,6 +4990,7 @@ public class ResolveTest extends TestCase {
                 .exists());
     }
 
+    @Test
     public void testNamespaceMapping4() throws Exception {
         // same as 2 but with incorrect dependency asked: the first ivy file asks for a dependency
         // in the resolver namespace and not the system one: this should fail
@@ -4816,6 +5007,7 @@ public class ResolveTest extends TestCase {
         assertTrue(report.hasError());
     }
 
+    @Test
     public void testNamespaceMapping5() throws Exception {
         // Verifies that mapping version numbers works
         Ivy ivy = new Ivy();
@@ -4827,6 +5019,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getIvyFileInCache(mrid).exists());
     }
 
+    @Test
     public void testIVY151() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/multirevisions/ivysettings.xml"));
@@ -4839,6 +5032,7 @@ public class ResolveTest extends TestCase {
             report.getUnresolvedDependencies().length);
     }
 
+    @Test
     public void testCheckRevision() throws Exception {
         // mod12.2 depends on mod12.1 1.0 which depends on mod1.2
         // mod12.1 doesn't have revision in its ivy file
@@ -4857,6 +5051,7 @@ public class ResolveTest extends TestCase {
         assertFalse(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testTrustRevision() throws Exception {
         // mod12.2 depends on mod12.1 1.0 which depends on mod1.2
         // mod12.1 doesn't have revision in its ivy file
@@ -4878,6 +5073,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache("org1", "mod1.2", "2.0", "mod1.2", "jar", "jar").exists());
     }
 
+    @Test
     public void testTransitiveConfMapping() throws Exception {
         // IVY-168
         // mod13.3 depends on mod13.2 which depends on mod13.1
@@ -4896,6 +5092,7 @@ public class ResolveTest extends TestCase {
         assertEquals(0, report.getConfigurationReport("j2ee").getArtifactsNumber());
     }
 
+    @Test
     public void testExtraAttributes() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
@@ -4923,6 +5120,7 @@ public class ResolveTest extends TestCase {
         assertEquals("another", resolveModRevId.getExtraAttribute("eatt2"));
     }
 
+    @Test
     public void testExtraAttributes2() throws Exception {
         // test case for IVY-773
         Ivy ivy = new Ivy();
@@ -4944,6 +5142,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File(cache, "apache/module2/task2/1976/module2-linux.jar").exists());
     }
 
+    @Test
     public void testExtraAttributes3() throws Exception {
         // test case for IVY-745
         MockMessageLogger mockLogger = new MockMessageLogger();
@@ -4961,6 +5160,7 @@ public class ResolveTest extends TestCase {
         mockLogger.assertLogContains("expected='task2' found='null'");
     }
 
+    @Test
     public void testExtraAttributes4() throws Exception {
         // second test case for IVY-745: now we disable consistency checking, everything should work
         // fine
@@ -4981,6 +5181,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File(cache, "apache/mymodule/task2/1749/mymodule-linux.jar").exists());
     }
 
+    @Test
     public void testNamespaceExtraAttributes() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/extra-attributes/ivysettings.xml"));
@@ -4995,6 +5196,7 @@ public class ResolveTest extends TestCase {
         assertTrue(new File(cache, "apache/mymodule/task1/1855/mymodule-linux.jar").exists());
     }
 
+    @Test
     public void testBranches1() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
@@ -5007,6 +5209,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#trunk;3", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testBranches2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
@@ -5019,6 +5222,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#branch1;4", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testBranches3() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/branches/ivysettings-defaultbranch1.xml"));
@@ -5031,6 +5235,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#branch1;4", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testBranches4() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/branches/ivysettings.xml"));
@@ -5044,6 +5249,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "bar#bar2#trunk;2", "bar2", "jar", "jar").exists());
     }
 
+    @Test
     public void testBranches5() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/branches/ivysettings-fooonbranch1.xml"));
@@ -5057,6 +5263,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "bar#bar2#trunk;2", "bar2", "jar", "jar").exists());
     }
 
+    @Test
     public void testBranches6() throws Exception {
         // test case for IVY-717
 
@@ -5084,6 +5291,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "foo#foo1#trunk;5", "foo1", "jar", "jar").exists());
     }
 
+    @Test
     public void testExternalArtifacts() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.getSettings().setVariable("test.base.url",
@@ -5100,6 +5308,7 @@ public class ResolveTest extends TestCase {
         assertTrue(getArchiveFileInCache(ivy, "apache", "C", "3.0", "C", "jar", "jar").exists());
     }
 
+    @Test
     public void testResolveWithMultipleIvyPatterns() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/multi-ivypattern/ivysettings.xml"));
@@ -5120,6 +5329,7 @@ public class ResolveTest extends TestCase {
         assertEquals("1.1", dependency.getResolvedId().getRevision());
     }
 
+    @Test
     public void testPrivateConfigurationTransferWhenConflict() throws Exception {
         ResolveReport report = ivy.resolve(new File(
                 "test/repositories/1/orgConflictAndPrivateConf/root/ivys/ivy-1.0.xml"),
@@ -5159,9 +5369,9 @@ public class ResolveTest extends TestCase {
                 artName, type, ext);
     }
 
-    private boolean containsArtifact(Artifact art, ArtifactDownloadReport[] adr) {
-        for (int i = 0; i < adr.length; i++) {
-            Artifact artifact = adr[i].getArtifact();
+    private boolean containsArtifact(Artifact art, ArtifactDownloadReport[] adrs) {
+        for (ArtifactDownloadReport adr : adrs) {
+            Artifact artifact = adr.getArtifact();
             if (artifact.getModuleRevisionId().equals(art.getModuleRevisionId())
                     && artifact.getName().equals(art.getName())
                     && artifact.getType().equals(art.getType())
@@ -5256,6 +5466,7 @@ public class ResolveTest extends TestCase {
         return new ResolveOptions().setConfs(confs);
     }
 
+    @Test
     public void testExtraAttributesForcedDependencies() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5282,6 +5493,7 @@ public class ResolveTest extends TestCase {
 
     }
 
+    @Test
     public void testNoAttributesForcedDependencies() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5307,6 +5519,7 @@ public class ResolveTest extends TestCase {
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testExtraAttributesMultipleDependenciesHang() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5319,6 +5532,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testExtraAttributesMultipleDependenciesNoHang() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5331,6 +5545,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testExtraAttributesMultipleDependenciesHang2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5343,6 +5558,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testExtraAttributesMultipleDependenciesNoHang2() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(new File(
@@ -5355,6 +5571,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testIVY956() throws Exception {
         ivy.getSettings().setDefaultConflictManager(
             ivy.getSettings().getConflictManager("latest-compatible"));
@@ -5367,6 +5584,7 @@ public class ResolveTest extends TestCase {
         }
     }
 
+    @Test
     public void testIVY1159_orderIsModAModB() throws Exception {
         testIVY1159("ivy-depsorder_modA_then_modB.xml", false);
 
@@ -5382,6 +5600,7 @@ public class ResolveTest extends TestCase {
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testIVY1159_orderIsModAModBReplaceForced() throws Exception {
         testIVY1159("ivy-depsorder_modA_then_modB.xml", true);
 
@@ -5397,6 +5616,7 @@ public class ResolveTest extends TestCase {
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testIVY1159_orderIsModBModA() throws Exception {
         testIVY1159("ivy-depsorder_modB_then_modA.xml", false);
 
@@ -5412,6 +5632,7 @@ public class ResolveTest extends TestCase {
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testIVY1159_orderIsModBModAReplaceForced() throws Exception {
         testIVY1159("ivy-depsorder_modB_then_modA.xml", true);
 
@@ -5460,6 +5681,7 @@ public class ResolveTest extends TestCase {
         ivy.deliver(pubrev, deliveryPattern, dopts);
     }
 
+    @Test
     public void testIVY1300() throws Exception {
         ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/IVY-1300/ivysettings.xml"));
@@ -5519,6 +5741,7 @@ public class ResolveTest extends TestCase {
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testUseCacheOnly() throws Exception {
         ResolveOptions option = getResolveOptions(new String[] {"*"}).setValidate(false);
         URL url = new File("test/repositories/1/usecacheonly/mod1/ivys/ivy-1.0.xml").toURI()
@@ -5578,6 +5801,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testUseCacheOnlyWithRange() throws Exception {
         ResolveOptions option = getResolveOptions(new String[] {"*"});
         option.setValidate(false);
@@ -5599,6 +5823,7 @@ public class ResolveTest extends TestCase {
         assertFalse(report.hasError());
     }
 
+    @Test
     public void testUseCacheOnlyWithChanging() throws Exception {
         ResolveOptions option = getResolveOptions(new String[] {"*"});
         option.setValidate(false);
@@ -5620,6 +5845,7 @@ public class ResolveTest extends TestCase {
 
     }
 
+    @Test
     public void testUnpack() throws Exception {
         ResolveOptions options = getResolveOptions(new String[] {"*"});
 

--- a/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
+++ b/test/java/org/apache/ivy/core/retrieve/RetrieveTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.SystemUtils;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyPatternHelper;
@@ -44,21 +43,26 @@ import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MockMessageLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class RetrieveTest extends TestCase {
+public class RetrieveTest {
 
     private Ivy ivy;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
         TestHelper.createCache();
         Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_INFO));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
         Delete del = new Delete();
         del.setProject(new Project());
@@ -66,10 +70,11 @@ public class RetrieveTest extends TestCase {
         del.execute();
     }
 
+    @Test
     public void testRetrieveSimple() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
+                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -86,10 +91,11 @@ public class RetrieveTest extends TestCase {
             "jar", "jar", "default")).exists());
     }
 
+    @Test
     public void testRetrieveSameFileConflict() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.1.xml").toURL(),
+                "test/repositories/1/org1/mod1.4/ivys/ivy-1.0.1.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -104,9 +110,10 @@ public class RetrieveTest extends TestCase {
         mockLogger.assertLogDoesntContain("conflict on");
     }
 
+    @Test
     public void testRetrieveDifferentArtifactsOfSameModuleToSameFile() throws Exception {
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.xml").toURL(),
+                "test/repositories/1/org2/mod2.2/ivys/ivy-0.5.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -117,16 +124,17 @@ public class RetrieveTest extends TestCase {
         Message.setDefaultLogger(mockLogger);
         try {
             ivy.retrieve(md.getModuleRevisionId(), pattern, getRetrieveOptions());
-            fail("Exeption should have been thrown!");
+            fail("Exception should have been thrown!");
         } catch (RuntimeException e) {
             // expected!
         }
         mockLogger.assertLogDoesntContain("multiple artifacts");
     }
 
+    @Test
     public void testEvent() throws Exception {
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
+                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
 
         final List events = new ArrayList();
@@ -157,10 +165,11 @@ public class RetrieveTest extends TestCase {
         assertEquals(1, ev.getNbUpToDate());
     }
 
+    @Test
     public void testRetrieveOverwrite() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
+                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -180,10 +189,11 @@ public class RetrieveTest extends TestCase {
             file.lastModified());
     }
 
+    @Test
     public void testRetrieveWithSymlinks() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
+                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -202,8 +212,9 @@ public class RetrieveTest extends TestCase {
             "jar", "default"));
     }
 
+    @Test
     public void testRetrieveWithSymlinksMass() throws Exception {
-        if (SystemUtils.IS_OS_WINDOWS) {
+        if (System.getProperty("os.name").startsWith("Windows")) {
             return;
         }
 
@@ -238,7 +249,7 @@ public class RetrieveTest extends TestCase {
         String os = System.getProperty("os.name");
         if (os.equals("Linux") || os.equals("Solaris") || os.equals("FreeBSD")
                 || os.equals("Mac OS X")) {
-            // these OS should support symnlink, so check that the file is actually a symlink.
+            // these OS should support symlink, so check that the file is actually a symlink.
             // this is done be checking that the canonical path is different from the absolute
             // path.
             File absFile = file.getAbsoluteFile();
@@ -247,11 +258,12 @@ public class RetrieveTest extends TestCase {
         }
     }
 
+    @Test
     public void testRetrieveWithVariable() throws Exception {
         // mod1.1 depends on mod1.2
         ivy.setVariable("retrieve.dir", "retrieve");
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURL(),
+                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -270,10 +282,11 @@ public class RetrieveTest extends TestCase {
             "jar", "jar", "default")).exists());
     }
 
+    @Test
     public void testRetrieveReport() throws Exception {
         // mod1.1 depends on mod1.2
         ResolveReport report = ivy.resolve(new File(
-                "test/repositories/1/org20/mod20.1/ivys/ivy-1.2.xml").toURL(),
+                "test/repositories/1/org20/mod20.1/ivys/ivy-1.2.xml").toURI().toURL(),
             getResolveOptions(new String[] {"*"}));
         assertNotNull(report);
         ModuleDescriptor md = report.getModuleDescriptor();
@@ -297,6 +310,7 @@ public class RetrieveTest extends TestCase {
         assertEquals(3, artifactsToCopy.size());
     }
 
+    @Test
     public void testUnpack() throws Exception {
         ResolveOptions roptions = getResolveOptions(new String[] {"*"});
 
@@ -324,6 +338,7 @@ public class RetrieveTest extends TestCase {
         assertEquals(new File(dest, "META-INF/MANIFEST.MF"), jarContents[0].listFiles()[0]);
     }
 
+    @Test
     public void testUnpackSync() throws Exception {
         ResolveOptions roptions = getResolveOptions(new String[] {"*"});
 
@@ -358,6 +373,7 @@ public class RetrieveTest extends TestCase {
      * @throws Exception
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1478">IVY-1478</a>
      */
+    @Test
     public void testUnpackExt() throws Exception {
         final ResolveOptions roptions = getResolveOptions(new String[] {"*"});
 

--- a/test/java/org/apache/ivy/core/search/SearchTest.java
+++ b/test/java/org/apache/ivy/core/search/SearchTest.java
@@ -31,10 +31,13 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class SearchTest extends TestCase {
+public class SearchTest {
+    @Test
     public void testListInMavenRepo() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml").toURI().toURL());
@@ -48,6 +51,7 @@ public class SearchTest extends TestCase {
             new HashSet(Arrays.asList(revs)));
     }
 
+    @Test
     public void testListInMavenRepo2() throws Exception {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/m2/ivysettings.xml").toURI().toURL());
@@ -62,6 +66,7 @@ public class SearchTest extends TestCase {
                 Arrays.asList(revs)));
     }
 
+    @Test
     public void testListModulesWithExtraAttributes() throws ParseException, IOException {
         Ivy ivy = Ivy.newInstance();
         ivy.configure(new File("test/repositories/IVY-1128/ivysettings.xml"));

--- a/test/java/org/apache/ivy/core/settings/ConfigureTest.java
+++ b/test/java/org/apache/ivy/core/settings/ConfigureTest.java
@@ -26,9 +26,14 @@ import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.IvyRepResolver;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class ConfigureTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigureTest {
+    @Test
     public void testDefault() throws ParseException, IOException {
         Ivy ivy = new Ivy();
         ivy.configureDefault();
@@ -43,6 +48,7 @@ public class ConfigureTest extends TestCase {
         assertTrue(ibiblio.isM2compatible());
     }
 
+    @Test
     public void testDefault14() throws ParseException, IOException {
         Ivy ivy = new Ivy();
         ivy.configureDefault14();
@@ -54,6 +60,7 @@ public class ConfigureTest extends TestCase {
         assertTrue(publicResolver instanceof IvyRepResolver);
     }
 
+    @Test
     public void testTypedefWithCustomClasspath() throws Exception {
         Ivy ivy = new Ivy();
         ivy.setVariable("ivy.custom.test.dir", new File("test/java/org/apache/ivy/core/settings")
@@ -65,6 +72,7 @@ public class ConfigureTest extends TestCase {
         assertEquals("org.apache.ivy.plugins.resolver.CustomResolver", custom.getClass().getName());
     }
 
+    @Test
     public void testTypedefWithCustomClasspathWithFile() throws Exception {
         Ivy ivy = new Ivy();
         ivy.setVariable("ivy.custom.test.dir",

--- a/test/java/org/apache/ivy/core/settings/IvySettingsTest.java
+++ b/test/java/org/apache/ivy/core/settings/IvySettingsTest.java
@@ -23,10 +23,13 @@ import java.text.ParseException;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class IvySettingsTest extends TestCase {
+import static org.junit.Assert.*;
 
+public class IvySettingsTest {
+
+    @Test
     public void testChangeDefaultResolver() throws ParseException, IOException {
         Ivy ivy = new Ivy();
         ivy.configureDefault();
@@ -45,6 +48,7 @@ public class IvySettingsTest extends TestCase {
         assertEquals("resolver changed successfully", "public", newDefault.getName());
     }
 
+    @Test
     public void testVariables() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configureDefault();

--- a/test/java/org/apache/ivy/core/settings/OnlineXmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/OnlineXmlSettingsParserTest.java
@@ -26,14 +26,18 @@ import org.apache.ivy.util.url.URLHandler;
 import org.apache.ivy.util.url.URLHandlerDispatcher;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * split from XmlIvyConfigurationParserTest due to dependency on network resource
  */
-public class OnlineXmlSettingsParserTest extends TestCase {
+public class OnlineXmlSettingsParserTest {
     // remote.test
 
+    @Test
     public void testIncludeHttpUrl() throws Exception {
         configureURLHandler();
         IvySettings settings = new IvySettings();
@@ -45,6 +49,7 @@ public class OnlineXmlSettingsParserTest extends TestCase {
         assertTrue(resolver instanceof IvyRepResolver);
     }
 
+    @Test
     public void testIncludeHttpRelativeUrl() throws Exception {
         // Use a settings file via http that use an include with relative url
         configureURLHandler();
@@ -58,6 +63,7 @@ public class OnlineXmlSettingsParserTest extends TestCase {
         assertTrue(resolver instanceof IvyRepResolver);
     }
 
+    @Test
     public void testIncludeHttpRelativeFile() throws Exception {
         // Use a settings file via http that use an include with relative file
         configureURLHandler();
@@ -71,6 +77,7 @@ public class OnlineXmlSettingsParserTest extends TestCase {
         assertTrue(resolver instanceof IvyRepResolver);
     }
 
+    @Test
     public void testIncludeHttpAbsoluteFile() throws Exception {
         // Use a settings file via http that use an include with absolute file
         // WARNING : this test will only work if the test are launched from the project root

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -46,13 +46,15 @@ import org.apache.ivy.plugins.resolver.packager.PackagerResolver;
 import org.apache.ivy.plugins.version.ChainVersionMatcher;
 import org.apache.ivy.plugins.version.MockVersionMatcher;
 import org.apache.ivy.plugins.version.VersionMatcher;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
 /**
  * TODO write javadoc
  */
-public class XmlSettingsParserTest extends TestCase {
+public class XmlSettingsParserTest {
+    @Test
     public void test() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -121,6 +123,7 @@ public class XmlSettingsParserTest extends TestCase {
             settings.getResolver(ModuleRevisionId.newInstance("apache", "ivyde", "1.0")).getName());
     }
 
+    @Test
     public void testTypedef() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -144,6 +147,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(subresolvers.get(1) instanceof MockResolver);
     }
 
+    @Test
     public void testStatuses() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -158,6 +162,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals(true, settings.getStatusManager().isIntegration("bronze"));
     }
 
+    @Test
     public void testConflictManager() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -168,6 +173,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("all", settings.getConflictManager(new ModuleId("apache", "ant")).getName());
     }
 
+    @Test
     public void testResolveMode() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -179,6 +185,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("default", settings.getResolveMode(new ModuleId("apache", "ant")));
     }
 
+    @Test
     public void testExtraModuleAttribute() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -188,6 +195,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("default", settings.getResolveMode(new ModuleId("apache", "ivy")));
     }
 
+    @Test
     public void testCache() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -240,6 +248,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals(c, settings.getResolver("B").getRepositoryCacheManager());
     }
 
+    @Test
     public void testInvalidCache() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -248,10 +257,11 @@ public class XmlSettingsParserTest extends TestCase {
             parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache-invalid.xml"));
             fail("resolver referencing a non existent cache should raise an exception");
         } catch (ParseException e) {
-            assertTrue(e.getMessage().indexOf("mycache") != -1);
+            assertTrue(e.getMessage().contains("mycache"));
         }
     }
 
+    @Test
     public void testVersionMatchers1() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -270,6 +280,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(chain.getMatchers().contains(settings.getVersionMatcher("latest")));
     }
 
+    @Test
     public void testVersionMatchers2() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -286,6 +297,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(chain.getMatchers().contains(mock));
     }
 
+    @Test
     public void testRef() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -324,6 +336,7 @@ public class XmlSettingsParserTest extends TestCase {
             ivyPatterns.get(0));
     }
 
+    @Test
     public void testMacro() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -374,6 +387,7 @@ public class XmlSettingsParserTest extends TestCase {
             ivyPatterns.get(0));
     }
 
+    @Test
     public void testMacroAndRef() throws Exception {
         // test case for IVY-319
         IvySettings settings = new IvySettings();
@@ -396,6 +410,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(shared instanceof FileSystemResolver);
     }
 
+    @Test
     public void testMacroAndRef2() throws Exception {
         // test case for IVY-860
         IvySettings settings = new IvySettings();
@@ -417,6 +432,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals(testResolver, subresolvers.get(0));
     }
 
+    @Test
     public void testPropertiesMissingFile() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -429,6 +445,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("libraries", defaultResolver.getName());
     }
 
+    @Test
     public void testInclude() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -473,6 +490,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("myvalue", settings.getVariable("ivy.test.prop"));
     }
 
+    @Test
     public void testIncludeAbsoluteFile() throws Exception {
         // WARNING : this test will only work if the test are launched from the project root
         // directory
@@ -486,6 +504,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(inc instanceof ChainResolver);
     }
 
+    @Test
     public void testIncludeMissingFile() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -498,6 +517,7 @@ public class XmlSettingsParserTest extends TestCase {
         }
     }
 
+   @Test
     public void testIncludeSpecialCharInName() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -542,6 +562,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals("myvalue", settings.getVariable("ivy.test.prop"));
     }
 
+    @Test
     public void testRelativePropertiesFile() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -551,6 +572,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertLocationEquals("lib", settings.getVariable("libraries.dir"));
     }
 
+    @Test
     public void testParser() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -559,6 +581,7 @@ public class XmlSettingsParserTest extends TestCase {
             ModuleDescriptorParserRegistry.getInstance().getParsers()[0].getClass().getName());
     }
 
+    @Test
     public void testOutputter() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -571,6 +594,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(testOutputter instanceof MyOutputter);
     }
 
+    @Test
     public void testLockingStrategies() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
@@ -581,6 +605,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertTrue(lockStrategy instanceof MyLockStrategy);
     }
 
+    @Test
     public void testFileAttribute() throws Exception {
         IvySettings settings = new IvySettings();
         File basedir = new File("test").getAbsoluteFile();
@@ -596,6 +621,7 @@ public class XmlSettingsParserTest extends TestCase {
         assertEquals(new File(basedir, "packager/cache"), packager.getResourceCache());
     }
 
+    @Test
     public void testBaseDirVariables() throws Exception {
         IvySettings settings = new IvySettings();
         settings.setBaseDir(new File("test/base/dir"));

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -46,7 +46,10 @@ import org.apache.ivy.plugins.resolver.packager.PackagerResolver;
 import org.apache.ivy.plugins.version.ChainVersionMatcher;
 import org.apache.ivy.plugins.version.MockVersionMatcher;
 import org.apache.ivy.plugins.version.VersionMatcher;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
@@ -54,6 +57,9 @@ import static org.junit.Assert.*;
  * TODO write javadoc
  */
 public class XmlSettingsParserTest {
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
+
     @Test
     public void test() throws Exception {
         IvySettings settings = new IvySettings();
@@ -248,17 +254,20 @@ public class XmlSettingsParserTest {
         assertEquals(c, settings.getResolver("B").getRepositoryCacheManager());
     }
 
+    /**
+     * Test of esolver referencing a non existent cache.
+     *
+     * @throws Exception
+     */
     @Test
     public void testInvalidCache() throws Exception {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("mycache");
+
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
 
-        try {
-            parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache-invalid.xml"));
-            fail("resolver referencing a non existent cache should raise an exception");
-        } catch (ParseException e) {
-            assertTrue(e.getMessage().contains("mycache"));
-        }
+        parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache-invalid.xml"));
     }
 
     @Test
@@ -504,17 +513,12 @@ public class XmlSettingsParserTest {
         assertTrue(inc instanceof ChainResolver);
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testIncludeMissingFile() throws Exception {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
-        try {
-            parser.parse(XmlSettingsParserTest.class
-                    .getResource("ivysettings-include-missing-file.xml"));
-            fail("An exception must be throwed");
-        } catch (Exception e) {
-            // An exception must be throwed
-        }
+        parser.parse(XmlSettingsParserTest.class
+                .getResource("ivysettings-include-missing-file.xml"));
     }
 
    @Test

--- a/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/core/AggregatedOSGiResolverTest.java
@@ -38,10 +38,13 @@ import org.apache.ivy.osgi.repo.AbstractOSGiResolver.RequirementStrategy;
 import org.apache.ivy.osgi.repo.AggregatedOSGiResolver;
 import org.apache.ivy.osgi.updatesite.UpdateSiteResolver;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class AggregatedOSGiResolverTest extends TestCase {
+public class AggregatedOSGiResolverTest {
 
     private IvySettings settings;
 
@@ -53,6 +56,7 @@ public class AggregatedOSGiResolverTest extends TestCase {
 
     private AggregatedOSGiResolver resolver;
 
+    @Before
     public void setUp() throws Exception {
         settings = new IvySettings();
 
@@ -104,8 +108,8 @@ public class AggregatedOSGiResolverTest extends TestCase {
 
         ivy.getResolutionCacheManager().clean();
         RepositoryCacheManager[] caches = settings.getRepositoryCacheManagers();
-        for (int i = 0; i < caches.length; i++) {
-            caches[i].clean();
+        for (RepositoryCacheManager cache : caches) {
+            cache.clean();
         }
 
         data = new ResolveData(ivy.getResolveEngine(), new ResolveOptions());
@@ -143,18 +147,21 @@ public class AggregatedOSGiResolverTest extends TestCase {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testResolveInUpdatesite() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy", "2.0.0.final_20090108225011");
         genericTestResolveDownload(resolver, mrid);
     }
 
+    @Test
     public void testResolveInObr() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy.osgi.testbundle", "1.2.3");
         genericTestResolveDownload(resolver, mrid);
     }
 
+    @Test
     public void testCrossResolve() throws Exception {
         ModuleRevisionId mrid1 = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy.osgi.testbundle1", "1.2.3");

--- a/test/java/org/apache/ivy/osgi/core/ExecutionEnvironmentProfileLoaderTest.java
+++ b/test/java/org/apache/ivy/osgi/core/ExecutionEnvironmentProfileLoaderTest.java
@@ -17,12 +17,15 @@
  */
 package org.apache.ivy.osgi.core;
 
+import org.junit.Test;
+
 import java.util.Map;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class ExecutionEnvironmentProfileLoaderTest extends TestCase {
+public class ExecutionEnvironmentProfileLoaderTest {
 
+    @Test
     public void testLoad() throws Exception {
         Map<String, ExecutionEnvironmentProfile> profiles = ExecutionEnvironmentProfileProvider
                 .loadDefaultProfileList();

--- a/test/java/org/apache/ivy/osgi/core/ManifestHeaderTest.java
+++ b/test/java/org/apache/ivy/osgi/core/ManifestHeaderTest.java
@@ -17,12 +17,16 @@
  */
 package org.apache.ivy.osgi.core;
 
+import org.junit.Test;
+
 import java.text.ParseException;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-public class ManifestHeaderTest extends TestCase {
+public class ManifestHeaderTest {
 
+    @Test
     public void testNormal() throws Exception {
         ManifestHeaderElement simpleValue = new ManifestHeaderElement();
         simpleValue.addValue("value");
@@ -76,6 +80,7 @@ public class ManifestHeaderTest extends TestCase {
         assertEquals(new ManifestHeaderValue(v1), new ManifestHeaderValue(v2));
     }
 
+    @Test
     public void testSpaceAndQuote() throws Exception {
         genericTestEquals("value1;att=value2;att2=other", "value1;att='value2';att2=other");
         genericTestEquals("value1;att=value2;att2=other", "value1;att=  'value2'  ;att2=other");
@@ -84,6 +89,7 @@ public class ManifestHeaderTest extends TestCase {
         genericTestEquals("value1;att=value2;att2=other", "value1;att=\"value2\";att2=other");
     }
 
+    @Test
     public void testReflexivity() throws Exception {
         genericTestEquals("value1;value2", "value2;value1");
         genericTestEquals("value1,value2", "value2,value1");
@@ -93,6 +99,7 @@ public class ManifestHeaderTest extends TestCase {
         genericTestEquals("value1;version=1.2.3;color:=red", "value1;color:=red;version=1.2.3");
     }
 
+    @Test
     public void testSyntaxError() throws Exception {
         genericTestSyntaxError("value1=");
         genericTestSyntaxError("value1;version=1;value2");
@@ -113,6 +120,7 @@ public class ManifestHeaderTest extends TestCase {
         }
     }
 
+    @Test
     public void testSpaceInValue() throws Exception {
         ManifestHeaderValue value = new ManifestHeaderValue("glassfish javax.servlet.3.1.0.b33");
         assertEquals("glassfish javax.servlet.3.1.0.b33", value.getSingleValue());

--- a/test/java/org/apache/ivy/osgi/core/ManifestParserTest.java
+++ b/test/java/org/apache/ivy/osgi/core/ManifestParserTest.java
@@ -24,11 +24,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.ivy.osgi.util.VersionRange;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class ManifestParserTest extends TestCase {
+public class ManifestParserTest {
 
+    @Test
     public void testParseManifest() throws Exception {
         BundleInfo bundleInfo;
 
@@ -49,8 +51,8 @@ public class ManifestParserTest extends TestCase {
         assertNull(bundleInfo.getClasspath());
 
         final String importsList = bundleInfo.getImports().toString();
-        assertTrue(importsList.indexOf("com.acme.bravo") != -1);
-        assertTrue(importsList.indexOf("com.acme.delta") != -1);
+        assertTrue(importsList.contains("com.acme.bravo"));
+        assertTrue(importsList.contains("com.acme.delta"));
 
         bundleInfo = ManifestParser.parseJarManifest(getClass().getResourceAsStream(
             "com.acme.bravo-2.0.0.20080202.jar"));
@@ -63,11 +65,12 @@ public class ManifestParserTest extends TestCase {
         expectedRequires.add(new BundleRequirement(BundleInfo.BUNDLE_TYPE, "com.acme.charlie",
                 new VersionRange("3.0.0"), null));
         assertEquals(1, bundleInfo.getExports().size());
-        assertTrue(bundleInfo.getExports().toString().indexOf("com.acme.bravo") != -1);
+        assertTrue(bundleInfo.getExports().toString().contains("com.acme.bravo"));
         assertEquals(1, bundleInfo.getImports().size());
-        assertTrue(bundleInfo.getImports().toString().indexOf("com.acme.charlie") != -1);
+        assertTrue(bundleInfo.getImports().toString().contains("com.acme.charlie"));
     }
 
+    @Test
     public void testClasspath() throws Exception {
         InputStream in = this.getClass().getResourceAsStream(
             "/org/apache/ivy/osgi/core/MANIFEST_classpath.MF");
@@ -97,6 +100,7 @@ public class ManifestParserTest extends TestCase {
         assertEquals(Arrays.asList(new String[] {"."}), cp);
     }
 
+    @Test
     public void testFormatLines() throws Exception {
         assertEquals("foo bar\n", ManifestParser.formatLines("foo bar"));
         assertEquals(

--- a/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
+++ b/test/java/org/apache/ivy/osgi/core/OSGiManifestParserTest.java
@@ -31,11 +31,19 @@ import org.apache.ivy.plugins.repository.file.FileResource;
 import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.Message;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class OSGiManifestParserTest extends AbstractModuleDescriptorParserTester {
 
     private IvySettings settings;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_WARN));
 
         settings = new IvySettings();
@@ -43,6 +51,7 @@ public class OSGiManifestParserTest extends AbstractModuleDescriptorParserTester
         settings.setDefaultCache(new File("build/cache"));
     }
 
+    @Test
     public void testSimple() throws Exception {
         ModuleDescriptor md = OSGiManifestParser.getInstance().parseDescriptor(settings,
             getClass().getResource("MANIFEST_classpath.MF"), true);
@@ -69,6 +78,7 @@ public class OSGiManifestParserTest extends AbstractModuleDescriptorParserTester
      *
      * @throws Exception
      */
+    @Test
     public void testFileResource() throws Exception {
         final File manifestFile = new File("test/repositories/osgi/module1/META-INF/MANIFEST.MF");
         assertTrue("Manifest file is either missing or not a file at " + manifestFile.getAbsolutePath(), manifestFile.isFile());

--- a/test/java/org/apache/ivy/osgi/core/OsgiLatestStrategyTest.java
+++ b/test/java/org/apache/ivy/osgi/core/OsgiLatestStrategyTest.java
@@ -24,11 +24,14 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.ivy.plugins.latest.ArtifactInfo;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class OsgiLatestStrategyTest extends TestCase {
+public class OsgiLatestStrategyTest {
 
+    @Test
     public void testComparator() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2.0.a", "0.2.0.b", "0.2.0.final", "1.0",
                 "1.0.0.gamma", "1.0.0.rc1", "1.0.0.rc2", "1.0.1", "2", "2.0.0.b006", "2.0.0.b012",
@@ -40,6 +43,7 @@ public class OsgiLatestStrategyTest extends TestCase {
         assertEquals(Arrays.asList(revs), shuffled);
     }
 
+    @Test
     public void testSort() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2.0.a", "0.2.0.b", "0.2.0.final", "1.0",
                 "1.0.0.gamma", "1.0.0.rc1", "1.0.0.rc2", "1.0.1", "2", "2.0.0.b006", "2.0.0.b012",
@@ -54,6 +58,7 @@ public class OsgiLatestStrategyTest extends TestCase {
         assertEquals(Arrays.asList(revs), sorted);
     }
 
+    @Test
     public void testFindLatest() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2.0.a", "0.2.0.b", "0.2.0.rc1",
                 "0.2.0.final", "1.0.0.dev1", "1.0.0.dev2", "1.0.0.alpha1", "1.0.0.alpha2",

--- a/test/java/org/apache/ivy/osgi/filter/OSGiFilterTest.java
+++ b/test/java/org/apache/ivy/osgi/filter/OSGiFilterTest.java
@@ -20,12 +20,14 @@ package org.apache.ivy.osgi.filter;
 import java.text.ParseException;
 
 import org.apache.ivy.osgi.filter.CompareFilter.Operator;
+import org.junit.Test;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-public class OSGiFilterTest extends TestCase {
+public class OSGiFilterTest {
 
+    @Test
     public void testParser() throws Exception {
         assertParseFail("c>2");
         assertParseFail("");
@@ -56,7 +58,7 @@ public class OSGiFilterTest extends TestCase {
     private void assertParseFail(String toParse) {
         try {
             OSGiFilterParser.parse(toParse);
-            Assert.fail("Expecting a ParseException");
+            fail("Expecting a ParseException");
         } catch (ParseException e) {
             // OK
         }
@@ -64,6 +66,6 @@ public class OSGiFilterTest extends TestCase {
 
     private void checkParse(OSGiFilter expected, String toParse) throws ParseException {
         OSGiFilter parsed = OSGiFilterParser.parse(toParse);
-        Assert.assertEquals(expected, parsed);
+        assertEquals(expected, parsed);
     }
 }

--- a/test/java/org/apache/ivy/osgi/filter/OSGiFilterTest.java
+++ b/test/java/org/apache/ivy/osgi/filter/OSGiFilterTest.java
@@ -27,11 +27,23 @@ import static org.junit.Assert.fail;
 
 public class OSGiFilterTest {
 
+    @Test(expected = ParseException.class)
+    public void testParserFailureNoParens() throws ParseException {
+        OSGiFilterParser.parse("c>2");
+    }
+
+    @Test(expected = ParseException.class)
+    public void testParserFailureEmpty() throws ParseException {
+        OSGiFilterParser.parse("");
+    }
+
+    @Test(expected = ParseException.class)
+    public void testParserFailureSingleParens() throws ParseException {
+        OSGiFilterParser.parse(")");
+    }
+
     @Test
     public void testParser() throws Exception {
-        assertParseFail("c>2");
-        assertParseFail("");
-        assertParseFail(")");
         OSGiFilter cgt2 = new CompareFilter("c", Operator.GREATER_THAN, "2");
         checkParse(cgt2, "(c>2)");
         OSGiFilter twoeqd = new CompareFilter("2", Operator.EQUALS, "d");
@@ -53,15 +65,6 @@ public class OSGiFilterTest {
                 notVersion400, bundle});
         checkParse(andEverythingWithSpace,
             "(&     (version>=3.5.0)     (!(version>=4.0.0))     (bundle=org.eclipse.core.runtime)    )");
-    }
-
-    private void assertParseFail(String toParse) {
-        try {
-            OSGiFilterParser.parse(toParse);
-            fail("Expecting a ParseException");
-        } catch (ParseException e) {
-            // OK
-        }
     }
 
     private void checkParse(OSGiFilter expected, String toParse) throws ParseException {

--- a/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRParserTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.ivy.osgi.obr;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Iterator;
@@ -26,13 +29,13 @@ import org.apache.ivy.osgi.obr.xml.OBRXMLParser;
 import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.util.CollectionUtils;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class OBRParserTest {
 
-public class OBRParserTest extends TestCase {
+    private final File testObr = new File("test/test-obr");
 
-    private File testObr = new File("test/test-obr");
-
+    @Test
     public void testParse() throws Exception {
         BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
                 new File(testObr, "obr.xml")));
@@ -41,6 +44,7 @@ public class OBRParserTest extends TestCase {
         assertEquals("1253581430652", repo.getLastModified());
     }
 
+    @Test
     public void testParseSource() throws Exception {
         BundleRepoDescriptor repo = OBRXMLParser.parse(testObr.toURI(), new FileInputStream(
                 new File(testObr, "sources.xml")));

--- a/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
@@ -53,10 +53,12 @@ import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.DualResolver;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class OBRResolverTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class OBRResolverTest {
 
     private static final ModuleRevisionId MRID_TEST_BUNDLE = ModuleRevisionId.newInstance(
         BundleInfo.BUNDLE_TYPE, "org.apache.ivy.osgi.testbundle", "1.2.3");
@@ -101,6 +103,7 @@ public class OBRResolverTest extends TestCase {
     private ExecutionEnvironmentProfileProvider profileProvider = ExecutionEnvironmentProfileProvider
             .getInstance();
 
+    @Before
     public void setUp() throws Exception {
         settings = new IvySettings();
 
@@ -148,25 +151,28 @@ public class OBRResolverTest extends TestCase {
 
         ivy.getResolutionCacheManager().clean();
         RepositoryCacheManager[] caches = settings.getRepositoryCacheManagers();
-        for (int i = 0; i < caches.length; i++) {
-            caches[i].clean();
+        for (RepositoryCacheManager cache : caches) {
+            cache.clean();
         }
 
         data = new ResolveData(ivy.getResolveEngine(), new ResolveOptions());
     }
 
+    @Test
     public void testSimpleResolve() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy.osgi.testbundle", "1.2.3");
         genericTestResolveDownload(bundleResolver, mrid);
     }
 
+    @Test
     public void testSimpleUrlResolve() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy.osgi.testbundle", "1.2.3");
         genericTestResolveDownload(bundleUrlResolver, mrid);
     }
 
+    @Test
     public void testResolveDual() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy.osgi.testbundle", "1.2.3");
@@ -205,11 +211,13 @@ public class OBRResolverTest extends TestCase {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testResolveImporting() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {MRID_TEST_BUNDLE});
     }
 
+    @Test
     public void testResolveImportingOptional() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.optional_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {});
@@ -218,6 +226,7 @@ public class OBRResolverTest extends TestCase {
             new ModuleRevisionId[] {MRID_TEST_BUNDLE});
     }
 
+    @Test
     public void testResolveImportingTransitiveOptional() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.transitiveoptional_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {});
@@ -227,39 +236,46 @@ public class OBRResolverTest extends TestCase {
                 MRID_TEST_BUNDLE, MRID_TEST_BUNDLE_IMPORTING_OPTIONAL});
     }
 
+    @Test
     public void testResolveImportingVersion() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.version_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {MRID_TEST_BUNDLE});
     }
 
+    @Test
     public void testResolveImportingRangeVersion() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.rangeversion_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {MRID_TEST_BUNDLE});
     }
 
+    @Test
     public void testResolveUse() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.use_2.2.2.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {});
     }
 
+    @Test
     public void testResolveImportingUse() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.use_3.2.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {MRID_TEST_BUNDLE_USE,
                 MRID_TEST_BUNDLE_IMPORTING, MRID_TEST_BUNDLE});
     }
 
+    @Test
     public void testResolveRequire() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.require_1.1.1.jar";
         genericTestResolve(jarName, "default", new ModuleRevisionId[] {MRID_TEST_BUNDLE,
                 MRID_TEST_BUNDLE_IMPORTING_VERSION});
     }
 
+    @Test
     public void testResolveOptionalConf() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.require_1.1.1.jar";
         genericTestResolve(jarName, "optional", new ModuleRevisionId[] {MRID_TEST_BUNDLE,
                 MRID_TEST_BUNDLE_IMPORTING_VERSION});
     }
 
+    @Test
     public void testResolveImportAmbiguity() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.ambiguity_3.2.1.jar";
         bundleResolver.setRequirementStrategy(RequirementStrategy.first);
@@ -268,12 +284,14 @@ public class OBRResolverTest extends TestCase {
                     MRID_TEST_BUNDLE, MRID_TEST_BUNDLE_IMPORTING_VERSION});
     }
 
+    @Test
     public void testResolveImportNoAmbiguity() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.importing.ambiguity_3.2.1.jar";
         bundleResolver.setRequirementStrategy(RequirementStrategy.noambiguity);
         genericTestFailingResolve(jarName, "default");
     }
 
+    @Test
     public void testResolveRequireAmbiguity() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.require.ambiguity_1.1.1.jar";
         bundleResolver.setRequirementStrategy(RequirementStrategy.noambiguity);
@@ -281,6 +299,7 @@ public class OBRResolverTest extends TestCase {
                 MRID_TEST_BUNDLE_IMPORTING_VERSION});
     }
 
+    @Test
     public void testResolveRequireJre() throws Exception {
         String jarName = "org.apache.ivy.osgi.testbundle.requirejre_2.2.2.jar";
         bundleResolver.setRequirementStrategy(RequirementStrategy.noambiguity);
@@ -293,6 +312,7 @@ public class OBRResolverTest extends TestCase {
         genericTestResolve(jarName, conf, expectedMrids, null);
     }
 
+    @SuppressWarnings("resource")
     private void genericTestResolve(String jarName, String conf, ModuleRevisionId[] expectedMrids,
             ModuleRevisionId[] expected2Mrids) throws Exception {
         Manifest manifest = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
@@ -319,7 +339,7 @@ public class OBRResolverTest extends TestCase {
                         Arrays.asList(expected2Mrids));
                 assertEquals(expected2, actual);
                 return; // test passed
-            } catch (AssertionFailedError e) {
+            } catch (AssertionError e) {
                 // too bad, let's continue
             }
         }

--- a/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRXMLWriterTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.ivy.osgi.obr;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -33,11 +36,12 @@ import org.apache.ivy.osgi.repo.BundleRepoDescriptor;
 import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.osgi.util.Version;
 import org.apache.ivy.util.CollectionUtils;
+
+import org.junit.Test;
+
 import org.xml.sax.ContentHandler;
 
-import junit.framework.TestCase;
-
-public class OBRXMLWriterTest extends TestCase {
+public class OBRXMLWriterTest {
 
     private static final Version BUNDLE_VERSION = new Version(1, 2, 3, null);
 
@@ -45,6 +49,7 @@ public class OBRXMLWriterTest extends TestCase {
 
     private static final String BUNDLE_2 = "org.apache.ivy.test2";
 
+    @Test
     public void testWriteWithSource() throws Exception {
         List<BundleInfo> bundles = new ArrayList<BundleInfo>();
 
@@ -61,8 +66,8 @@ public class OBRXMLWriterTest extends TestCase {
         File obrFile = new File("build/test-files/obr-sources.xml");
         FileOutputStream out = new FileOutputStream(obrFile);
         try {
-            ContentHandler hanlder = OBRXMLWriter.newHandler(out, "UTF-8", true);
-            OBRXMLWriter.writeBundles(bundles, hanlder);
+            ContentHandler handler = OBRXMLWriter.newHandler(out, "UTF-8", true);
+            OBRXMLWriter.writeBundles(bundles, handler);
         } finally {
             out.close();
         }

--- a/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
+++ b/test/java/org/apache/ivy/osgi/p2/P2DescriptorTest.java
@@ -34,10 +34,15 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.osgi.updatesite.UpdateSiteResolver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-public class P2DescriptorTest extends TestCase {
+public class P2DescriptorTest {
 
     private File cache;
 
@@ -53,7 +58,8 @@ public class P2DescriptorTest extends TestCase {
 
     private ResolveData data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         settings = new IvySettings();
 
         p2SourceResolver = new UpdateSiteResolver();
@@ -85,18 +91,19 @@ public class P2DescriptorTest extends TestCase {
 
         ivy.getResolutionCacheManager().clean();
         RepositoryCacheManager[] caches = settings.getRepositoryCacheManagers();
-        for (int i = 0; i < caches.length; i++) {
-            caches[i].clean();
+        for (RepositoryCacheManager cache : caches) {
+            cache.clean();
         }
 
         data = new ResolveData(ivy.getResolveEngine(), new ResolveOptions());
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         ivy.getLoggerEngine().sumupProblems();
     }
 
+    @Test
     public void testResolveSource() throws Exception {
         settings.setDefaultResolver("p2-sources");
 
@@ -139,6 +146,7 @@ public class P2DescriptorTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolveNotZipped() throws Exception {
         settings.setDefaultResolver("p2-zipped");
 
@@ -168,6 +176,7 @@ public class P2DescriptorTest extends TestCase {
         assertNull(ar.getUnpackedLocalFile());
     }
 
+    @Test
     public void testResolveZipped() throws Exception {
         settings.setDefaultResolver("p2-zipped");
 
@@ -204,6 +213,7 @@ public class P2DescriptorTest extends TestCase {
         }
     }
 
+    @Test
     public void testResolvePacked() throws Exception {
         settings.setDefaultResolver("p2-with-packed");
 

--- a/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
+++ b/test/java/org/apache/ivy/osgi/repo/BundleRepoTest.java
@@ -36,16 +36,18 @@ import org.apache.ivy.osgi.obr.xml.OBRXMLWriter;
 import org.apache.ivy.plugins.repository.file.FileRepository;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
 import org.apache.tools.ant.BuildException;
+import org.junit.Test;
 import org.xml.sax.SAXException;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class BundleRepoTest extends TestCase {
+public class BundleRepoTest {
 
     private File bundlerepo = new File("test/test-repo/bundlerepo");
 
     private File ivyrepo = new File("test/test-repo/ivyrepo");
 
+    @Test
     public void testFS() throws Exception {
         FSManifestIterable it = new FSManifestIterable(bundlerepo);
         BundleRepoDescriptor repo = new BundleRepoDescriptor(bundlerepo.toURI(),
@@ -58,6 +60,7 @@ public class BundleRepoTest extends TestCase {
         assertEquals(repo, repo2);
     }
 
+    @Test
     public void testFileRepo() throws Exception {
         RepositoryManifestIterable it = new RepositoryManifestIterable(new FileRepository(
                 bundlerepo.getAbsoluteFile()));
@@ -71,6 +74,7 @@ public class BundleRepoTest extends TestCase {
         assertEquals(repo, repo2);
     }
 
+    @Test
     public void testResolver() throws Exception {
         FileSystemResolver fileSystemResolver = new FileSystemResolver();
         fileSystemResolver.setName("test");
@@ -90,6 +94,7 @@ public class BundleRepoTest extends TestCase {
         assertEquals(repo, repo2);
     }
 
+    @Test
     public void testXMLSerialisation() throws SAXException, ParseException, IOException {
         FSManifestIterable it = new FSManifestIterable(bundlerepo);
         BundleRepoDescriptor repo = new BundleRepoDescriptor(bundlerepo.toURI(),

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteAndIbiblioResolverTest.java
@@ -32,10 +32,12 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.plugins.resolver.ChainResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
 
-public class UpdateSiteAndIbiblioResolverTest extends TestCase {
+public class UpdateSiteAndIbiblioResolverTest {
 
     private IvySettings settings;
 
@@ -51,6 +53,7 @@ public class UpdateSiteAndIbiblioResolverTest extends TestCase {
 
     ChainResolver chain;
 
+    @Before
     public void setUp() throws Exception {
         settings = new IvySettings();
 
@@ -87,13 +90,14 @@ public class UpdateSiteAndIbiblioResolverTest extends TestCase {
 
         ivy.getResolutionCacheManager().clean();
         RepositoryCacheManager[] caches = settings.getRepositoryCacheManagers();
-        for (int i = 0; i < caches.length; i++) {
-            caches[i].clean();
+        for (RepositoryCacheManager cache : caches) {
+            cache.clean();
         }
 
         data = new ResolveData(ivy.getResolveEngine(), new ResolveOptions());
     }
 
+   @Test
     public void testArtifactRef() throws ParseException {
 
         // Simple Dependency for ibiblio

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.ivy.osgi.updatesite;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -31,17 +34,22 @@ import org.apache.ivy.osgi.repo.ModuleDescriptorWrapper;
 import org.apache.ivy.osgi.repo.RepoDescriptor;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.CollectionUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import org.xml.sax.SAXException;
 
-import junit.framework.TestCase;
-
-public class UpdateSiteLoaderTest extends TestCase {
+public class UpdateSiteLoaderTest {
 
     private UpdateSiteLoader loader;
 
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         IvySettings ivySettings = new IvySettings();
         cache = new File("build/cache");
         cache.mkdirs();
@@ -50,10 +58,12 @@ public class UpdateSiteLoaderTest extends TestCase {
         loader = new UpdateSiteLoader(ivySettings.getDefaultRepositoryCacheManager(), null, options);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testIvyDE() throws IOException, ParseException, SAXException, URISyntaxException {
         RepoDescriptor site = loader.load(new URI(
                 "http://www.apache.org/dist/ant/ivyde/updatesite/"));
@@ -65,6 +75,7 @@ public class UpdateSiteLoaderTest extends TestCase {
         }
     }
 
+    @Test
     public void testM2Eclipse() throws IOException, ParseException, SAXException,
             URISyntaxException {
         RepoDescriptor site = loader.load(new URI(
@@ -72,12 +83,15 @@ public class UpdateSiteLoaderTest extends TestCase {
         assertTrue(CollectionUtils.toList(site.getModules()).size() > 20);
     }
 
-    public void _disabled_testHeliosEclipse() throws IOException, ParseException, SAXException,
+    @Ignore
+    @Test
+    public void testHeliosEclipse() throws IOException, ParseException, SAXException,
             URISyntaxException {
         RepoDescriptor site = loader.load(new URI("http://download.eclipse.org/releases/helios/"));
         assertTrue(CollectionUtils.toList(site.getModules()).size() > 900);
     }
 
+    @Test
     public void testComposite() throws Exception {
         RepoDescriptor site = loader.load(new File("test/test-p2/composite/").toURI());
         assertEquals(8, CollectionUtils.toList(site.getModules()).size());

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolverTest.java
@@ -37,10 +37,14 @@ import org.apache.ivy.core.search.OrganisationEntry;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.osgi.core.BundleInfo;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-public class UpdateSiteResolverTest extends TestCase {
+public class UpdateSiteResolverTest {
 
     private IvySettings settings;
 
@@ -52,6 +56,7 @@ public class UpdateSiteResolverTest extends TestCase {
 
     private ResolveData data;
 
+    @Before
     public void setUp() throws Exception {
         settings = new IvySettings();
 
@@ -73,13 +78,14 @@ public class UpdateSiteResolverTest extends TestCase {
 
         ivy.getResolutionCacheManager().clean();
         RepositoryCacheManager[] caches = settings.getRepositoryCacheManagers();
-        for (int i = 0; i < caches.length; i++) {
-            caches[i].clean();
+        for (RepositoryCacheManager cache : caches) {
+            cache.clean();
         }
 
         data = new ResolveData(ivy.getResolveEngine(), new ResolveOptions());
     }
 
+    @Test
     public void testListOrganization() throws Exception {
         OrganisationEntry[] orgs = resolver.listOrganisations();
         assertEquals(2, orgs.length);
@@ -89,6 +95,7 @@ public class UpdateSiteResolverTest extends TestCase {
                         .getOrganisation().equals(BundleInfo.BUNDLE_TYPE)));
     }
 
+    @Test
     public void testListModules() throws Exception {
         ModuleEntry[] modules = resolver.listModules(new OrganisationEntry(resolver,
                 BundleInfo.BUNDLE_TYPE));
@@ -129,6 +136,7 @@ public class UpdateSiteResolverTest extends TestCase {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testResolve() throws Exception {
         ModuleRevisionId mrid = ModuleRevisionId.newInstance(BundleInfo.BUNDLE_TYPE,
             "org.apache.ivy", "2.0.0.final_20090108225011");

--- a/test/java/org/apache/ivy/osgi/util/ParseUtilTest.java
+++ b/test/java/org/apache/ivy/osgi/util/ParseUtilTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.ivy.osgi.util;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class ParseUtilTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+public class ParseUtilTest {
+
+    @Test
     public void testParse() {
         final String[] result = ParseUtil.parseDelimitedString(
             "bravo;bundle-version=\"1.0.0\", delta;bundle-version=\"1.0.0\"", ",");

--- a/test/java/org/apache/ivy/osgi/util/VersionRangeTest.java
+++ b/test/java/org/apache/ivy/osgi/util/VersionRangeTest.java
@@ -17,10 +17,15 @@
  */
 package org.apache.ivy.osgi.util;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class VersionRangeTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+public class VersionRangeTest {
+
+    @Test
     public void testParse() throws Exception {
         assertEquals(new VersionRange(false, new Version("1.0.0"), false, null), new VersionRange(
                 "1.0.0"));
@@ -40,6 +45,7 @@ public class VersionRangeTest extends TestCase {
             new VersionRange("1.0.0.A"));
     }
 
+    @Test
     public void testContains() throws Exception {
         assertFalse(new VersionRange("1").contains("0.9"));
         assertTrue(new VersionRange("1").contains("1"));

--- a/test/java/org/apache/ivy/osgi/util/VersionTest.java
+++ b/test/java/org/apache/ivy/osgi/util/VersionTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.ivy.osgi.util;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class VersionTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+public class VersionTest {
+
+    @Test
     public void testParsing() throws Exception {
         Version v;
 
@@ -41,6 +45,7 @@ public class VersionTest extends TestCase {
         assertEquals("abc", v.qualifier());
     }
 
+    @Test
     public void testCompareTo() throws Exception {
         assertTrue(new Version("1.2.3").compareTo(new Version("1.2.3")) == 0);
 

--- a/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
@@ -20,27 +20,32 @@ package org.apache.ivy.plugins.circular;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class IgnoreCircularDependencyStrategyTest extends TestCase {
+public class IgnoreCircularDependencyStrategyTest {
     private CircularDependencyStrategy strategy;
 
     private MockMessageLogger mockMessageImpl;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         strategy = IgnoreCircularDependencyStrategy.getInstance();
 
         mockMessageImpl = new MockMessageLogger();
         Message.setDefaultLogger(mockMessageImpl);
     }
 
+    @Test
     public void testLog() throws Exception {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.0, #B;1.0"));
 
         mockMessageImpl.assertLogVerboseContains("circular dependency found: #A;1.0->#B;1.0");
     }
 
+    @Test
     public void testRemoveDuplicates() throws Exception {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));

--- a/test/java/org/apache/ivy/plugins/circular/WarnCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/WarnCircularDependencyStrategyTest.java
@@ -27,15 +27,18 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class WarnCircularDependencyStrategyTest extends TestCase {
+public class WarnCircularDependencyStrategyTest {
     private CircularDependencyStrategy strategy;
 
     private MockMessageLogger mockMessageImpl;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         strategy = WarnCircularDependencyStrategy.getInstance();
 
         resetLogger();
@@ -46,12 +49,14 @@ public class WarnCircularDependencyStrategyTest extends TestCase {
         Message.setDefaultLogger(mockMessageImpl);
     }
 
+    @Test
     public void testLog() throws Exception {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.0, #B;1.0"));
 
         mockMessageImpl.assertLogWarningContains("circular dependency found: #A;1.0->#B;1.0");
     }
 
+    @Test
     public void testRemoveDuplicates() throws Exception {
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
         strategy.handleCircularDependency(TestHelper.parseMridsToArray("#A;1.1, #B;1.0"));
@@ -60,6 +65,7 @@ public class WarnCircularDependencyStrategyTest extends TestCase {
         assertEquals(1, mockMessageImpl.getLogs().size());
     }
 
+    @Test
     public void testRemoveDuplicates2() throws Exception {
         setResolveContext("1");
         resetLogger();

--- a/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
@@ -25,23 +25,31 @@ import org.apache.ivy.TestFixture;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.report.ConfigurationResolveReport;
 import org.apache.ivy.core.report.ResolveReport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class LatestCompatibleConflictManagerTest extends TestCase {
+public class LatestCompatibleConflictManagerTest {
     private TestFixture fixture;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         fixture = new TestFixture();
         LatestCompatibleConflictManager cm = new LatestCompatibleConflictManager();
         fixture.getSettings().addConfigured(cm);
         fixture.getSettings().setDefaultConflictManager(cm);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         fixture.clean();
     }
 
+    @Test
     public void testInitFromSettings() throws Exception {
         Ivy ivy = new Ivy();
         ivy.configure(LatestCompatibleConflictManagerTest.class
@@ -50,12 +58,14 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         assertTrue(cm instanceof LatestCompatibleConflictManager);
     }
 
+    @Test
     public void testCompatibilityResolve1() throws Exception {
         fixture.addMD("#A;1-> { #B;1.4 #C;[2.0,2.5] }").addMD("#B;1.4->#D;1.5")
                 .addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5").addMD("#D;1.6").init();
         resolveAndAssert("#A;1", "#B;1.4, #C;2.5, #D;1.5");
     }
 
+    @Test
     public void testCompatibilityResolve2() throws Exception {
         fixture.addMD("#A;2-> { #B;[1.0,1.5] #C;[2.0,2.5] }").addMD("#B;1.4->#D;1.5")
                 .addMD("#B;1.5->#D;2.0").addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5")
@@ -63,6 +73,7 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;2", "#B;1.4, #C;2.5, #D;1.5");
     }
 
+    @Test
     public void testCompatibilityResolve3() throws Exception {
         fixture.addMD("#A;3-> { #B;[2.0,2.5] #C;[3.0,3.5] }").addMD("#B;2.3-> { #D;1.5 #E;1.0 }")
                 .addMD("#B;2.4-> { #D;1.5 #E;2.0 }").addMD("#B;2.5-> { #D;2.0 }")
@@ -72,6 +83,7 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;3", "#B;2.3, #C;3.4, #D;1.5, #E;1.0");
     }
 
+    @Test
     public void testCompatibilityResolve4() throws Exception {
         fixture.addMD("#A;4-> { #B;[1.0,1.5] #C;[2.0,2.5] #F;[1.0,1.1] }").addMD("#B;1.4->#D;1.5")
                 .addMD("#B;1.5->#D;2.0").addMD("#C;2.5->#D;[1.0,1.6]").addMD("#F;1.0->#D;1.5")
@@ -79,6 +91,7 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;4", "#B;1.4, #C;2.5, #D;1.5, #F;1.0");
     }
 
+    @Test
     public void testCompatibilityResolve5() throws Exception {
         fixture.addMD("#A;5->{ #B;[1.0,1.5] #C;2.6 }").addMD("#B;1.3->{ }").addMD("#B;1.4->#D;1.5")
                 .addMD("#B;1.5->#D;2.0").addMD("#C;2.6->#D;1.6").addMD("#D;1.5").addMD("#D;1.6")
@@ -86,12 +99,14 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;5", "#B;1.3, #C;2.6, #D;1.6");
     }
 
+    @Test
     public void testCompatibilityResolve6() throws Exception {
         fixture.addMD("#A;1-> { #C;[2.0,2.5] #B;1.4 }").addMD("#B;1.4->#D;1.5")
                 .addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5").addMD("#D;1.6").init();
         resolveAndAssert("#A;1", "#B;1.4, #C;2.5, #D;1.5");
     }
 
+    @Test
     public void testCompatibilityResolveCircularDependency1() throws Exception {
         fixture.addMD("#A;6->{ #B;[3.0,3.5] #C;4.6 }").addMD("#B;3.4->#D;2.5")
                 .addMD("#B;3.5->#D;3.0").addMD("#C;4.6->#D;2.5").addMD("#D;3.0->#B;3.5") // circular
@@ -101,6 +116,7 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;6", "#B;3.4, #C;4.6, #D;2.5");
     }
 
+    @Test
     public void testCompatibilityResolveCircularDependency2() throws Exception {
         fixture.addMD("#A;1->#C;2").addMD("#C;1->#B;1").addMD("#C;2->#B;2").addMD("#C;3->#B;3")
                 .addMD("#B;1->#C;latest.integration") // circular dependency
@@ -110,6 +126,7 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;1", "#B;2, #C;2");
     }
 
+    @Test
     public void testCompatibilityResolveCircularDependency3() throws Exception {
         // same as 2, but A depends on B
         fixture.addMD("#A;1->#B;2").addMD("#C;1->#B;1").addMD("#C;2->#B;2").addMD("#C;3->#B;3")
@@ -120,34 +137,28 @@ public class LatestCompatibleConflictManagerTest extends TestCase {
         resolveAndAssert("#A;1", "#B;2, #C;2");
     }
 
+    @Test(expected = StrictConflictException.class)
     public void testConflict() throws Exception {
-        try {
-            fixture.addMD("#A;conflict-> { #B;[1.5,1.6] #C;2.5 }").addMD("#B;1.5->#D;2.0")
-                    .addMD("#B;1.6->#D;2.0").addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5")
-                    .addMD("#D;1.6").addMD("#D;2.0").init();
-            fixture.resolve("#A;conflict");
+        fixture.addMD("#A;conflict-> { #B;[1.5,1.6] #C;2.5 }").addMD("#B;1.5->#D;2.0")
+                .addMD("#B;1.6->#D;2.0").addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5")
+                .addMD("#D;1.6").addMD("#D;2.0").init();
+        fixture.resolve("#A;conflict");
 
-            fail("Resolve should have failed with a conflict");
-        } catch (StrictConflictException e) {
-            // this is expected
-        }
+        fail("Resolve should have failed with a conflict");
     }
 
+    @Test(expected = StrictConflictException.class)
     public void testDynamicRootConflict() throws Exception {
-        try {
-            fixture.addMD("#A;conflict-> {#B;[1.2,2.0[ #C;pCC.main.+ #D;[1.5,1.7[ }")
-                    .addMD("#B;1.0.0->#D;[1.6.1,2.0[").addMD("#B;1.1.0->#D;[1.6.1,2.0[")
-                    .addMD("#B;pCC.main.0.0->#D;[1.6.1,2.0[")
-                    .addMD("#C;1.0.0-> {#B;[1.0,2.0[ #D;[1.6.0,1.7[ }")
-                    .addMD("#C;1.1.0-> {#B;[1.1,2.0[ #D;[1.6.0,1.7[ }")
-                    .addMD("#C;pCC.main.1.9-> {#B;pCC.main.+ #D;[1.6.0,1.7[ }").addMD("#D;1.6.1")
-                    .init();
-            fixture.resolve("#A;conflict");
+        fixture.addMD("#A;conflict-> {#B;[1.2,2.0[ #C;pCC.main.+ #D;[1.5,1.7[ }")
+                .addMD("#B;1.0.0->#D;[1.6.1,2.0[").addMD("#B;1.1.0->#D;[1.6.1,2.0[")
+                .addMD("#B;pCC.main.0.0->#D;[1.6.1,2.0[")
+                .addMD("#C;1.0.0-> {#B;[1.0,2.0[ #D;[1.6.0,1.7[ }")
+                .addMD("#C;1.1.0-> {#B;[1.1,2.0[ #D;[1.6.0,1.7[ }")
+                .addMD("#C;pCC.main.1.9-> {#B;pCC.main.+ #D;[1.6.0,1.7[ }").addMD("#D;1.6.1")
+                .init();
+        fixture.resolve("#A;conflict");
 
-            fail("Resolve should have failed with a conflict");
-        } catch (StrictConflictException e) {
-            // this is expected }
-        }
+        fail("Resolve should have failed with a conflict");
     }
 
     private void resolveAndAssert(String mrid, String expectedModuleSet) throws ParseException,

--- a/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
@@ -137,16 +137,24 @@ public class LatestCompatibleConflictManagerTest {
         resolveAndAssert("#A;1", "#B;2, #C;2");
     }
 
+    /**
+     * Resolve must fail with a conflict.
+     *
+     * @throws Exception
+     */
     @Test(expected = StrictConflictException.class)
     public void testConflict() throws Exception {
         fixture.addMD("#A;conflict-> { #B;[1.5,1.6] #C;2.5 }").addMD("#B;1.5->#D;2.0")
                 .addMD("#B;1.6->#D;2.0").addMD("#C;2.5->#D;[1.0,1.6]").addMD("#D;1.5")
                 .addMD("#D;1.6").addMD("#D;2.0").init();
         fixture.resolve("#A;conflict");
-
-        fail("Resolve should have failed with a conflict");
     }
 
+    /**
+     * Resolve must fail with a conflict.
+     *
+     * @throws Exception
+     */
     @Test(expected = StrictConflictException.class)
     public void testDynamicRootConflict() throws Exception {
         fixture.addMD("#A;conflict-> {#B;[1.2,2.0[ #C;pCC.main.+ #D;[1.5,1.7[ }")
@@ -157,8 +165,6 @@ public class LatestCompatibleConflictManagerTest {
                 .addMD("#C;pCC.main.1.9-> {#B;pCC.main.+ #D;[1.6.0,1.7[ }").addMD("#D;1.6.1")
                 .init();
         fixture.resolve("#A;conflict");
-
-        fail("Resolve should have failed with a conflict");
     }
 
     private void resolveAndAssert(String mrid, String expectedModuleSet) throws ParseException,

--- a/test/java/org/apache/ivy/plugins/conflict/LatestConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/LatestConflictManagerTest.java
@@ -28,27 +28,34 @@ import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.IvyNode;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-public class LatestConflictManagerTest extends TestCase {
+public class LatestConflictManagerTest {
 
     private Ivy ivy;
 
     private File _cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(LatestConflictManagerTest.class.getResource("ivysettings-latest.xml"));
         _cache = new File("build/cache");
         _cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(_cache);
     }
 
     // Test case for issue IVY-388
+    @Test
     public void testIvy388() throws Exception {
         ResolveReport report = ivy.resolve(
             LatestConflictManagerTest.class.getResource("ivy-388.xml"), getResolveOptions());
@@ -73,6 +80,7 @@ public class LatestConflictManagerTest extends TestCase {
     }
 
     // Test case for issue IVY-383
+    @Test
     public void testIvy383() throws Exception {
         ResolveReport report = ivy.resolve(
             LatestConflictManagerTest.class.getResource("ivy-383.xml"), getResolveOptions());
@@ -89,6 +97,7 @@ public class LatestConflictManagerTest extends TestCase {
     }
 
     // Test case for issue IVY-407
+    @Test
     public void testLatestTime1() throws Exception {
         ivy = new Ivy();
         ivy.configure(LatestConflictManagerTest.class.getResource("ivysettings-latest-time.xml"));
@@ -116,6 +125,7 @@ public class LatestConflictManagerTest extends TestCase {
         }
     }
 
+    @Test
     public void testLatestTime2() throws Exception {
         ivy = new Ivy();
         ivy.configure(LatestConflictManagerTest.class.getResource("ivysettings-latest-time.xml"));
@@ -150,6 +160,7 @@ public class LatestConflictManagerTest extends TestCase {
      * ok and publish D-1.0.0 5) E needs D-1.0.0 and A-1.0.0 (D before A in ivy file) retrieve
      * failed to get C-1.0.2 from A (get apparently C-1.0.1 from D)
      */
+    @Test
     public void testLatestTimeTransitivity() throws Exception {
         ivy = new Ivy();
         ivy.configure(LatestConflictManagerTest.class
@@ -203,6 +214,7 @@ public class LatestConflictManagerTest extends TestCase {
      *         MyCompany#C;1
      *             conflicting-dependency#dep;1
      */
+    @Test
     public void testEvictedModules() throws Exception {
         ivy.configure(LatestConflictManagerTest.class
                 .getResource("ivysettings-evicted.xml"));

--- a/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
@@ -22,25 +22,32 @@ import java.io.File;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class RegexpConflictManagerTest extends TestCase {
+public class RegexpConflictManagerTest {
     private Ivy ivy;
 
     private File _cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(RegexpConflictManagerTest.class.getResource("ivysettings-regexp-test.xml"));
         _cache = new File("build/cache");
         _cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(_cache);
     }
 
+    @Test
     public void testNoApiConflictResolve() throws Exception {
         try {
             ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-no-regexp-conflict.xml"),
@@ -50,6 +57,7 @@ public class RegexpConflictManagerTest extends TestCase {
         }
     }
 
+    @Test
     public void testConflictResolve() throws Exception {
         try {
             ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-conflict.xml"),
@@ -60,14 +68,12 @@ public class RegexpConflictManagerTest extends TestCase {
             // this is expected
             assertTrue(
                 "bad exception message: " + e.getMessage(),
-                e.getMessage().indexOf(
-                    "org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0])") != -1);
+                    e.getMessage().contains("org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0])"));
             assertTrue("bad exception message: " + e.getMessage(),
-                e.getMessage().indexOf("conflicts with") != -1);
+                    e.getMessage().contains("conflicts with"));
             assertTrue(
                 "bad exception message: " + e.getMessage(),
-                e.getMessage().indexOf(
-                    "org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])") != -1);
+                    e.getMessage().contains("org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])"));
         }
     }
 

--- a/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
@@ -24,7 +24,9 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.FileUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -33,6 +35,9 @@ public class RegexpConflictManagerTest {
     private Ivy ivy;
 
     private File _cache;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -59,22 +64,11 @@ public class RegexpConflictManagerTest {
 
     @Test
     public void testConflictResolve() throws Exception {
-        try {
-            ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-conflict.xml"),
-                getResolveOptions());
+        expExc.expect(StrictConflictException.class);
+        expExc.expectMessage("org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0]) conflicts with org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])");
 
-            fail("Resolve should have failed with a conflict");
-        } catch (StrictConflictException e) {
-            // this is expected
-            assertTrue(
-                "bad exception message: " + e.getMessage(),
-                    e.getMessage().contains("org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0])"));
-            assertTrue("bad exception message: " + e.getMessage(),
-                    e.getMessage().contains("conflicts with"));
-            assertTrue(
-                "bad exception message: " + e.getMessage(),
-                    e.getMessage().contains("org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])"));
-        }
+        ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-conflict.xml"),
+                getResolveOptions());
     }
 
     private ResolveOptions getResolveOptions() {

--- a/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
@@ -65,28 +65,26 @@ public class StrictConflictManagerTest {
             getResolveOptions());
     }
 
-    @Test
+    /**
+     * Resolve must fail with a conflict.
+     *
+     * @throws Exception
+     */
+    @Test(expected = StrictConflictException.class)
     public void testConflictResolve() throws Exception {
-        try {
-            ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict.xml"),
+        ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict.xml"),
                 getResolveOptions());
-
-            fail("Resolve should have failed with a conflict");
-        } catch (StrictConflictException e) {
-            // this is expected
-        }
     }
 
-    @Test
+    /**
+     * Resolve must fail with a conflict.
+     *
+     * @throws Exception
+     */
+    @Test(expected = StrictConflictException.class)
     public void testConflictWithDynamicRevisionResolve() throws Exception {
-        try {
-            ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict-dynamic.xml"),
+        ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict-dynamic.xml"),
                 getResolveOptions());
-
-            fail("Resolve should have failed with a conflict");
-        } catch (StrictConflictException e) {
-            // this is expected
-        }
     }
 
     private ResolveOptions getResolveOptions() {

--- a/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/StrictConflictManagerTest.java
@@ -22,40 +22,50 @@ import java.io.File;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class StrictConflictManagerTest extends TestCase {
+public class StrictConflictManagerTest {
     private Ivy ivy;
 
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(StrictConflictManagerTest.class.getResource("ivysettings-strict-test.xml"));
         cache = new File("build/cache");
         cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(cache);
     }
 
+    @Test
     public void testInitFromConf() throws Exception {
         ConflictManager cm = ivy.getSettings().getDefaultConflictManager();
         assertTrue(cm instanceof StrictConflictManager);
     }
 
+    @Test
     public void testNoConflictResolve() throws Exception {
         ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-noconflict.xml"),
             getResolveOptions());
     }
 
+    @Test
     public void testNoConflictWithDynamicRevisionResolve() throws Exception {
         ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-noconflict-dynamic.xml"),
             getResolveOptions());
     }
 
+    @Test
     public void testConflictResolve() throws Exception {
         try {
             ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict.xml"),
@@ -67,6 +77,7 @@ public class StrictConflictManagerTest extends TestCase {
         }
     }
 
+    @Test
     public void testConflictWithDynamicRevisionResolve() throws Exception {
         try {
             ivy.resolve(StrictConflictManagerTest.class.getResource("ivy-conflict-dynamic.xml"),

--- a/test/java/org/apache/ivy/plugins/latest/LatestRevisionStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/latest/LatestRevisionStrategyTest.java
@@ -17,15 +17,19 @@
  */
 package org.apache.ivy.plugins.latest;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class LatestRevisionStrategyTest extends TestCase {
+public class LatestRevisionStrategyTest {
+    @Test
     public void testComparator() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2a", "0.2_b", "0.2rc1", "0.2-final",
                 "1.0-dev1", "1.0-dev2", "1.0-alpha1", "1.0-alpha2", "1.0-beta1", "1.0-beta2",
@@ -37,6 +41,7 @@ public class LatestRevisionStrategyTest extends TestCase {
         assertEquals(Arrays.asList(revs), shuffled);
     }
 
+    @Test
     public void testSort() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2a", "0.2_b", "0.2rc1", "0.2-final",
                 "1.0-dev1", "1.0-dev2", "1.0-alpha1", "1.0-alpha2", "1.0-beta1", "1.0-beta2",
@@ -51,6 +56,7 @@ public class LatestRevisionStrategyTest extends TestCase {
         assertEquals(Arrays.asList(revs), sorted);
     }
 
+    @Test
     public void testFindLatest() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.2a", "0.2_b", "0.2rc1", "0.2-final",
                 "1.0-dev1", "1.0-dev2", "1.0-alpha1", "1.0-alpha2", "1.0-beta1", "1.0-beta2",
@@ -66,6 +72,7 @@ public class LatestRevisionStrategyTest extends TestCase {
         assertEquals("2.0", latest.getRevision());
     }
 
+    @Test
     public void testSpecialMeaningComparator() {
         ArtifactInfo[] revs = toMockAI(new String[] {"0.1", "0.2-pre", "0.2-dev", "0.2-rc1",
                 "0.2-final", "0.2-QA", "1.0-dev1"});

--- a/test/java/org/apache/ivy/plugins/lock/ArtifactLockStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/lock/ArtifactLockStrategyTest.java
@@ -37,18 +37,25 @@ import org.apache.ivy.plugins.resolver.FileSystemResolver;
 import org.apache.ivy.util.CopyProgressEvent;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class ArtifactLockStrategyTest extends TestCase {
-    protected void setUp() throws Exception {
+public class ArtifactLockStrategyTest {
+    @Before
+    public void setUp() {
         FileUtil.forceDelete(new File("build/test/cache"));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(new File("build/test/cache"));
     }
 
+    @Test
     public void testConcurrentResolve() throws Exception {
         // we use different settings because Ivy do not support multi thread resolve with the same
         // settings yet and this is not what this test is about: the focus of this test is running

--- a/test/java/org/apache/ivy/plugins/matcher/AbstractPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/AbstractPatternMatcherTest.java
@@ -77,13 +77,11 @@ public abstract class AbstractPatternMatcherTest {
     public void testNullInput() {
         Matcher matcher = patternMatcher.getMatcher("some expression");
         matcher.matches(null);
-        fail("Should fail for null input");
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullExpression() {
         patternMatcher.getMatcher(null);
-        fail("Should fail for null expression");
     }
 
     public abstract void testImplementation();

--- a/test/java/org/apache/ivy/plugins/matcher/AbstractPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/AbstractPatternMatcherTest.java
@@ -17,20 +17,23 @@
  */
 package org.apache.ivy.plugins.matcher;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Base test classes for PatternMatcher testcase implementation
  */
-public abstract class AbstractPatternMatcherTest extends TestCase {
+public abstract class AbstractPatternMatcherTest {
     protected PatternMatcher patternMatcher;
 
-    protected abstract void setUp() throws Exception;
-
+    // used by setUp() in subclasses
     protected void setUp(PatternMatcher matcher) {
         this.patternMatcher = matcher;
     }
 
+    @Test
     public void testAnyExpression() {
         Matcher matcher = patternMatcher.getMatcher("*");
         assertTrue(matcher.matches(""));
@@ -38,6 +41,7 @@ public abstract class AbstractPatternMatcherTest extends TestCase {
         assertTrue(matcher.matches("        "));
     }
 
+    @Test
     public void testIsExact() {
         // '*' is a special matcher
         Matcher matcher = patternMatcher.getMatcher("*");
@@ -69,27 +73,22 @@ public abstract class AbstractPatternMatcherTest extends TestCase {
 
     protected abstract String[] getInexactExpressions();
 
+    @Test(expected = NullPointerException.class)
     public void testNullInput() {
         Matcher matcher = patternMatcher.getMatcher("some expression");
-        try {
-            matcher.matches(null);
-            fail("Should fail for null input");
-        } catch (NullPointerException expected) {
-
-        }
+        matcher.matches(null);
+        fail("Should fail for null input");
     }
 
+    @Test(expected = NullPointerException.class)
     public void testNullExpression() {
-        try {
-            patternMatcher.getMatcher(null);
-            fail("Should fail for null expression");
-        } catch (NullPointerException expected) {
-
-        }
+        patternMatcher.getMatcher(null);
+        fail("Should fail for null expression");
     }
 
     public abstract void testImplementation();
 
+    @Test
     public void testLoadTestMatches() {
         Matcher matcher = patternMatcher.getMatcher("this.is.an.expression");
         String[] inputs = {"this.is.an.expression", "this:is:an:expression",
@@ -100,6 +99,7 @@ public abstract class AbstractPatternMatcherTest extends TestCase {
         }
     }
 
+    @Test
     public void testLoadTestGetMatcher() {
         String[] inputs = {"this.is.an.expression", "this:is:an:expression",
                 "this is an expression", "whatever this is", "maybe, maybe not"};

--- a/test/java/org/apache/ivy/plugins/matcher/ExactOrRegexpPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/ExactOrRegexpPatternMatcherTest.java
@@ -64,6 +64,5 @@ public class ExactOrRegexpPatternMatcherTest extends AbstractPatternMatcherTest 
         assertTrue(matcher.isExact());
 
         matcher = patternMatcher.getMatcher("(");
-        fail("Should fail on invalid regexp syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/matcher/ExactOrRegexpPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/ExactOrRegexpPatternMatcherTest.java
@@ -17,14 +17,22 @@
  */
 package org.apache.ivy.plugins.matcher;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.regex.PatternSyntaxException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
  */
 public class ExactOrRegexpPatternMatcherTest extends AbstractPatternMatcherTest {
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         setUp(new ExactOrRegexpPatternMatcher());
     }
 
@@ -36,6 +44,7 @@ public class ExactOrRegexpPatternMatcherTest extends AbstractPatternMatcherTest 
         return new String[] {"abc+", "12.3", "abc-123*", "abc_123\\d"};
     }
 
+    @Test(expected = PatternSyntaxException.class)
     public void testImplementation() {
         Matcher matcher = patternMatcher.getMatcher(".");
         assertFalse(matcher.isExact());
@@ -54,11 +63,7 @@ public class ExactOrRegexpPatternMatcherTest extends AbstractPatternMatcherTest 
         matcher = patternMatcher.getMatcher("abc-123_ABC");
         assertTrue(matcher.isExact());
 
-        try {
-            matcher = patternMatcher.getMatcher("(");
-            fail("Should fail on invalid regexp syntax");
-        } catch (PatternSyntaxException e) {
-
-        }
+        matcher = patternMatcher.getMatcher("(");
+        fail("Should fail on invalid regexp syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/matcher/ExactPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/ExactPatternMatcherTest.java
@@ -17,12 +17,19 @@
  */
 package org.apache.ivy.plugins.matcher;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @see ExactPatternMatcher
  */
 public class ExactPatternMatcherTest extends AbstractPatternMatcherTest {
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         setUp(new ExactPatternMatcher());
     }
 
@@ -34,6 +41,7 @@ public class ExactPatternMatcherTest extends AbstractPatternMatcherTest {
         return new String[0]; // there are no inexact expressions possible
     }
 
+    @Test
     public void testImplementation() {
         Matcher matcher = patternMatcher.getMatcher(".");
         assertFalse(matcher.matches(""));

--- a/test/java/org/apache/ivy/plugins/matcher/GlobPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/GlobPatternMatcherTest.java
@@ -17,14 +17,22 @@
  */
 package org.apache.ivy.plugins.matcher;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.regex.PatternSyntaxException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @see GlobPatternMatcher
  */
 public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         setUp(new GlobPatternMatcher());
     }
 
@@ -36,6 +44,7 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
         return new String[] {"abc*", "12?3", "abc[123]"};
     }
 
+    @Test
     public void testValidRegexpSyntaxAsNormalCharacter() {
         Matcher matcher = patternMatcher.getMatcher(".");
         assertTrue(matcher.isExact());
@@ -45,6 +54,7 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
         assertFalse(matcher.matches("aa"));
     }
 
+    @Test
     public void testRegexpSyntaxAndGlob() {
         Matcher matcher = patternMatcher.getMatcher(".*");
         assertFalse(matcher.isExact());
@@ -56,11 +66,13 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
         assertTrue(matcher.matches(".abcdef"));
     }
 
+    @Test
     public void testImplementation() {
         Matcher matcher = patternMatcher.getMatcher("abc-123_ABC");
         assertTrue(matcher.isExact());
     }
 
+    @Test
     public void testQuoteMeta() {
         Matcher matcher = patternMatcher.getMatcher("\\*");
         assertTrue(matcher.matches("*"));
@@ -68,11 +80,13 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
         assertFalse(matcher.matches("Xsfsdfsd"));
     }
 
+    @Test
     public void testInvalidRegexpSyntaxAsNormalCharacter() {
         Matcher matcher = patternMatcher.getMatcher("(");
         assertTrue(matcher.matches("("));
     }
 
+    @Test
     public void testGlob() {
         Matcher matcher = patternMatcher.getMatcher("*ivy*");
         assertTrue(matcher.matches("ivy"));
@@ -81,12 +95,9 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
         assertTrue(matcher.matches("abcdefivy"));
     }
 
+    @Test(expected = PatternSyntaxException.class)
     public void testInvalidSyntax() {
-        try {
-            patternMatcher.getMatcher("[");
-            fail("Should fail on invalid regexp syntax");
-        } catch (PatternSyntaxException e) {
-
-        }
+        patternMatcher.getMatcher("[");
+        fail("Should fail on invalid regexp syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/matcher/GlobPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/GlobPatternMatcherTest.java
@@ -98,6 +98,5 @@ public class GlobPatternMatcherTest extends AbstractPatternMatcherTest {
     @Test(expected = PatternSyntaxException.class)
     public void testInvalidSyntax() {
         patternMatcher.getMatcher("[");
-        fail("Should fail on invalid regexp syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/matcher/RegexpPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/RegexpPatternMatcherTest.java
@@ -17,14 +17,21 @@
  */
 package org.apache.ivy.plugins.matcher;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.regex.PatternSyntaxException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @see RegexpPatternMatcher
  */
 public class RegexpPatternMatcherTest extends AbstractPatternMatcherTest {
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         setUp(new RegexpPatternMatcher());
     }
 
@@ -36,6 +43,7 @@ public class RegexpPatternMatcherTest extends AbstractPatternMatcherTest {
         return new String[] {"abc+", "12.3", "abc-123*", "abc_123\\d"};
     }
 
+    @Test(expected = PatternSyntaxException.class)
     public void testImplementation() {
         Matcher matcher = patternMatcher.getMatcher(".*");
         assertTrue(matcher.matches(".*"));
@@ -43,11 +51,7 @@ public class RegexpPatternMatcherTest extends AbstractPatternMatcherTest {
         assertTrue(matcher.matches("a"));
         assertTrue(matcher.matches("aa"));
 
-        try {
-            matcher = patternMatcher.getMatcher("(");
-            fail("Should fail on invalid syntax");
-        } catch (PatternSyntaxException e) {
-
-        }
+        matcher = patternMatcher.getMatcher("(");
+        fail("Should fail on invalid syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/matcher/RegexpPatternMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/matcher/RegexpPatternMatcherTest.java
@@ -52,6 +52,5 @@ public class RegexpPatternMatcherTest extends AbstractPatternMatcherTest {
         assertTrue(matcher.matches("aa"));
 
         matcher = patternMatcher.getMatcher("(");
-        fail("Should fail on invalid syntax");
     }
 }

--- a/test/java/org/apache/ivy/plugins/namespace/MRIDTransformationRuleTest.java
+++ b/test/java/org/apache/ivy/plugins/namespace/MRIDTransformationRuleTest.java
@@ -18,11 +18,13 @@
 package org.apache.ivy.plugins.namespace;
 
 import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class MRIDTransformationRuleTest extends TestCase {
+public class MRIDTransformationRuleTest {
 
+    @Test
     public void testTransformation() {
         MRIDTransformationRule r = new MRIDTransformationRule();
         r.addSrc(new MRIDRule("apache", "commons.+", null));

--- a/test/java/org/apache/ivy/plugins/namespace/NameSpaceHelperTest.java
+++ b/test/java/org/apache/ivy/plugins/namespace/NameSpaceHelperTest.java
@@ -24,10 +24,12 @@ import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.core.module.descriptor.DefaultArtifact;
 import org.apache.ivy.core.module.id.ArtifactRevisionId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class NameSpaceHelperTest extends TestCase {
+public class NameSpaceHelperTest {
+    @Test
     public void testTransformArtifactWithExtraAttributes() throws Exception {
         Artifact artifact = new DefaultArtifact(ArtifactRevisionId.newInstance(
             ModuleRevisionId.parse("org.apache#test;1.0"), "test", "jar", "jar",

--- a/test/java/org/apache/ivy/plugins/parser/AbstractModuleDescriptorParserTester.java
+++ b/test/java/org/apache/ivy/plugins/parser/AbstractModuleDescriptorParserTester.java
@@ -28,15 +28,17 @@ import org.apache.ivy.core.module.descriptor.ExcludeRule;
 import org.apache.ivy.core.module.descriptor.IncludeRule;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-public abstract class AbstractModuleDescriptorParserTester extends TestCase {
+public abstract class AbstractModuleDescriptorParserTester {
     protected DependencyDescriptor getDependency(DependencyDescriptor[] dependencies, String name) {
-        for (int i = 0; i < dependencies.length; i++) {
-            assertNotNull(dependencies[i]);
-            assertNotNull(dependencies[i].getDependencyId());
-            if (name.equals(dependencies[i].getDependencyId().getName())) {
-                return dependencies[i];
+        for (DependencyDescriptor dependency : dependencies) {
+            assertNotNull(dependency);
+            assertNotNull(dependency.getDependencyId());
+            if (name.equals(dependency.getDependencyId().getName())) {
+                return dependency;
             }
         }
         return null;
@@ -45,16 +47,16 @@ public abstract class AbstractModuleDescriptorParserTester extends TestCase {
     protected void assertArtifacts(Artifact[] artifacts, String[] artifactsNames) {
         assertNotNull(artifacts);
         assertEquals(artifactsNames.length, artifacts.length);
-        for (int i = 0; i < artifactsNames.length; i++) {
+        for (String artifactsName : artifactsNames) {
             boolean found = false;
-            for (int j = 0; j < artifacts.length; j++) {
-                assertNotNull(artifacts[j]);
-                if (artifacts[j].getName().equals(artifactsNames[i])) {
+            for (Artifact artifact : artifacts) {
+                assertNotNull(artifact);
+                if (artifact.getName().equals(artifactsName)) {
                     found = true;
                     break;
                 }
             }
-            assertTrue("artifact not found: " + artifactsNames[i], found);
+            assertTrue("artifact not found: " + artifactsName, found);
         }
     }
 
@@ -63,16 +65,16 @@ public abstract class AbstractModuleDescriptorParserTester extends TestCase {
         DependencyArtifactDescriptor[] dads = dd.getDependencyArtifacts(confs);
         assertNotNull(dads);
         assertEquals(artifactsNames.length, dads.length);
-        for (int i = 0; i < artifactsNames.length; i++) {
+        for (String artifactsName : artifactsNames) {
             boolean found = false;
-            for (int j = 0; j < dads.length; j++) {
-                assertNotNull(dads[j]);
-                if (dads[j].getName().equals(artifactsNames[i])) {
+            for (DependencyArtifactDescriptor dad : dads) {
+                assertNotNull(dad);
+                if (dad.getName().equals(artifactsName)) {
                     found = true;
                     break;
                 }
             }
-            assertTrue("dependency artifact not found: " + artifactsNames[i], found);
+            assertTrue("dependency artifact not found: " + artifactsName, found);
         }
     }
 
@@ -81,16 +83,16 @@ public abstract class AbstractModuleDescriptorParserTester extends TestCase {
         IncludeRule[] dads = dd.getIncludeRules(confs);
         assertNotNull(dads);
         assertEquals(artifactsNames.length, dads.length);
-        for (int i = 0; i < artifactsNames.length; i++) {
+        for (String artifactsName : artifactsNames) {
             boolean found = false;
-            for (int j = 0; j < dads.length; j++) {
-                assertNotNull(dads[j]);
-                if (dads[j].getId().getName().equals(artifactsNames[i])) {
+            for (IncludeRule dad : dads) {
+                assertNotNull(dad);
+                if (dad.getId().getName().equals(artifactsName)) {
                     found = true;
                     break;
                 }
             }
-            assertTrue("dependency include not found: " + artifactsNames[i], found);
+            assertTrue("dependency include not found: " + artifactsName, found);
         }
     }
 
@@ -99,16 +101,16 @@ public abstract class AbstractModuleDescriptorParserTester extends TestCase {
         ExcludeRule[] rules = dd.getExcludeRules(confs);
         assertNotNull(rules);
         assertEquals(artifactsNames.length, rules.length);
-        for (int i = 0; i < artifactsNames.length; i++) {
+        for (String artifactsName : artifactsNames) {
             boolean found = false;
-            for (int j = 0; j < rules.length; j++) {
-                assertNotNull(rules[j]);
-                if (rules[j].getId().getName().equals(artifactsNames[i])) {
+            for (ExcludeRule rule : rules) {
+                assertNotNull(rule);
+                if (rule.getId().getName().equals(artifactsName)) {
                     found = true;
                     break;
                 }
             }
-            assertTrue("dependency exclude not found: " + artifactsNames[i], found);
+            assertTrue("dependency exclude not found: " + artifactsName, found);
         }
     }
 
@@ -117,16 +119,16 @@ public abstract class AbstractModuleDescriptorParserTester extends TestCase {
         ExcludeRule[] rules = dd.getExcludeRules(confs);
         assertNotNull(rules);
         assertEquals(moduleNames.length, rules.length);
-        for (int i = 0; i < moduleNames.length; i++) {
+        for (String moduleName : moduleNames) {
             boolean found = false;
-            for (int j = 0; j < rules.length; j++) {
-                assertNotNull(rules[j]);
-                if (rules[j].getId().getModuleId().getName().equals(moduleNames[i])) {
+            for (ExcludeRule rule : rules) {
+                assertNotNull(rule);
+                if (rule.getId().getModuleId().getName().equals(moduleName)) {
                     found = true;
                     break;
                 }
             }
-            assertTrue("dependency module exclude not found: " + moduleNames[i], found);
+            assertTrue("dependency module exclude not found: " + moduleName, found);
         }
     }
 

--- a/test/java/org/apache/ivy/plugins/parser/ModuleDescriptorParserRegistryTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/ModuleDescriptorParserRegistryTest.java
@@ -28,10 +28,12 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.repository.Resource;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class ModuleDescriptorParserRegistryTest extends TestCase {
+public class ModuleDescriptorParserRegistryTest {
     public static class MyParser extends AbstractModuleDescriptorParser {
         public ModuleDescriptor parseDescriptor(ParserSettings ivy, URL descriptorURL,
                 Resource res, boolean validate) throws ParseException, IOException {
@@ -49,6 +51,7 @@ public class ModuleDescriptorParserRegistryTest extends TestCase {
 
     }
 
+    @Test
     public void testAddConfigured() throws Exception {
         IvySettings settings = new IvySettings();
         settings.addConfigured(new MyParser());

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -44,14 +44,16 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParserTest;
 import org.apache.ivy.plugins.repository.url.URLResource;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.MockResolver;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
-    // junit test -- DO NOT REMOVE used by ant to know it's a junit test
 
     private IvySettings settings = new IvySettings();
 
@@ -71,6 +73,9 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     private File dest = new File("build/test/test-write.xml");
 
     private MockResolver mockedResolver = new MockedDependencyResolver();
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -201,13 +206,11 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
     @Test
     public void testParentNotFound() throws Exception {
-        try {
-            PomModuleDescriptorParser.getInstance().parseDescriptor(new IvySettings(),
+        expExc.expect(IOException.class);
+        expExc.expectMessage("Impossible to load parent");
+
+        PomModuleDescriptorParser.getInstance().parseDescriptor(new IvySettings(),
                 getClass().getResource("test-parent-not-found.pom"), false);
-            fail("IOException should have been thrown!");
-        } catch (IOException e) {
-            assertTrue(e.getMessage().contains("Impossible to load parent"));
-        }
     }
 
     @Test

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -44,6 +44,11 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParserTest;
 import org.apache.ivy.plugins.repository.url.URLResource;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.MockResolver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
     // junit test -- DO NOT REMOVE used by ant to know it's a junit test
@@ -55,8 +60,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
                 throws ParseException {
             // TODO make it a real mock and check that dd and data are the one that are expected
             final ModuleDescriptor moduleDesc = getModuleDescriptor(dd);
-            ResolvedModuleRevision r = new ResolvedModuleRevision(this, this, moduleDesc, null);
-            return r;
+            return new ResolvedModuleRevision(this, this, moduleDesc, null);
         }
 
         protected ModuleDescriptor getModuleDescriptor(final DependencyDescriptor dependencyDescriptor) {
@@ -68,9 +72,9 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
 
     private MockResolver mockedResolver = new MockedDependencyResolver();
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings.setDictatorResolver(mockedResolver);
-        super.setUp();
         if (dest.exists()) {
             dest.delete();
         }
@@ -79,12 +83,14 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         }
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         if (dest.exists()) {
             dest.delete();
         }
     }
 
+    @Test
     public void testAccept() throws Exception {
         assertTrue(PomModuleDescriptorParser.getInstance().accept(
             new URLResource(getClass().getResource("test-simple.pom"))));
@@ -92,6 +98,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             new URLResource(XmlModuleDescriptorParserTest.class.getResource("test.xml"))));
     }
 
+    @Test
     public void testSimple() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-simple.pom"), false);
@@ -112,6 +119,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifact[0].getType());
     }
 
+    @Test
     public void testLargePom() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-large-pom.pom"), false);
@@ -121,6 +129,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(mrid, md.getModuleRevisionId());
     }
 
+    @Test
     public void testPackaging() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-packaging.pom"), false);
@@ -137,6 +146,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("war", artifact[0].getType());
     }
 
+    @Test
     public void testEjbPackaging() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-ejb-packaging.pom"), false);
@@ -153,6 +163,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("ejb", artifact[0].getType());
     }
 
+    @Test
     public void testEjbType() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-ejb-type.pom"), false);
@@ -173,6 +184,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("ejb", artifacts[0].getType());
     }
 
+    @Test
     public void testParent() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-parent.pom"), false);
@@ -187,16 +199,18 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("test", artifact[0].getName());
     }
 
+    @Test
     public void testParentNotFound() throws Exception {
         try {
             PomModuleDescriptorParser.getInstance().parseDescriptor(new IvySettings(),
                 getClass().getResource("test-parent-not-found.pom"), false);
             fail("IOException should have been thrown!");
         } catch (IOException e) {
-            assertTrue(e.getMessage().indexOf("Impossible to load parent") != -1);
+            assertTrue(e.getMessage().contains("Impossible to load parent"));
         }
     }
 
+    @Test
     public void testParent2() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-parent2.pom"), false);
@@ -211,6 +225,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("test", artifact[0].getName());
     }
 
+    @Test
     public void testParentVersion() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-parent.version.pom"), false);
@@ -225,6 +240,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("test", artifact[0].getName());
     }
 
+    @Test
     public void testParentGroupId() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-parent.groupid.pom"), false);
@@ -239,6 +255,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("test", artifact[0].getName());
     }
 
+    @Test
     public void testProjectParentVersion() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-project.parent.version.pom"), false);
@@ -253,6 +270,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("test", artifact[0].getName());
     }
 
+    @Test
     public void testDependencies() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencies.pom"), false);
@@ -270,6 +288,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getAllDependencyArtifacts().length);
     }
 
+    @Test
     public void testDependenciesWithClassifier() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencies-with-classifier.pom"), true);
@@ -307,6 +326,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(extraAtt, dds[0].getAllDependencyArtifacts()[0].getExtraAttributes());
     }
 
+    @Test
     public void testDependenciesWithType() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencies-with-type.pom"), true);
@@ -325,6 +345,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("dll", dds[0].getAllDependencyArtifacts()[0].getType());
     }
 
+    @Test
     public void testWithVersionPropertyAndPropertiesTag() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-version.pom"), false);
@@ -340,6 +361,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     }
 
     // IVY-392
+    @Test
     public void testDependenciesWithInactiveProfile() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencies-with-profile.pom"), false);
@@ -355,6 +377,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testWithoutVersion() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-without-version.pom"), false);
@@ -369,6 +392,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testProperties() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-properties.pom"), false);
@@ -384,6 +408,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testReal() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("commons-lang-1.0.pom"), false);
@@ -399,6 +424,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testReal2() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("wicket-1.3-incubating-SNAPSHOT.pom"), false);
@@ -409,6 +435,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             md.getModuleRevisionId());
     }
 
+    @Test
     public void testVariables() throws Exception {
         // test case for IVY-425
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -426,6 +453,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[10].getDependencyRevisionId());
     }
 
+    @Test
     public void testDependenciesInProfile() throws Exception {
         // test case for IVY-423
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -437,6 +465,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             md.getModuleRevisionId());
     }
 
+    @Test
     public void testIVY424() throws Exception {
         // test case for IVY-424
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -448,6 +477,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             md.getModuleRevisionId());
     }
 
+    @Test
     public void testOptional() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-optional.pom"), false);
@@ -488,6 +518,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             new HashSet(Arrays.asList(dds[2].getDependencyConfigurations("runtime"))));
     }
 
+    @Test
     public void testDependenciesWithScope() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -526,6 +557,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             new HashSet(Arrays.asList(dds[2].getDependencyConfigurations("runtime"))));
     }
 
+    @Test
     public void testExclusion() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-exclusion.pom"), false);
@@ -582,6 +614,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertFalse("Dependency  " + excludeAllTransitiveDepsDescriptor + " was expected to have transitive=false", excludeAllTransitiveDepsDescriptor.isTransitive());
     }
 
+    @Test
     public void testWithPlugins() throws Exception {
         // test case for IVY-417
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -596,6 +629,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, dds.length);
     }
 
+    @Test
     public void testHomeAndDescription() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("mule-1.3.3.pom"), false);
@@ -613,6 +647,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
                     .replaceAll("\r\n", "\n").replace('\r', '\n'));
     }
 
+    @Test
     public void testLicense() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("spring-hibernate3-2.0.2.pom"), false);
@@ -625,11 +660,12 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     }
 
     /**
-     * Tests that if a module doesn't have a license specified, then parent pom's license (if any) is used for the child
-     * module
+     * Tests that if a module doesn't have a license specified, then parent pom's license (if any)
+     * is used for the child module
      *
      * @throws Exception
      */
+    @Test
     public void testLicenseFromParent() throws Exception {
         final IvySettings customIvySettings = createIvySettingsForParentLicenseTesting("test-parent-with-licenses.pom",
                 "org.apache", "test-ivy-license-parent");
@@ -645,11 +681,12 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     }
 
     /**
-     * Tests that if a project explicitly specifies the licenses, then the licenses (if any) from its parent pom
-     * aren't applied to the child project
+     * Tests that if a project explicitly specifies the licenses, then the licenses (if any) from
+     * its parent pom aren't applied to the child project
      *
      * @throws Exception
      */
+    @Test
     public void testOverriddenLicense() throws Exception {
         final IvySettings customIvySettings = createIvySettingsForParentLicenseTesting("test-parent-with-licenses.pom",
                 "org.apache", "test-ivy-license-parent");
@@ -664,8 +701,8 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("Unexpected license URL", "http://www.apache.org/licenses/LICENSE-2.0.txt", licenses[0].getUrl());
     }
 
-
-    public void testDependencyManagment() throws ParseException, IOException {
+    @Test
+    public void testDependencyManagement() throws ParseException, IOException {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencyMgt.pom"), false);
         assertNotNull(md);
@@ -682,7 +719,8 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(4, md.getExtraInfos().size());
     }
 
-    public void testDependencyManagmentWithScope() throws ParseException, IOException {
+    @Test
+    public void testDependencyManagementWithScope() throws ParseException, IOException {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-dependencyMgt-with-scope.pom"), false);
         assertNotNull(md);
@@ -701,6 +739,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("The configuration must be test", "test", dds[0].getModuleConfigurations()[0]);
     }
 
+    @Test
     public void testParentDependencyMgt() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -740,7 +779,9 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jms", excludes[1].getId().getModuleId().getName());
     }
 
-    public void testOverrideParentVersionPropertyDependencyMgt() throws ParseException, IOException {
+    @Test
+    public void testOverrideParentVersionPropertyDependencyMgt()
+            throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
                     throws ParseException {
@@ -780,6 +821,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jms", excludes[1].getId().getModuleId().getName());
     }
 
+    @Test
     public void testParentProperties() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -810,6 +852,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
                                               // parent
     }
 
+    @Test
     public void testOverrideParentProperties() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -838,6 +881,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testOverrideGrandparentProperties() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -873,12 +917,14 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[2].getDependencyRevisionId());
     }
 
+    @Test
     public void testPomWithEntity() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-entity.pom"), true);
         assertNotNull(md);
     }
 
+    @Test
     public void testModel() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-model.pom"), false);
@@ -899,6 +945,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifact[0].getType());
     }
 
+    @Test
     public void testParentBomImport() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -928,6 +975,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[0].getDependencyRevisionId());
     }
 
+    @Test
     public void testGrandparentBomImport() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)
@@ -960,6 +1008,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             dds[1].getDependencyRevisionId());
     }
 
+    @Test
     public void testParentProfileBomImport() throws ParseException, IOException {
         settings.setDictatorResolver(new MockResolver() {
             public ResolvedModuleRevision getDependency(DependencyDescriptor dd, ResolveData data)

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorWriterTest.java
@@ -27,10 +27,14 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.ModuleDescriptorParserRegistry;
 import org.apache.ivy.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class PomModuleDescriptorWriterTest extends TestCase {
+public class PomModuleDescriptorWriterTest {
     private static String LICENSE;
     static {
         try {
@@ -43,6 +47,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
 
     private File _dest = new File("build/test/test-write.xml");
 
+    @Test
     public void testSimple() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-simple.pom"), false);
@@ -56,6 +61,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testSimpleDependencies() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies.pom"), false);
@@ -69,6 +75,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testDependenciesWithScope() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -82,6 +89,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testDependenciesWithType() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-type.pom"), false);
@@ -95,6 +103,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testDependenciesWithClassifier() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-classifier.pom"),
@@ -109,6 +118,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testOptional() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-optional.pom"), false);
@@ -122,6 +132,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testTransitive() throws Exception {
         ModuleDescriptor md = ModuleDescriptorParserRegistry.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-transitive.xml"), false);
@@ -136,6 +147,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testPackaging() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-packaging.pom"), false);
@@ -149,6 +161,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testWriteCompileConfigurationOnly() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -163,6 +176,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testWriteRuntimeConfigurationOnly() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -177,6 +191,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testWriteAllConfiguration() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -190,6 +205,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testWriteAllExceptRuntimeConfiguration() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), getClass().getResource("test-dependencies-with-scope.pom"), false);
@@ -213,6 +229,7 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         return (new PomWriterOptions()).setLicenseHeader(LICENSE).setPrintIvyInfo(false);
     }
 
+    @Before
     public void setUp() {
         if (_dest.exists()) {
             _dest.delete();
@@ -222,7 +239,8 @@ public class PomModuleDescriptorWriterTest extends TestCase {
         }
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         if (_dest.exists()) {
             _dest.delete();
         }

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
@@ -52,12 +52,16 @@ import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.XMLHelper;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
 public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
     private IvySettings settings = null;
 
-    protected void setUp() throws Exception {
-        super.setUp();
-
+    @Before
+    public void setUp() {
         Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_WARN));
 
         this.settings = new IvySettings();
@@ -65,6 +69,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         settings.setDefaultCache(new File("build/cache"));
     }
 
+    @Test
     public void testSimple() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-simple.xml"), true);
@@ -87,6 +92,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, md.getDependencies().length);
     }
 
+    @Test
     public void testNamespaces() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-namespaces.xml"), true);
@@ -102,6 +108,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("http://ant.apache.org/ivy/extra", md.getExtraAttributesNamespaces().get("e"));
     }
 
+    @Test
     public void testEmptyDependencies() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-empty-dependencies.xml"), true);
@@ -124,6 +131,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, md.getDependencies().length);
     }
 
+    @Test
     public void testBad() throws IOException {
         try {
             XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -132,11 +140,13 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         } catch (ParseException ex) {
             if (XMLHelper.canUseSchemaValidation()) {
                 assertTrue("exception message not explicit. It should contain 'modul', but it's:"
-                        + ex.getMessage(), ex.getMessage().indexOf("'modul'") != -1);
+                        + ex.getMessage(),
+                    ex.getMessage().contains("'modul'"));
             }
         }
     }
 
+    @Test
     public void testBadOrg() throws IOException {
         try {
             XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -147,11 +157,12 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         } catch (ParseException ex) {
             if (XMLHelper.canUseSchemaValidation()) {
                 assertTrue("invalid exception: " + ex.getMessage(),
-                    ex.getMessage().indexOf("organization") != -1);
+                    ex.getMessage().contains("organization"));
             }
         }
     }
 
+    @Test
     public void testBadConfs() throws IOException {
         try {
             XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -160,10 +171,11 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         } catch (ParseException ex) {
             ex.printStackTrace();
             assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().indexOf("invalidConf") != -1);
+                ex.getMessage().contains("invalidConf"));
         }
     }
 
+    @Test
     public void testCyclicConfs() throws IOException {
         try {
             XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -171,7 +183,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             fail("bad ivy file raised no error");
         } catch (ParseException ex) {
             assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().indexOf("A => B => A") != -1);
+                ex.getMessage().contains("A => B => A"));
         }
         try {
             XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -179,25 +191,25 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             fail("bad ivy file raised no error");
         } catch (ParseException ex) {
             assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().indexOf("A => C => B => A") != -1);
+                ex.getMessage().contains("A => C => B => A"));
         }
     }
 
+    @Test
     public void testNoValidate() throws IOException, ParseException {
         XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-novalidate.xml"), false);
     }
 
-    public void testBadVersion() throws IOException {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    @Test(expected = ParseException.class)
+    public void testBadVersion() throws IOException, ParseException {
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-bad-version.xml"), true);
-            fail("bad version ivy file raised no error");
-        } catch (ParseException ex) {
-            // ok
-        }
+        fail("bad version ivy file raised no error");
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
     public void testFull() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test.xml"), true);
@@ -491,6 +503,8 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(rules[1].getConfigurations()));
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
     public void testFullNoValidation() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test.xml"), false);
@@ -499,6 +513,8 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("56576", md.getExtraInfo().get("e:someExtra"));
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
     public void testExtraInfos() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-extrainfo.xml"), true);
@@ -520,6 +536,8 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, secondExtraInfoElement.getNestedExtraInfoHolder().size());
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
     public void testExtraInfosNested() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-extrainfo-nested.xml"), true);
@@ -555,6 +573,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, yetAnotherExtraInfoElement.getNestedExtraInfoHolder().size());
     }
 
+    @Test
     public void testBug60() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-bug60.xml"), true);
@@ -572,6 +591,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertArtifacts(md.getArtifacts("default"), new String[] {"myartifact1", "myartifact2"});
     }
 
+    @Test
     public void testNoArtifact() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-noartifact.xml"), true);
@@ -592,6 +612,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(0, md.getDependencies().length);
     }
 
+    @Test
     public void testNoPublication() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-nopublication.xml"), true);
@@ -614,6 +635,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(1, md.getDependencies().length);
     }
 
+    @Test
     public void testArtifactsDefaults() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-artifacts-defaults.xml"), true);
@@ -632,6 +654,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
                 + "/" + artifact.getExt());
     }
 
+    @Test
     public void testDefaultConfWithDefaultConfMapping() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-defaultconf-withdefaultconfmapping.xml"), true);
@@ -662,6 +685,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("test")));
     }
 
+    @Test
     public void testDefaultConf() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-defaultconf.xml"), true);
@@ -691,6 +715,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("default")));
     }
 
+    @Test
     public void testDefaultConf2() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-defaultconf2.xml"), true);
@@ -723,6 +748,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("test")));
     }
 
+    @Test
     public void testPublicationDefaultConf() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-publication-defaultconf.xml"), true);
@@ -741,6 +767,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(1, artifacts.length);
     }
 
+    @Test
     public void testDefaultConfMapping() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-defaultconfmapping.xml"), true);
@@ -772,6 +799,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("test")));
     }
 
+   @Test
     public void testExtraAttributes() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
             getClass().getResource("test-extra-attributes.xml"), false);
@@ -800,6 +828,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("depextravalue", dd.getDependencyRevisionId().getAttribute("depextra"));
     }
 
+    @Test
     public void testImportConfigurations1() throws Exception {
         // import configurations
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -832,6 +861,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("conf1")));
     }
 
+    @Test
     public void testImportConfigurations2() throws Exception {
         // import configurations and add another one
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -867,6 +897,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("conf3")));
     }
 
+    @Test
     public void testImportConfigurations3() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -901,6 +932,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("conf1")));
     }
 
+    @Test
     public void testImportConfigurations5() throws Exception {
         // import configurations
         settings.setVariable("base.dir", new File(".").getAbsolutePath());
@@ -934,6 +966,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("conf1")));
     }
 
+    @Test
     public void testExtendOtherConfigs() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -949,6 +982,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(Arrays.asList(new String[] {"default", "test"}), Arrays.asList(allPublicExt));
     }
 
+    @Test
     public void testImportConfigurationsWithExtendOtherConfigs() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -965,6 +999,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(allPublicExt));
     }
 
+    @Test
     public void testImportConfigurationsWithMappingOverride() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -993,6 +1028,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("conf2")));
     }
 
+    @Test
     public void testImportConfigurationsWithWildcardAndMappingOverride() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1021,6 +1057,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("all-public")));
     }
 
+    @Test
     public void testDefaultConfMappingWithSelectors() throws Exception {
         // import configurations and default mapping
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1052,38 +1089,30 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("bla")));
     }
 
+    // IVY-442
+    @Test(expected = ParseException.class)
     public void testWithNonExistingConfigInDependency() throws Exception {
-        // IVY-442
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf1.xml"), true);
-            fail("ParseException hasn't been thrown");
-        } catch (ParseException e) {
-            // expected
-        }
+        fail("ParseException hasn't been thrown");
     }
 
+    @Test(expected = ParseException.class)
     public void testWithNonExistingConfigInPublications() throws Exception {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf2.xml"), true);
-            fail("ParseException hasn't been thrown");
-        } catch (ParseException e) {
-            // expected
-        }
+        fail("ParseException hasn't been thrown");
     }
 
+    // IVY-441
+    @Test(expected = ParseException.class)
     public void testWithExistingConfigsInPublicationsSeparatedBySemiColon() throws Exception {
-        // IVY-441
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf3.xml"), true);
-            fail("ParseException hasn't been thrown");
-        } catch (ParseException e) {
-            // expected
-        }
+        fail("ParseException hasn't been thrown");
     }
 
+    @Test
     public void testExtendsAll() throws Exception {
         Message.setDefaultLogger(new DefaultMessageLogger(99));
 
@@ -1133,6 +1162,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsDependencies() throws Exception {
         // descriptor specifies that only parent dependencies should be included
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1179,6 +1209,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsConfigurations() throws Exception {
         // descriptor specifies that only parent configurations should be included
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1219,6 +1250,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsDescription() throws Exception {
         // descriptor specifies that only parent description should be included
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1258,6 +1290,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsDescriptionWithOverride() throws Exception {
         // descriptor specifies that only parent description should be included
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1297,6 +1330,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsMixed() throws Exception {
         // descriptor specifies that parent configurations and dependencies should be included
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
@@ -1344,6 +1378,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals("jar", artifacts[0].getType());
     }
 
+    @Test
     public void testExtendsCached() throws Exception {
         // configure a resolver to serve the parent descriptor, so that parse succeeds.
         File resolveRoot = new File("build/tmp/xmlModuleDescriptorTest");

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
@@ -53,12 +53,17 @@ import org.apache.ivy.util.Message;
 import org.apache.ivy.util.XMLHelper;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
     private IvySettings settings = null;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -132,67 +137,52 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     }
 
     @Test
-    public void testBad() throws IOException {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    public void testBad() throws IOException, ParseException {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("'modul'");
+
+        assertTrue(XMLHelper.canUseSchemaValidation());
+
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-bad.xml"), true);
-            fail("bad ivy file raised no error");
-        } catch (ParseException ex) {
-            if (XMLHelper.canUseSchemaValidation()) {
-                assertTrue("exception message not explicit. It should contain 'modul', but it's:"
-                        + ex.getMessage(),
-                    ex.getMessage().contains("'modul'"));
-            }
-        }
     }
 
     @Test
-    public void testBadOrg() throws IOException {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    public void testBadOrg() throws IOException, ParseException {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("organization");
+
+        assertTrue(XMLHelper.canUseSchemaValidation());
+
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-bad-org.xml"), true);
-            if (XMLHelper.canUseSchemaValidation()) {
-                fail("bad ivy file raised no error");
-            }
-        } catch (ParseException ex) {
-            if (XMLHelper.canUseSchemaValidation()) {
-                assertTrue("invalid exception: " + ex.getMessage(),
-                    ex.getMessage().contains("organization"));
-            }
-        }
     }
 
     @Test
-    public void testBadConfs() throws IOException {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    public void testBadConfs() throws IOException, ParseException {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("invalidConf");
+
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-bad-confs.xml"), true);
-            fail("bad ivy file raised no error");
-        } catch (ParseException ex) {
-            ex.printStackTrace();
-            assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().contains("invalidConf"));
-        }
     }
 
     @Test
-    public void testCyclicConfs() throws IOException {
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    public void testCyclicConfs2() throws IOException, ParseException {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("A => B => A");
+
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-cyclic-confs1.xml"), true);
-            fail("bad ivy file raised no error");
-        } catch (ParseException ex) {
-            assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().contains("A => B => A"));
-        }
-        try {
-            XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
+    }
+
+    @Test
+    public void testCyclicConfs3() throws IOException, ParseException {
+        expExc.expect(ParseException.class);
+        expExc.expectMessage("A => C => B => A");
+
+        XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-cyclic-confs2.xml"), true);
-            fail("bad ivy file raised no error");
-        } catch (ParseException ex) {
-            assertTrue("invalid exception: " + ex.getMessage(),
-                ex.getMessage().contains("A => C => B => A"));
-        }
     }
 
     @Test
@@ -201,11 +191,16 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             getClass().getResource("test-novalidate.xml"), false);
     }
 
+    /**
+     * Test must fail because of bad version.
+     *
+     * @throws IOException
+     * @throws ParseException
+     */
     @Test(expected = ParseException.class)
     public void testBadVersion() throws IOException, ParseException {
         XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-bad-version.xml"), true);
-        fail("bad version ivy file raised no error");
     }
 
     @SuppressWarnings("deprecation")
@@ -1089,27 +1084,37 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
             Arrays.asList(dd.getDependencyConfigurations("bla")));
     }
 
-    // IVY-442
+    /**
+     * IVY-442: test for parser failure.
+     *
+     * @throws Exception
+     */
     @Test(expected = ParseException.class)
     public void testWithNonExistingConfigInDependency() throws Exception {
         XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf1.xml"), true);
-        fail("ParseException hasn't been thrown");
     }
 
+    /**
+     * Test for parser failure.
+     *
+     * @throws Exception
+     */
     @Test(expected = ParseException.class)
     public void testWithNonExistingConfigInPublications() throws Exception {
         XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf2.xml"), true);
-        fail("ParseException hasn't been thrown");
     }
 
-    // IVY-441
+    /**
+     * IVY-441: test for parser failure.
+     *
+     * @throws Exception
+     */
     @Test(expected = ParseException.class)
     public void testWithExistingConfigsInPublicationsSeparatedBySemiColon() throws Exception {
         XmlModuleDescriptorParser.getInstance().parseDescriptor(settings,
                 getClass().getResource("test-incorrectconf3.xml"), true);
-        fail("ParseException hasn't been thrown");
     }
 
     @Test

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
@@ -35,9 +35,17 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorParser;
 import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorParserTest;
 import org.apache.ivy.util.FileUtil;
-import org.custommonkey.xmlunit.XMLTestCase;
 
-public class XmlModuleDescriptorWriterTest extends XMLTestCase {
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class XmlModuleDescriptorWriterTest {
     private static String LICENSE;
     static {
         try {
@@ -50,6 +58,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
 
     private File dest = new File("build/test/test-write.xml");
 
+    @Test
     public void testSimple() throws Exception {
         DefaultModuleDescriptor md = (DefaultModuleDescriptor) XmlModuleDescriptorParser
                 .getInstance().parseDescriptor(new IvySettings(),
@@ -67,6 +76,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testInfo() throws Exception {
         DefaultModuleDescriptor md = (DefaultModuleDescriptor) XmlModuleDescriptorParser
                 .getInstance().parseDescriptor(new IvySettings(),
@@ -84,6 +94,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testDependencies() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
@@ -98,6 +109,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testFull() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(), XmlModuleDescriptorWriterTest.class.getResource("test.xml"), false);
@@ -111,6 +123,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testExtraInfos() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
@@ -125,6 +138,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testExtraInfosWithNestedElement() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
@@ -139,6 +153,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertEquals(expected, wrote);
     }
 
+    @Test
     public void testExtraInfosFromMaven() throws Exception {
         ModuleDescriptor md = PomModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
@@ -157,6 +172,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         assertXMLEqual(expected, wrote);
     }
 
+    @Test
     public void testExtends() throws Exception {
         ModuleDescriptor md = XmlModuleDescriptorParser.getInstance().parseDescriptor(
             new IvySettings(),
@@ -178,6 +194,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1207">IVY-1207</a>
      * @throws Exception
      */
+    @Test
     public void testTransitiveAttributeForNonTransitiveConfs() throws Exception {
         // Given a ModuleDescriptor with a non-transitive configuration
         DefaultModuleDescriptor md = new DefaultModuleDescriptor(new ModuleRevisionId(new ModuleId(
@@ -193,7 +210,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         String writtenConf = output.substring(output.indexOf("<configurations>") + 16,
             output.indexOf("</configurations>")).trim();
         assertTrue("Transitive attribute not set to false: " + writtenConf,
-            writtenConf.indexOf("transitive=\"false\"") >= 0);
+                writtenConf.contains("transitive=\"false\""));
     }
 
     /**
@@ -205,6 +222,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1207">IVY-1207</a>
      * @throws Exception
      */
+    @Test
     public void testTransitiveAttributeNotWrittenForTransitiveConfs() throws Exception {
         // Given a ModuleDescriptor with a transitive configuration
         DefaultModuleDescriptor md = new DefaultModuleDescriptor(new ModuleRevisionId(new ModuleId(
@@ -220,7 +238,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         String writtenConf = output.substring(output.indexOf("<configurations>") + 16,
             output.indexOf("</configurations>")).trim();
         assertFalse("Transitive attribute set: " + writtenConf,
-            writtenConf.indexOf("transitive=") >= 0);
+                writtenConf.contains("transitive="));
     }
 
     private String readEntirely(String resource) throws IOException {
@@ -228,6 +246,7 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
                 XmlModuleDescriptorWriterTest.class.getResource(resource).openStream())));
     }
 
+    @Before
     public void setUp() {
         if (dest.exists()) {
             dest.delete();
@@ -237,7 +256,8 @@ public class XmlModuleDescriptorWriterTest extends XMLTestCase {
         }
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         if (dest.exists()) {
             dest.delete();
         }

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
@@ -43,8 +43,10 @@ import org.apache.ivy.plugins.repository.BasicResource;
 import org.apache.ivy.util.FileUtil;
 
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
+import org.junit.rules.ExpectedException;
 import org.xml.sax.SAXParseException;
 
 import static org.junit.Assert.*;
@@ -239,21 +241,13 @@ public class XmlModuleUpdaterTest {
         assertNotNull("myconf4 has been removed", updatedMd.getConfiguration("myconf4"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testUpdateWithExcludeConfigurations2() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingFile = new File("test/java/org/apache/ivy/plugins/parser/xml/"
                 + "test-update-excludedconfs2.xml").toURI().toURL();
-        try {
-            XmlModuleDescriptorUpdater
-                    .update(settingFile, buffer, getUpdateOptions("release", "mynewrev")
-                            .setConfsToExclude(new String[] {"myconf2"}));
-            fail("IllegalArgumentException hasn't been thrown");
-        } catch (IllegalArgumentException e) {
-            // this is ok
-        } catch (SAXParseException e) {
-            // this is ok too
-        }
+        XmlModuleDescriptorUpdater.update(settingFile, buffer, getUpdateOptions("release", "mynewrev")
+                .setConfsToExclude(new String[] {"myconf2"}));
     }
 
     @Test

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleUpdaterTest.java
@@ -41,18 +41,22 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.repository.BasicResource;
 import org.apache.ivy.util.FileUtil;
+
+import org.junit.After;
+import org.junit.Test;
+
 import org.xml.sax.SAXParseException;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
-public class XmlModuleUpdaterTest extends TestCase {
+public class XmlModuleUpdaterTest {
 
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
+    @After
+    public void tearDown() {
         XmlModuleDescriptorUpdater.LINE_SEPARATOR = System.getProperty("line.separator");
     }
 
+    @Test
     public void testUpdate() throws Exception {
         /*
          * For updated file to be equals to updated.xml, we have to fix the line separator to the
@@ -93,6 +97,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertEquals(expected, updated);
     }
 
+    @Test
     public void testUpdateWithComments() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -110,6 +115,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertEquals(3, dependencies.length);
     }
 
+    @Test
     public void testVariableReplacement() throws Exception {
         /*
          * For updated file to be equals to updated.xml, we have to fix the line separator to the
@@ -191,6 +197,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertEquals(expected, updated);
     }
 
+    @Test
     public void testUpdateWithImportedMappingOverride() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -202,9 +209,10 @@ public class XmlModuleUpdaterTest extends TestCase {
 
         // just make sure that 'confmappingoverride="true"' is declared somewhere in the XML.
         assertTrue("Updated XML doesn't define the confmappingoverride attribute",
-            updatedXml.indexOf("confmappingoverride=\"true\"") != -1);
+            updatedXml.contains("confmappingoverride=\"true\""));
     }
 
+    @Test
     public void testUpdateWithExcludeConfigurations1() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -231,6 +239,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertNotNull("myconf4 has been removed", updatedMd.getConfiguration("myconf4"));
     }
 
+    @Test
     public void testUpdateWithExcludeConfigurations2() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingFile = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -247,6 +256,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         }
     }
 
+    @Test
     public void testUpdateWithExcludeConfigurations3() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -279,6 +289,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         assertNotNull("myconf4 has been removed", updatedMd.getConfiguration("myconf4"));
     }
 
+    @Test
     public void testUpdateWithExcludeConfigurations4() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -305,6 +316,7 @@ public class XmlModuleUpdaterTest extends TestCase {
         }
     }
 
+    @Test
     public void testUpdateWithExcludeConfigurations5() throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         URL settingsUrl = new File("test/java/org/apache/ivy/plugins/parser/xml/"
@@ -333,6 +345,7 @@ public class XmlModuleUpdaterTest extends TestCase {
     }
 
     // IVY-1356
+    @Test
     public void testMergedUpdateWithExtendsAndExcludes() throws Exception {
         URL url = XmlModuleUpdaterTest.class.getResource("test-extends-dependencies-exclude.xml");
 
@@ -354,10 +367,9 @@ public class XmlModuleUpdaterTest extends TestCase {
         // test indentation
         String updatedXml = buffer.toString();
         System.out.println(updatedXml);
-        assertTrue(updatedXml
-                .indexOf(XmlModuleDescriptorUpdater.LINE_SEPARATOR
-                        + "\t\t<dependency org=\"myorg\" name=\"mymodule1\" rev=\"1.0\" conf=\"default->default\"/>"
-                        + XmlModuleDescriptorUpdater.LINE_SEPARATOR) != -1);
+        assertTrue(updatedXml.contains(XmlModuleDescriptorUpdater.LINE_SEPARATOR
+                + "\t\t<dependency org=\"myorg\" name=\"mymodule1\" rev=\"1.0\" conf=\"default->default\"/>"
+                + XmlModuleDescriptorUpdater.LINE_SEPARATOR));
     }
 
     private UpdateOptions getUpdateOptions(String status, String revision) {

--- a/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportParserTest.java
@@ -24,23 +24,30 @@ import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class XmlReportParserTest extends TestCase {
+public class XmlReportParserTest {
 
     private Ivy ivy;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(new File("test/repositories/ivysettings.xml"));
         TestHelper.createCache();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testGetResolvedModule() throws Exception {
         ResolveReport report = ivy.resolve(
             new File("test/java/org/apache/ivy/plugins/report/ivy-with-info.xml"),

--- a/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/report/XmlReportWriterTest.java
@@ -26,16 +26,21 @@ import org.apache.ivy.core.report.ResolveReport;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.XMLHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.xml.sax.helpers.DefaultHandler;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-public class XmlReportWriterTest extends TestCase {
+public class XmlReportWriterTest {
     private Ivy _ivy;
 
     private File _cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         _ivy = new Ivy();
         _ivy.configure(new File("test/repositories/ivysettings.xml"));
         createCache();
@@ -46,7 +51,8 @@ public class XmlReportWriterTest extends TestCase {
         _cache.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         cleanCache();
     }
 
@@ -54,6 +60,7 @@ public class XmlReportWriterTest extends TestCase {
         CacheCleaner.deleteDir(_cache);
     }
 
+    @Test
     public void testWriteOrigin() throws Exception {
         ResolveReport report = _ivy.resolve(new File(
                 "test/repositories/1/special-encoding-root-ivy.xml"),
@@ -73,16 +80,17 @@ public class XmlReportWriterTest extends TestCase {
         String expectedOrg = "organisation=\"sp\u00E9cial\"";
 
         assertTrue("XML doesn't contain artifact location attribute",
-            xml.indexOf(expectedLocation) != -1);
+                xml.contains(expectedLocation));
         assertTrue("XML doesn't contain artifact is-local attribute",
-            xml.indexOf(expectedIsLocal) != -1);
-        assertTrue("XML doesn't contain the organisation", xml.indexOf(expectedOrg) != -1);
+                xml.contains(expectedIsLocal));
+        assertTrue("XML doesn't contain the organisation", xml.contains(expectedOrg));
 
         // check that the XML is valid
         XMLHelper.parse(new ByteArrayInputStream(buffer.toByteArray()), null, new DefaultHandler(),
             null);
     }
 
+    @Test
     public void testEscapeXml() throws Exception {
         _ivy.configure(new File("test/repositories/IVY-635/ivysettings.xml"));
         ResolveReport report = _ivy.resolve(new File(
@@ -98,9 +106,10 @@ public class XmlReportWriterTest extends TestCase {
 
         String expectedArtName = "art1&amp;_.txt";
 
-        assertTrue("XML doesn't contain escaped artifact name", xml.indexOf(expectedArtName) != -1);
+        assertTrue("XML doesn't contain escaped artifact name", xml.contains(expectedArtName));
     }
 
+    @Test
     public void testWriteModuleInfo() throws Exception {
         ResolveReport report = _ivy.resolve(new File(
                 "test/java/org/apache/ivy/plugins/report/ivy-with-info.xml"),
@@ -119,11 +128,11 @@ public class XmlReportWriterTest extends TestCase {
         String extra1Attribute = "extra-blabla=\"abc\"";
         String extra2Attribute = "extra-blabla2=\"123\"";
 
-        assertTrue("XML doesn't contain organisation attribute", xml.indexOf(orgAttribute) != -1);
-        assertTrue("XML doesn't contain module attribute", xml.indexOf(modAttribute) != -1);
-        assertTrue("XML doesn't contain revision attribute", xml.indexOf(revAttribute) != -1);
-        assertTrue("XML doesn't contain extra attribute 1", xml.indexOf(extra1Attribute) != -1);
-        assertTrue("XML doesn't contain extra attribute 2", xml.indexOf(extra2Attribute) != -1);
+        assertTrue("XML doesn't contain organisation attribute", xml.contains(orgAttribute));
+        assertTrue("XML doesn't contain module attribute", xml.contains(modAttribute));
+        assertTrue("XML doesn't contain revision attribute", xml.contains(revAttribute));
+        assertTrue("XML doesn't contain extra attribute 1", xml.contains(extra1Attribute));
+        assertTrue("XML doesn't contain extra attribute 2", xml.contains(extra2Attribute));
     }
 
     private ResolveOptions getResolveOptions(String[] confs) {

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
@@ -27,8 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Testing Testing was the single biggest hurdle I faced. I have tried to provide a complete test
@@ -90,10 +89,8 @@ public class VfsRepositoryTest {
 
             try {
                 repo.put(new File(srcFile), vfsURI.toString(), false);
-                if (!new File(srcFile).exists()) {
-                    fail("Put didn't happen. Src VfsURI: " + vfsURI.toString()
-                            + ".\nExpected file: " + destFile);
-                }
+                assertTrue("Put didn't happen. Src VfsURI: " + vfsURI.toString()
+                        + ".\nExpected file: " + destFile, new File(srcFile).exists());
             } catch (IOException e) {
                 fail("Caught unexpected IOException on Vfs URI: " + vfsURI.toString() + "\n"
                         + e.getLocalizedMessage());
@@ -128,13 +125,10 @@ public class VfsRepositoryTest {
 
             try {
                 repo.put(new File(srcFile), vfsURI.toString(), true);
-                if (!new File(srcFile).exists()) {
-                    fail("Put didn't happen. Src VfsURI: " + vfsURI.toString()
-                            + ".\nExpected file: " + destFile);
-                }
-                if (destFile.length() == 0) {
-                    fail("Zero file size indicates file not overwritten");
-                }
+                assertTrue("Put didn't happen. Src VfsURI: " + vfsURI.toString()
+                        + ".\nExpected file: " + destFile, new File(srcFile).exists());
+                assertNotEquals("Zero file size indicates file not overwritten", 0,
+                        destFile.length());
             } catch (IOException e) {
                 fail("Caught unexpected IOException on Vfs URI: " + vfsURI.toString() + "\n"
                         + e.getLocalizedMessage());
@@ -147,7 +141,7 @@ public class VfsRepositoryTest {
      * 
      * @throws Exception
      */
-    @Test
+    @Test(expected = IOException.class)
     public void testPutOverwriteFalse() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
@@ -159,12 +153,7 @@ public class VfsRepositoryTest {
         Iterator vfsURIs = helper.createVFSUriSet(destResource).iterator();
         while (vfsURIs.hasNext()) {
             VfsURI vfsURI = (VfsURI) vfsURIs.next();
-
-            try {
-                repo.put(new File(srcFile), vfsURI.toString(), false);
-                fail("Did not throw expected IOException from attempted overwrite of existing file");
-            } catch (IOException e) {
-            }
+            repo.put(new File(srcFile), vfsURI.toString(), false);
         }
     }
 
@@ -187,10 +176,8 @@ public class VfsRepositoryTest {
 
             try {
                 repo.get(vfsURI.toString(), new File(testFile));
-                if (!new File(testFile).exists()) {
-                    fail("Expected file: " + testFile + "not found. Failed vfsURI: "
-                            + vfsURI.toString());
-                }
+                assertTrue("Expected file: " + testFile + "not found. Failed vfsURI: "
+                        + vfsURI.toString(), new File(testFile).exists());
             } catch (IOException e) {
                 fail("Caught unexpected IOException on Vfs URI: " + vfsURI.toString() + "\n"
                         + e.getLocalizedMessage());
@@ -221,13 +208,10 @@ public class VfsRepositoryTest {
 
             try {
                 repo.get(vfsURI.toString(), testFile);
-                if (!testFile.exists()) {
-                    fail("Expected file: " + testFile + "not found. Failed vfsURI: "
-                            + vfsURI.toString());
-                }
-                if (testFile.length() == 0) {
-                    fail("Zero file size indicates file not overwritten");
-                }
+                assertTrue("Expected file: " + testFile + "not found. Failed vfsURI: "
+                        + vfsURI.toString(), testFile.exists());
+                assertNotEquals("Zero file size indicates file not overwritten", 0,
+                        testFile.length());
             } catch (IOException e) {
                 fail("Caught unexpected IOException on Vfs URI: " + vfsURI.toString() + "\n"
                         + e.getLocalizedMessage());

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
@@ -23,7 +23,12 @@ import java.util.Iterator;
 
 import org.apache.ivy.util.FileUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Testing Testing was the single biggest hurdle I faced. I have tried to provide a complete test
@@ -40,19 +45,15 @@ import junit.framework.TestCase;
  * (http://jsystemtest.sourceforge.net/) in other projects and am finding it a much better solution
  * than straight junit. Stephen Nesbitt
  */
-public class VfsRepositoryTest extends TestCase {
+public class VfsRepositoryTest {
     private VfsRepository repo = null;
 
     private VfsTestHelper helper = null;
 
     private File scratchDir = null;
 
-    public VfsRepositoryTest(String arg0) throws Exception {
-        super(arg0);
-    }
-
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         helper = new VfsTestHelper();
         repo = new VfsRepository();
         scratchDir = new File(FileUtil.concat(VfsTestHelper.TEST_REPO_DIR,
@@ -60,8 +61,8 @@ public class VfsRepositoryTest extends TestCase {
         scratchDir.mkdir();
     }
 
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() {
         repo = null;
         if (scratchDir.exists()) {
             FileUtil.forceDelete(scratchDir);
@@ -73,6 +74,7 @@ public class VfsRepositoryTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testPutValid() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
@@ -104,6 +106,7 @@ public class VfsRepositoryTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testPutOverwriteTrue() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
@@ -144,6 +147,7 @@ public class VfsRepositoryTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testPutOverwriteFalse() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String srcFile = FileUtil.concat(VfsTestHelper.TEST_REPO_DIR, testResource);
@@ -169,6 +173,7 @@ public class VfsRepositoryTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testGetNoExisting() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         String testFile = FileUtil.concat(scratchDir.getAbsolutePath(), testResource);
@@ -198,6 +203,7 @@ public class VfsRepositoryTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testGetOverwriteExisting() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
         File testFile = new File(FileUtil.concat(scratchDir.getAbsolutePath(), testResource));
@@ -233,6 +239,7 @@ public class VfsRepositoryTest extends TestCase {
      * Validate that we get a non null Resource instance when passed a well-formed VfsURI pointing
      * to an existing file
      */
+    @Test
     public void testGetResourceValidExist() throws Exception {
         String testResource = VfsTestHelper.TEST_IVY_XML;
 
@@ -253,6 +260,7 @@ public class VfsRepositoryTest extends TestCase {
      * Validate that we get a non null Resource instance when passed a well-formed VfsURI pointing
      * to a non-existent file.
      */
+    @Test
     public void testGetResourceValidNoExist() throws Exception {
         String testResource = VfsTestHelper.SCRATCH_DIR + "/nosuchfile.jar";
 

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
@@ -30,7 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class VfsResourceTest {
     private VfsTestHelper helper = null;
@@ -56,32 +56,20 @@ public class VfsResourceTest {
             VfsURI vfsURI = (VfsURI) vfsURIs.next();
             String resId = vfsURI.toString();
             VfsResource res = new VfsResource(resId, helper.fsManager);
-            if (res == null) {
-                fail("Unexpected null value on VFS URI: " + resId);
-            }
-
-            if (!res.exists()) {
-                fail("Resource does not exist and it should: " + resId);
-            }
+            assertNotNull("Unexpected null value on VFS URI: " + resId, res);
+            assertTrue("Resource does not exist and it should: " + resId, res.exists());
 
             // VFS apparently does some weird normalization so that resource id used to create
             // the VFS resource is not necessarily identical to the id returned from the getName
             // method <sigh>. We try to work around this by transforming things into java URIs.
-            if (!new URI(escapeUrl(resId)).equals(new URI(escapeUrl(res.getName())).normalize())) {
-                fail("Failed on getName. Expected: " + resId + ". Actual: " + res.getName());
-            }
-
-            if (res.getLastModified() == 0) {
-                fail("Expected non-null file modification date for URI: " + resId);
-            }
-
-            if (res.getContentLength() == 0) {
-                fail("Expected non-zero file length for URI: " + resId);
-            }
-
-            if (!res.physicallyExists()) {
-                fail("Physical existence check returned false for existing resource: " + resId);
-            }
+            assertEquals("Failed on getName. Expected: " + resId + ". Actual: " + res.getName(),
+                    new URI(escapeUrl(resId)), new URI(escapeUrl(res.getName())).normalize());
+            assertNotEquals("Expected non-null file modification date for URI: " + resId,
+                    0, res.getLastModified());
+            assertNotEquals("Expected non-zero file length for URI: " + resId,
+                    0, res.getContentLength());
+            assertTrue("Physical existence check returned false for existing resource: " + resId,
+                    res.physicallyExists());
         }
     }
 
@@ -117,34 +105,21 @@ public class VfsResourceTest {
             VfsURI vfsURI = (VfsURI) vfsURIs.next();
             String resId = vfsURI.toString();
             VfsResource res = new VfsResource(resId, helper.fsManager);
-            if (res == null) {
-                fail("Unexpected null value on VFS URI: " + resId);
-            }
-
-            if (res.exists()) {
-                fail("Resource does not exist and it shouldn't: " + resId);
-            }
+            assertNotNull("Unexpected null value on VFS URI: " + resId, res);
+            assertFalse("Resource does exist and it should not: " + resId, res.exists());
 
             // VFS apparently does some weird normalization so that resource id used to create
             // the VFS resource is not necessarily identical to the id returned from the getName
             // method <sigh>. We try to work around this by transforming things into java URIs.
-            if (!new URI(escapeUrl(resId)).equals(new URI(escapeUrl(res.getName())).normalize())) {
-                fail("Failed on getName. Expected: " + resId + ". Actual: " + res.getName());
-            }
-
-            if (res.getLastModified() != 0) {
-                fail("Expected null file modification date for URI: " + resId + ": "
-                        + res.getLastModified());
-            }
-
-            if (res.getContentLength() != 0) {
-                fail("Expected non-zero file length for URI: " + resId);
-            }
-
-            if (res.physicallyExists()) {
-                fail("Physical existence check returned true for non-existent resource: " + resId);
-            }
-        }
+            assertEquals("Failed on getName. Expected: " + resId + ". Actual: " + res.getName(),
+                    new URI(escapeUrl(resId)), new URI(escapeUrl(res.getName())).normalize());
+            assertEquals("Expected null file modification date for URI: " + resId,
+                    0, res.getLastModified());
+            assertEquals("Expected zero file length for URI: " + resId,
+                    0, res.getContentLength());
+            assertFalse("Physical existence check returned true for non-existent resource: " + resId,
+                    res.physicallyExists());
+       }
     }
 
     /**
@@ -156,30 +131,16 @@ public class VfsResourceTest {
         String vfsURI = "smb1:/goobeldygook";
         VfsResource res = new VfsResource(vfsURI, helper.fsManager);
 
-        if (res == null) {
-            fail("Unexpected null value on VFS URI: " + vfsURI);
-        }
-
-        if (res.exists()) {
-            fail("Resource is marked as existing and it should not: " + vfsURI);
-        }
-
-        if (!res.getName().equals("smb1:/goobeldygook")) {
-            fail("Failed on getName. Expected: " + vfsURI + ". Actual: " + res.getName());
-        }
-
-        if (res.getLastModified() != 0) {
-            fail("Expected null file modification date for URI: " + vfsURI + ": "
-                    + res.getLastModified());
-        }
-
-        if (res.getContentLength() != 0) {
-            fail("Expected zero file length for URI: " + vfsURI);
-        }
-
-        if (res.physicallyExists()) {
-            fail("Physical existence check returned false for existing resource: " + vfsURI);
-        }
+        assertNotNull("Unexpected null value on VFS URI: " + vfsURI, res);
+        assertFalse("Resource is marked as existing and it should not: " + vfsURI, res.exists());
+        assertEquals("Failed on getName. Expected: " + vfsURI + ". Actual: " + res.getName(),
+                res.getName(), "smb1:/goobeldygook");
+        assertEquals("Expected null file modification date for URI: " + vfsURI + ": "
+                        + res.getLastModified(), 0, res.getLastModified());
+        assertEquals("Expected zero file length for URI: " + vfsURI,
+                0, res.getContentLength());
+        assertFalse("Physical existence check returned true for non-existent resource: " + vfsURI,
+                res.physicallyExists());
     }
 
     /**
@@ -214,9 +175,8 @@ public class VfsResourceTest {
 
             Collections.sort(actual);
             Collections.sort(expected);
-            if (!actual.equals(expected)) {
-                fail("\nExpected: " + expected.toString() + "\n.Actual: " + actual.toString());
-            }
+            assertTrue("\nExpected: " + expected.toString() + "\nActual: " + actual.toString(),
+                    actual.equals(expected));
         }
     }
 
@@ -231,9 +191,8 @@ public class VfsResourceTest {
             VfsURI vfsURI = (VfsURI) testSet.next();
             VfsResource res = new VfsResource(vfsURI.toString(), helper.fsManager);
             List results = res.getChildren();
-            if (results.size() > 0) {
-                fail("getChildren query on file provided results when it shouldn't have");
-            }
+            assertEquals("getChildren query on file provided results when it shouldn't have",
+                    0, results.size());
         }
     }
 
@@ -248,9 +207,8 @@ public class VfsResourceTest {
             VfsURI vfsURI = (VfsURI) testSet.next();
             VfsResource res = new VfsResource(vfsURI.toString(), helper.fsManager);
             List results = res.getChildren();
-            if (results.size() > 0) {
-                fail("getChildren query on file provided results when it shouldn't have");
-            }
+            assertEquals("getChildren query on file provided results when it shouldn't have",
+                    0, results.size());
         }
     }
 }

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
@@ -26,23 +26,21 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class VfsResourceTest extends TestCase {
+import static org.junit.Assert.fail;
+
+public class VfsResourceTest {
     private VfsTestHelper helper = null;
 
-    public VfsResourceTest() {
-        super();
-    }
-
-    public VfsResourceTest(String arg0) {
-        super(arg0);
-    }
-
+    @Before
     public void setUp() throws Exception {
         helper = new VfsTestHelper();
     }
 
+    @After
     public void tearDown() {
         helper = null;
     }
@@ -50,6 +48,8 @@ public class VfsResourceTest extends TestCase {
     /**
      * Validate VFSResource creation for a valid VFS URI pointing to an physically existing file
      */
+    @SuppressWarnings("unused")
+    @Test
     public void testCreateResourceThatExists() throws Exception {
         Iterator vfsURIs = helper.createVFSUriSet(VfsTestHelper.TEST_IVY_XML).iterator();
         while (vfsURIs.hasNext()) {
@@ -89,7 +89,7 @@ public class VfsResourceTest extends TestCase {
      * Escape invalid URL characters (Copied from Wicket, just use StringUtils instead of Strings)
      * 
      * @param queryString
-     *            The orginal querystring
+     *            The original querystring
      * @return url The querystring with invalid characters escaped
      */
     private String escapeUrl(String queryString) {
@@ -109,6 +109,8 @@ public class VfsResourceTest extends TestCase {
      * Validating that resource can be created for files which don't physically exists - e.g.
      * resources that are going to created.
      */
+    @SuppressWarnings("unused")
+    @Test
     public void testCreateResourceThatDoesntExist() throws Exception {
         Iterator vfsURIs = helper.createVFSUriSet("zzyyxx.zzyyxx").iterator();
         while (vfsURIs.hasNext()) {
@@ -148,6 +150,8 @@ public class VfsResourceTest extends TestCase {
     /**
      * Validate VFSResource creation when given a poorly formed VFS identifier
      */
+    @SuppressWarnings("unused")
+    @Test
     public void testBadURI() throws Exception {
         String vfsURI = "smb1:/goobeldygook";
         VfsResource res = new VfsResource(vfsURI, helper.fsManager);
@@ -181,6 +185,7 @@ public class VfsResourceTest extends TestCase {
     /**
      * Validate getChildren when given a VFS URI for a directory
      */
+    @Test
     public void testListFolderChildren() throws Exception {
         final String testFolder = "2/mod10.1";
         final List expectedFiles = Arrays.asList(new String[] {"ivy-1.0.xml", "ivy-1.1.xml",
@@ -219,6 +224,7 @@ public class VfsResourceTest extends TestCase {
      * Validate that we don't get any results when we query a VFSResource file object for its
      * children
      */
+    @Test
     public void testListFileChildren() throws Exception {
         Iterator testSet = helper.createVFSUriSet(VfsTestHelper.TEST_IVY_XML).iterator();
         while (testSet.hasNext()) {
@@ -235,6 +241,7 @@ public class VfsResourceTest extends TestCase {
      * Validate that we don't get any results if we ask an IMAGINARY VFSResource - a nonexistent
      * file - for a list of its children
      */
+    @Test
     public void testListImaginary() throws Exception {
         Iterator testSet = helper.createVFSUriSet("idontexistzzxx").iterator();
         while (testSet.hasNext()) {

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
@@ -73,7 +73,7 @@ public class VfsTestHelper {
      * 
      * @param resource
      *            name of the resource
-     * @return <class>List</class> of well-formed VFS reosurce identifiers
+     * @return <class>List</class> of well-formed VFS resource identifiers
      */
     public List createVFSUriSet(String resource) {
         List set = new ArrayList();

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsURI.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsURI.java
@@ -51,10 +51,12 @@ public class VfsURI {
 
     /**
      * Create a set of valid VFS URIs for the file access protocol
-     * 
-     * @param resourcePath
+     *
+     * @param scheme String
+     * @param resource
      *            relative path (from the base repo) to the resource to be accessed
-     * @return
+     * @param ivy Ivy
+     * @return VfsURI
      */
     public static VfsURI vfsURIFactory(String scheme, String resource, Ivy ivy) {
         VfsURI vfsURI = null;
@@ -84,7 +86,7 @@ public class VfsURI {
      * Create a wellformed VFS resource identifier
      * 
      * @param scheme
-     *            the name of the scheme used to acces the resource
+     *            the name of the scheme used to access the resource
      * @param user
      *            a user name. May be <code>null</code>
      * @param passwd
@@ -92,7 +94,7 @@ public class VfsURI {
      * @param host
      *            a host identifier. May be <code>null</code>
      * @param path
-     *            a scheme spacific path to a resource
+     *            a scheme specific path to a resource
      */
     public VfsURI(String scheme, String user, String passwd, String host, String path) {
         this.scheme = scheme.trim();
@@ -124,19 +126,19 @@ public class VfsURI {
      * @return <code>String<code> representing a well formed VFS resource identifier
      */
     public String getVfsURI() {
-        StringBuffer uri = new StringBuffer();
-        uri.append(this.scheme + "://");
+        StringBuilder uri = new StringBuilder();
+        uri.append(this.scheme).append("://");
 
         // not all resource identifiers include user/passwd specifiers
         if (user != null && user.trim().length() > 0) {
-            uri.append(this.user + ":");
+            uri.append(this.user).append(":");
 
             if (passwd != null && passwd.trim().length() > 0) {
                 this.passwd = passwd.trim();
             } else {
                 this.passwd = "";
             }
-            uri.append(this.passwd + "@");
+            uri.append(this.passwd).append("@");
         }
 
         // not all resource identifiers include a host specifier

--- a/test/java/org/apache/ivy/plugins/resolver/AbstractDependencyResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/AbstractDependencyResolverTest.java
@@ -19,9 +19,7 @@ package org.apache.ivy.plugins.resolver;
 
 import org.apache.ivy.core.resolve.DownloadOptions;
 
-import junit.framework.TestCase;
-
-public class AbstractDependencyResolverTest extends TestCase {
+public class AbstractDependencyResolverTest {
 
     protected DownloadOptions downloadOptions() {
         return new DownloadOptions();

--- a/test/java/org/apache/ivy/plugins/resolver/BintrayResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/BintrayResolverTest.java
@@ -37,6 +37,13 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class BintrayResolverTest extends AbstractDependencyResolverTest {
 
@@ -46,25 +53,27 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
 
     private ResolveData _data;
 
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
         _data = new ResolveData(_engine, new ResolveOptions());
         _settings.setDefaultCache(TestHelper.cache);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testDefaults() {
         BintrayResolver resolver = new BintrayResolver();
         assertEquals("https://jcenter.bintray.com/", resolver.getRoot());
         assertEquals("bintray/jcenter", resolver.getName());
     }
 
+    @Test
     public void testDefaultsWithName() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setName("TestName");
@@ -72,6 +81,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("TestName", resolver.getName());
     }
 
+    @Test
     public void testSubjectOnly() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSubject("jfrog");
@@ -79,6 +89,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("bintray/jcenter", resolver.getName());
     }
 
+    @Test
     public void testRepoOnly() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setRepo("jfrog-jars");
@@ -86,6 +97,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("bintray/jcenter", resolver.getName());
     }
 
+    @Test
     public void testSubjectOnlyWithName() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSubject("jfrog");
@@ -94,6 +106,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("TestName", resolver.getName());
     }
 
+    @Test
     public void testRepoOnlyWithName() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setRepo("jfrog-jars");
@@ -102,6 +115,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("TestName", resolver.getName());
     }
 
+    @Test
     public void testSubjectAndRepo() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSubject("jfrog");
@@ -110,6 +124,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("bintray/jfrog/jfrog-jars", resolver.getName());
     }
 
+    @Test
     public void testSubjectAndRepoWithName() {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSubject("jfrog");
@@ -119,6 +134,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals("TestName", resolver.getName());
     }
 
+    @Test
     public void testBintray() throws Exception {
 
         BintrayResolver resolver = new BintrayResolver();
@@ -156,6 +172,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testErrorReport() throws Exception {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSubject("unknown");
@@ -180,6 +197,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
                 .assertLogContains("tried https://dl.bintray.com/unknown/unknown/org/apache/commons-fileupload/1.0/commons-fileupload-1.0.jar");
     }
 
+    @Test
     public void testBintrayArtifacts() throws Exception {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setName("test");
@@ -238,6 +256,7 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testUnknown() throws Exception {
         BintrayResolver resolver = new BintrayResolver();
         resolver.setName("test");

--- a/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
@@ -44,6 +44,13 @@ import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.latest.LatestRevisionStrategy;
 import org.apache.ivy.plugins.latest.LatestTimeStrategy;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests ChainResolver
@@ -56,7 +63,8 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
 
     private ResolveData data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         TestHelper.createCache();
@@ -64,10 +72,12 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         settings.setDefaultCache(TestHelper.cache);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testOrderFromConf() throws Exception {
         new XmlSettingsParser(settings).parse(ChainResolverTest.class
                 .getResource("chainresolverconf.xml"));
@@ -87,6 +97,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testName() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setSettings(settings);
@@ -94,6 +105,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         assertEquals("chain", chain.getName());
     }
 
+    @Test
     public void testResolveOrder() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
@@ -102,8 +114,8 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
                 MockResolver.buildMockResolver(settings, "1", false, null),
                 MockResolver.buildMockResolver(settings, "2", true, null),
                 MockResolver.buildMockResolver(settings, "3", true, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -117,24 +129,26 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         assertTrue(resolvers[2].askedDeps.isEmpty());
     }
 
+    @Test
     public void testLatestTimeResolve() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
         chain.setSettings(settings);
         settings.setDefaultLatestStrategy(new LatestTimeStrategy());
         MockResolver[] resolvers = new MockResolver[] {
-                MockResolver.buildMockResolver(settings, "1", true, new GregorianCalendar(2005, 1,
-                        20).getTime()),
+                MockResolver.buildMockResolver(settings, "1", true,
+                    new GregorianCalendar(2005, 1, 20).getTime()),
                 MockResolver.buildMockResolver(settings, "2", false, null),
-                MockResolver.buildMockResolver(settings, "3", true, new GregorianCalendar(2005, 1,
-                        25).getTime()), // younger -> should the one kept
+                MockResolver.buildMockResolver(settings, "3", true,
+                    new GregorianCalendar(2005, 1, 25).getTime()), // younger -> should the one kept
                 MockResolver.buildMockResolver(settings, "4", false, null),
-                MockResolver.buildMockResolver(settings, "5", true, new GregorianCalendar(2005, 1,
-                        22).getTime()),
-                MockResolver.buildMockResolver(settings, "6", true, new GregorianCalendar(2005, 1,
-                        18).getTime()), MockResolver.buildMockResolver(settings, "7", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+                MockResolver.buildMockResolver(settings, "5", true,
+                    new GregorianCalendar(2005, 1, 22).getTime()),
+                MockResolver.buildMockResolver(settings, "6", true,
+                    new GregorianCalendar(2005, 1, 18).getTime()),
+                MockResolver.buildMockResolver(settings, "7", false, null)};
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -149,27 +163,32 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testLatestRevisionResolve() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
         chain.setSettings(settings);
         chain.setLatestStrategy(new LatestRevisionStrategy());
         MockResolver[] resolvers = new MockResolver[] {
-                MockResolver.buildMockResolver(settings, "1", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "1"), new GregorianCalendar(2005, 1, 20).getTime()),
+                MockResolver.buildMockResolver(settings, "1", true,
+                    ModuleRevisionId.newInstance("org", "mod", "1"),
+                    new GregorianCalendar(2005, 1, 20).getTime()),
                 MockResolver.buildMockResolver(settings, "2", false, null),
-                MockResolver.buildMockResolver(settings, "3", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "2"), new GregorianCalendar(2005, 1, 25).getTime()),
+                MockResolver.buildMockResolver(settings, "3", true,
+                    ModuleRevisionId.newInstance("org", "mod", "2"),
+                    new GregorianCalendar(2005, 1, 25).getTime()),
                 MockResolver.buildMockResolver(settings, "4", false, null),
-                MockResolver.buildMockResolver(settings, "5", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
+                MockResolver.buildMockResolver(settings, "5", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
                 // should the
                 // one kept
-                MockResolver.buildMockResolver(settings, "6", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "3"), new GregorianCalendar(2005, 1, 18).getTime()),
+                MockResolver.buildMockResolver(settings, "6", true,
+                    ModuleRevisionId.newInstance("org", "mod", "3"),
+                    new GregorianCalendar(2005, 1, 18).getTime()),
                 MockResolver.buildMockResolver(settings, "7", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -184,6 +203,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testWithDefault() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
@@ -191,21 +211,23 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         chain.setLatestStrategy(new LatestRevisionStrategy());
         MockResolver[] resolvers = new MockResolver[] {
                 MockResolver.buildMockResolver(settings, "1", false, null),
-                MockResolver.buildMockResolver(settings, "2", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime(), true), // latest
+                MockResolver.buildMockResolver(settings, "2", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime(), true), // latest
                 // ->
                 // but
                 // default
                 MockResolver.buildMockResolver(settings, "3", false, null),
                 MockResolver.buildMockResolver(settings, "4", false, null),
-                MockResolver.buildMockResolver(settings, "5", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
+                MockResolver.buildMockResolver(settings, "5", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
                 // should the
                 // one kept
                 MockResolver.buildMockResolver(settings, "6", false, null),
                 MockResolver.buildMockResolver(settings, "7", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -223,31 +245,37 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testLatestWithDefault() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
         chain.setSettings(settings);
         chain.setLatestStrategy(new LatestRevisionStrategy());
         MockResolver[] resolvers = new MockResolver[] {
-                MockResolver.buildMockResolver(settings, "1", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "1"), new GregorianCalendar(2005, 1, 20).getTime()),
-                MockResolver.buildMockResolver(settings, "2", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime(), true), // latest
+                MockResolver.buildMockResolver(settings, "1", true,
+                    ModuleRevisionId.newInstance("org", "mod", "1"),
+                    new GregorianCalendar(2005, 1, 20).getTime()),
+                MockResolver.buildMockResolver(settings, "2", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime(), true), // latest
                 // ->
                 // but
                 // default
-                MockResolver.buildMockResolver(settings, "3", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "2"), new GregorianCalendar(2005, 1, 25).getTime()),
+                MockResolver.buildMockResolver(settings, "3", true,
+                    ModuleRevisionId.newInstance("org", "mod", "2"),
+                    new GregorianCalendar(2005, 1, 25).getTime()),
                 MockResolver.buildMockResolver(settings, "4", false, null),
-                MockResolver.buildMockResolver(settings, "5", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
+                MockResolver.buildMockResolver(settings, "5", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
                 // should the
                 // one kept
-                MockResolver.buildMockResolver(settings, "6", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "3"), new GregorianCalendar(2005, 1, 18).getTime()),
+                MockResolver.buildMockResolver(settings, "6", true,
+                    ModuleRevisionId.newInstance("org", "mod", "3"),
+                    new GregorianCalendar(2005, 1, 18).getTime()),
                 MockResolver.buildMockResolver(settings, "7", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -262,6 +290,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testFixedWithDefault() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
@@ -269,17 +298,19 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         chain.setLatestStrategy(new LatestRevisionStrategy());
         MockResolver[] resolvers = new MockResolver[] {
                 MockResolver.buildMockResolver(settings, "1", false, null),
-                MockResolver.buildMockResolver(settings, "2", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime(), true), // default
+                MockResolver.buildMockResolver(settings, "2", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime(), true), // default
                 MockResolver.buildMockResolver(settings, "3", false, null),
-                MockResolver.buildMockResolver(settings, "4", true, ModuleRevisionId.newInstance(
-                    "org", "mod", "4"), new GregorianCalendar(2005, 1, 22).getTime()), // not
-                                                                                       // default
+                MockResolver.buildMockResolver(settings, "4", true,
+                    ModuleRevisionId.newInstance("org", "mod", "4"),
+                    new GregorianCalendar(2005, 1, 22).getTime()), // not
+                                                                   // default
                 // -> should the
                 // one kept
                 MockResolver.buildMockResolver(settings, "5", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -299,6 +330,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testFixedWithDefaultAndRealResolver() throws Exception {
         // test case for IVY-206
         ChainResolver chain = new ChainResolver();
@@ -335,6 +367,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         assertEquals("2", rmr.getResolver().getName());
     }
 
+    @Test
     public void testUseCache() throws Exception {
         DefaultDependencyDescriptor dd = new DefaultDependencyDescriptor(
                 ModuleRevisionId.newInstance("org1", "mod1.1", "1.0"), false);
@@ -361,18 +394,19 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         chain.setReturnFirst(true);
 
         MockResolver[] resolvers = new MockResolver[] {
-                MockResolver.buildMockResolver(settings, "1", true, new GregorianCalendar(2005, 1,
-                        20).getTime()),
+                MockResolver.buildMockResolver(settings, "1", true,
+                    new GregorianCalendar(2005, 1, 20).getTime()),
                 MockResolver.buildMockResolver(settings, "2", false, null),
-                MockResolver.buildMockResolver(settings, "3", true, new GregorianCalendar(2005, 1,
-                        25).getTime()), // younger -> should the one kept
+                MockResolver.buildMockResolver(settings, "3", true,
+                    new GregorianCalendar(2005, 1, 25).getTime()), // younger -> should the one kept
                 MockResolver.buildMockResolver(settings, "4", false, null),
-                MockResolver.buildMockResolver(settings, "5", true, new GregorianCalendar(2005, 1,
-                        22).getTime()),
-                MockResolver.buildMockResolver(settings, "6", true, new GregorianCalendar(2005, 1,
-                        18).getTime()), MockResolver.buildMockResolver(settings, "7", false, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+                MockResolver.buildMockResolver(settings, "5", true,
+                    new GregorianCalendar(2005, 1, 22).getTime()),
+                MockResolver.buildMockResolver(settings, "6", true,
+                    new GregorianCalendar(2005, 1, 18).getTime()),
+                MockResolver.buildMockResolver(settings, "7", false, null)};
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -386,6 +420,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testReturnFirstWithDefaultAndCacheAndRealResolver() throws Exception {
         // test case for IVY-389
         DefaultDependencyDescriptor dd = new DefaultDependencyDescriptor(
@@ -473,6 +508,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         return chain;
     }
 
+    @Test
     public void testDual() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");
@@ -482,8 +518,8 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
                 MockResolver.buildMockResolver(settings, "1", false, null),
                 MockResolver.buildMockResolver(settings, "2", true, null),
                 MockResolver.buildMockResolver(settings, "3", true, null)};
-        for (int i = 0; i < resolvers.length; i++) {
-            chain.add(resolvers[i]);
+        for (MockResolver resolver : resolvers) {
+            chain.add(resolver);
         }
         assertResolversSizeAndNames(chain, resolvers.length);
 
@@ -495,6 +531,7 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
         assertEquals("chain", rmr.getArtifactResolver().getName());
     }
 
+    @Test
     public void testDownloadWithDual() throws Exception {
         ChainResolver chain = new ChainResolver();
         chain.setName("chain");

--- a/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ChainResolverTest.java
@@ -213,17 +213,14 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
                 MockResolver.buildMockResolver(settings, "1", false, null),
                 MockResolver.buildMockResolver(settings, "2", true,
                     ModuleRevisionId.newInstance("org", "mod", "4"),
-                    new GregorianCalendar(2005, 1, 22).getTime(), true), // latest
-                // ->
-                // but
-                // default
+                    new GregorianCalendar(2005, 1, 22).getTime(), true),
+                    // latest -> but default
                 MockResolver.buildMockResolver(settings, "3", false, null),
                 MockResolver.buildMockResolver(settings, "4", false, null),
                 MockResolver.buildMockResolver(settings, "5", true,
                     ModuleRevisionId.newInstance("org", "mod", "4"),
-                    new GregorianCalendar(2005, 1, 22).getTime()), // latest ->
-                // should the
-                // one kept
+                    new GregorianCalendar(2005, 1, 22).getTime()),
+                    // latest -> should be the one kept
                 MockResolver.buildMockResolver(settings, "6", false, null),
                 MockResolver.buildMockResolver(settings, "7", false, null)};
         for (MockResolver resolver : resolvers) {
@@ -300,14 +297,13 @@ public class ChainResolverTest extends AbstractDependencyResolverTest {
                 MockResolver.buildMockResolver(settings, "1", false, null),
                 MockResolver.buildMockResolver(settings, "2", true,
                     ModuleRevisionId.newInstance("org", "mod", "4"),
-                    new GregorianCalendar(2005, 1, 22).getTime(), true), // default
+                    new GregorianCalendar(2005, 1, 22).getTime(), true),
+                    // default
                 MockResolver.buildMockResolver(settings, "3", false, null),
                 MockResolver.buildMockResolver(settings, "4", true,
                     ModuleRevisionId.newInstance("org", "mod", "4"),
-                    new GregorianCalendar(2005, 1, 22).getTime()), // not
-                                                                   // default
-                // -> should the
-                // one kept
+                    new GregorianCalendar(2005, 1, 22).getTime()),
+                    // not default -> should be the one kept
                 MockResolver.buildMockResolver(settings, "5", false, null)};
         for (MockResolver resolver : resolvers) {
             chain.add(resolver);

--- a/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
@@ -18,6 +18,8 @@
 package org.apache.ivy.plugins.resolver;
 
 import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.GregorianCalendar;
 
@@ -33,6 +35,11 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.settings.XmlSettingsParser;
 import org.apache.ivy.core.sort.SortEngine;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
 /**
  * Test for DualResolver
  */
@@ -45,7 +52,8 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
 
     private File _cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
         _cache = new File("build/cache");
@@ -54,6 +62,7 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         _settings.setDefaultCache(_cache);
     }
 
+    @Test
     public void testFromConf() throws Exception {
         new XmlSettingsParser(_settings).parse(DualResolverTest.class
                 .getResource("dualresolverconf.xml"));
@@ -75,29 +84,24 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         assertNull(dual.getArtifactResolver());
     }
 
-    public void testFromBadConf() throws Exception {
-        try {
-            new XmlSettingsParser(_settings).parse(DualResolverTest.class
-                    .getResource("dualresolverconf-bad.xml"));
-            fail("bad dual resolver configuration should raise exception");
-        } catch (Exception ex) {
-            // ok -> bad conf has raised an exception
-        }
+    @Test(expected = ParseException.class)
+    public void testFromBadConf() throws IOException, ParseException {
+        new XmlSettingsParser(_settings).parse(DualResolverTest.class
+                .getResource("dualresolverconf-bad.xml"));
+        fail("bad dual resolver configuration should raise exception");
     }
 
-    public void testBad() throws Exception {
+    @Test(expected = IllegalStateException.class)
+    public void testBad() throws ParseException {
         DualResolver dual = new DualResolver();
         dual.setIvyResolver(new IBiblioResolver());
         DefaultDependencyDescriptor dd = new DefaultDependencyDescriptor(
                 ModuleRevisionId.newInstance("org", "mod", "rev"), false);
-        try {
-            dual.getDependency(dd, _data);
-            fail("bad dual resolver configuration should raise exception");
-        } catch (Exception ex) {
-            // ok -> should have raised an exception
-        }
+        dual.getDependency(dd, _data);
+        fail("bad dual resolver configuration should raise exception");
     }
 
+   @Test
     public void testResolve() throws Exception {
         DualResolver dual = new DualResolver();
         MockResolver ivyResolver = MockResolver.buildMockResolver(_settings, "ivy", true,
@@ -116,6 +120,7 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         assertTrue(artifactResolver.askedDeps.isEmpty());
     }
 
+    @Test
     public void testResolveFromArtifact() throws Exception {
         DualResolver dual = new DualResolver();
         MockResolver ivyResolver = MockResolver.buildMockResolver(_settings, "ivy", false,
@@ -134,6 +139,7 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         assertEquals(Arrays.asList(new DependencyDescriptor[] {dd}), artifactResolver.askedDeps);
     }
 
+    @Test
     public void testResolveFail() throws Exception {
         DualResolver dual = new DualResolver();
         MockResolver ivyResolver = MockResolver.buildMockResolver(_settings, "ivy", false,

--- a/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/DualResolverTest.java
@@ -84,13 +84,23 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         assertNull(dual.getArtifactResolver());
     }
 
+    /**
+     * Test fails due to bad resolver configuration.
+     *
+     * @throws IOException
+     * @throws ParseException
+     */
     @Test(expected = ParseException.class)
     public void testFromBadConf() throws IOException, ParseException {
         new XmlSettingsParser(_settings).parse(DualResolverTest.class
                 .getResource("dualresolverconf-bad.xml"));
-        fail("bad dual resolver configuration should raise exception");
     }
 
+    /**
+     * Test fails due to bad resolver configuration
+     *
+     * @throws ParseException
+     */
     @Test(expected = IllegalStateException.class)
     public void testBad() throws ParseException {
         DualResolver dual = new DualResolver();
@@ -98,7 +108,6 @@ public class DualResolverTest extends AbstractDependencyResolverTest {
         DefaultDependencyDescriptor dd = new DefaultDependencyDescriptor(
                 ModuleRevisionId.newInstance("org", "mod", "rev"), false);
         dual.getDependency(dd, _data);
-        fail("bad dual resolver configuration should raise exception");
     }
 
    @Test

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -48,6 +48,11 @@ import org.apache.ivy.plugins.latest.LatestTimeStrategy;
 import org.apache.ivy.plugins.resolver.util.ResolvedResource;
 import org.apache.ivy.util.CacheCleaner;
 import org.apache.ivy.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * 
@@ -77,7 +82,8 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         setupLastModified();
     }
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         cache = new File("build/cache");
@@ -100,10 +106,12 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         new File("test/repositories/1/org1/mod1.1/ivys/ivy-2.0.xml").setLastModified(time);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testFixedRevision() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -149,6 +157,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testFindIvyFileRefWithMultipleIvyPatterns() throws Exception {
         // cfr IVY-676
         FileSystemResolver resolver = new FileSystemResolver();
@@ -173,6 +182,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         return new DownloadOptions();
     }
 
+    @Test
     public void testMaven2() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -196,6 +206,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         resolver.reportFailure();
     }
 
+    @Test
     public void testChecksum() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -246,6 +257,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
      * Tests that <code>SHA-256</code> algorithm can be used for checksums on resolvers
      * @throws Exception
      */
+	@Test
     public void testSHA256Checksum() throws Exception {
         final FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("sha256-checksum-resolver");
@@ -275,6 +287,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
      * Tests that <code>SHA-512</code> algorithm can be used for checksums on resolvers
      * @throws Exception
      */
+	@Test
     public void testSHA512Checksum() throws Exception {
         final FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("sha256-checksum-resolver");
@@ -300,6 +313,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals("Unexpected revision of downloaded artifact", "3.0", downloadedArtifact.getModuleRevisionId().getRevision());
     }
 
+	@Test
     public void testCheckModified() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -347,6 +361,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testNoRevision() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -418,6 +433,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         r.close();
     }
 
+    @Test
     public void testChanging() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -497,6 +513,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         r.close();
     }
 
+    @Test
     public void testLatestTime() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -519,6 +536,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testLatestRevision() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -541,6 +559,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testRelativePath() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -563,6 +582,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testFormattedLatestTime() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -585,6 +605,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testFormattedLatestRevision() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -607,6 +628,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testPublish() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -639,6 +661,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testPublishOverwrite() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -680,6 +703,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         file.createNewFile();
     }
 
+    @Test
     public void testPublishTransaction() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -719,6 +743,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testPublishTransactionWithBranch() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -761,6 +786,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testPublishTransactionWithSubDirectories() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -802,6 +828,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testPublishTransactionWithDottedOrganisation() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -845,6 +872,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testAbortTransaction() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -875,6 +903,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testUnsupportedTransaction() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -897,13 +926,14 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 resolver.publish(artifact, src, false);
                 fail("publishing with transaction=true and an unsupported pattern should raise an exception");
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().indexOf("transactional") != -1);
+                assertTrue(ex.getMessage().contains("transactional"));
             }
         } finally {
             FileUtil.forceDelete(new File("test/repositories/1/myorg"));
         }
     }
 
+    @Test
     public void testUnsupportedTransaction2() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -928,13 +958,14 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 resolver.publish(artifact, src, false);
                 fail("publishing with transaction=true and an unsupported combination of patterns should raise an exception");
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().indexOf("transactional") != -1);
+                assertTrue(ex.getMessage().contains("transactional"));
             }
         } finally {
             FileUtil.forceDelete(new File("test/repositories/1/myorg"));
         }
     }
 
+    @Test
     public void testUnsupportedTransaction3() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -956,13 +987,14 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 resolver.publish(artifact, src, true);
                 fail("publishing with transaction=true and overwrite mode should raise an exception");
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().indexOf("transactional") != -1);
+                assertTrue(ex.getMessage().contains("transactional"));
             }
         } finally {
             FileUtil.forceDelete(new File("test/repositories/1/myorg"));
         }
     }
 
+    @Test
     public void testDisableTransaction() throws Exception {
         try {
             FileSystemResolver resolver = new FileSystemResolver();
@@ -1002,6 +1034,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testListing() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
@@ -1032,6 +1065,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 "2.0", "2.1", "2.2"}, revs);
     }
 
+    @Test
     public void testDownloadWithUseOriginIsTrue() throws Exception {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");

--- a/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
@@ -47,6 +47,11 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * 
@@ -60,7 +65,8 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
 
     private ResolveData _data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
         _data = new ResolveData(_engine, new ResolveOptions());
@@ -68,10 +74,12 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
         _settings.setDefaultCache(TestHelper.cache);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testDefaults() {
         IBiblioResolver resolver = new IBiblioResolver();
         _settings.setVariable("ivy.ibiblio.default.artifact.root",
@@ -86,6 +94,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
             l.get(0));
     }
 
+    @Test
     public void testInitFromConf() throws Exception {
         _settings.setVariable("ivy.ibiblio.default.artifact.root", "http://www.ibiblio.org/maven/");
         _settings.setVariable("ivy.ibiblio.default.artifact.pattern",
@@ -149,6 +158,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
             l.get(0));
     }
 
+    @Test
     public void testIBiblio() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -193,6 +203,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testMaven2Listing() throws Exception {
         IBiblioResolver resolver = new IBiblioResolver();
         resolver.setName("test");
@@ -227,6 +238,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
         assertEquals("commons-lang", values[0]);
     }
 
+    @Test
     public void testErrorReport() throws Exception {
         IBiblioResolver resolver = new IBiblioResolver();
         resolver.setRoot("http://unknown.host.comx/");
@@ -250,6 +262,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
                 .assertLogContains("tried http://unknown.host.comx/org/apache/commons-fileupload/1.0/commons-fileupload-1.0.jar");
     }
 
+    @Test
     public void testIBiblioArtifacts() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -313,6 +326,7 @@ public class IBiblioResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testUnknown() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {

--- a/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
@@ -35,6 +35,11 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * 
@@ -46,7 +51,8 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
 
     private ResolveData _data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         _settings = new IvySettings();
         _engine = new ResolveEngine(_settings, new EventManager(), new SortEngine(_settings));
         _data = new ResolveData(_engine, new ResolveOptions());
@@ -54,10 +60,12 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
         _settings.setDefaultCache(TestHelper.cache);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testDefaults() {
         IvyRepResolver resolver = new IvyRepResolver();
         _settings.setVariable("ivy.ivyrep.default.ivy.root", "http://www.jayasoft.fr/myivyrep/");
@@ -81,6 +89,7 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
             l.get(0));
     }
 
+    @Test
     public void testMandatoryRoot() throws Exception {
         // IVY-625: should fail if no ivyroot specified
         IvyRepResolver resolver = new IvyRepResolver();
@@ -93,11 +102,12 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
             fail("using ivyrep resolver without ivyroot should raise an exception");
         } catch (IllegalStateException ex) {
             assertTrue(
-                "exception thrown when using ivyrep with no ivyroot should talk about the root", ex
-                        .getMessage().indexOf("ivyroot") != -1);
+                "exception thrown when using ivyrep with no ivyroot should talk about the root",
+                ex.getMessage().contains("ivyroot"));
         }
     }
 
+    @Test
     public void testIvyRepWithLocalURL() throws Exception {
         IvyRepResolver resolver = new IvyRepResolver();
         String rootpath = new File("test/repositories/1").getAbsolutePath();

--- a/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
@@ -37,7 +37,9 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
@@ -50,6 +52,9 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
     private ResolveEngine _engine;
 
     private ResolveData _data;
+
+    @Rule
+    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -89,22 +94,23 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
             l.get(0));
     }
 
+    /**
+     * IVY-625: should fail if no ivyroot specified.
+     *
+     * @throws Exception
+     */
     @Test
     public void testMandatoryRoot() throws Exception {
-        // IVY-625: should fail if no ivyroot specified
+        expExc.expect(IllegalStateException.class);
+        expExc.expectMessage("ivyroot");
+
         IvyRepResolver resolver = new IvyRepResolver();
         resolver.setName("test");
         resolver.setSettings(_settings);
 
         ModuleRevisionId mrid = ModuleRevisionId.newInstance("apache", "commons-cli", "1.0");
-        try {
-            resolver.getDependency(new DefaultDependencyDescriptor(mrid, false), _data);
-            fail("using ivyrep resolver without ivyroot should raise an exception");
-        } catch (IllegalStateException ex) {
-            assertTrue(
-                "exception thrown when using ivyrep with no ivyroot should talk about the root",
-                ex.getMessage().contains("ivyroot"));
-        }
+
+        resolver.getDependency(new DefaultDependencyDescriptor(mrid, false), _data);
     }
 
     @Test

--- a/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/JarResolverTest.java
@@ -30,10 +30,13 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.util.CacheCleaner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
 
-public class JarResolverTest extends TestCase {
+public class JarResolverTest {
 
     private IvySettings settings;
 
@@ -43,9 +46,11 @@ public class JarResolverTest extends TestCase {
 
     private ResolveData data;
 
+    @SuppressWarnings("unused")
     private DefaultRepositoryCacheManager cacheManager;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         cache = new File("build/cache");
@@ -55,10 +60,12 @@ public class JarResolverTest extends TestCase {
         cacheManager = (DefaultRepositoryCacheManager) settings.getDefaultRepositoryCacheManager();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testSimpleFile() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1");
@@ -73,6 +80,7 @@ public class JarResolverTest extends TestCase {
         assertNotNull(rmr);
     }
 
+    @Test
     public void testSubdirInFile() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1_subdir");
@@ -87,6 +95,7 @@ public class JarResolverTest extends TestCase {
         assertNotNull(rmr);
     }
 
+    @Test
     public void testUrl() throws Exception {
         JarResolver resolver = new JarResolver();
         resolver.setName("jarresolver1");

--- a/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/Maven2LocalTest.java
@@ -30,10 +30,14 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.util.CacheCleaner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class Maven2LocalTest extends TestCase {
+public class Maven2LocalTest {
     private IvySettings settings;
 
     private ResolveEngine engine;
@@ -42,7 +46,8 @@ public class Maven2LocalTest extends TestCase {
 
     private File cache;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         cache = new File("build/cache");
@@ -51,10 +56,12 @@ public class Maven2LocalTest extends TestCase {
         settings.setDefaultCache(cache);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         CacheCleaner.deleteDir(cache);
     }
 
+    @Test
     public void testUseMetadataForListing() throws Exception {
         IBiblioResolver resolver = maven2Resolver();
 
@@ -67,6 +74,7 @@ public class Maven2LocalTest extends TestCase {
         assertEquals(ModuleRevisionId.newInstance("org.apache", "test-metadata", "1.1"), m.getId());
     }
 
+    @Test
     public void testNotUseMetadataForListing() throws Exception {
         IBiblioResolver resolver = maven2Resolver();
         resolver.setUseMavenMetadata(false);

--- a/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/MirroredURLResolverTest.java
@@ -28,10 +28,15 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.settings.XmlSettingsParser;
 import org.apache.ivy.core.sort.SortEngine;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-public class MirroredURLResolverTest extends TestCase {
+public class MirroredURLResolverTest {
 
     private IvySettings settings;
 
@@ -39,7 +44,8 @@ public class MirroredURLResolverTest extends TestCase {
 
     private ResolveData data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         data = new ResolveData(engine, new ResolveOptions());
@@ -55,10 +61,12 @@ public class MirroredURLResolverTest extends TestCase {
                 .getResource("mirror-resolver-settings.xml"));
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testSolo() throws Exception {
         DependencyResolver resolver = settings.getResolver("solo");
         assertNotNull(resolver);
@@ -71,6 +79,7 @@ public class MirroredURLResolverTest extends TestCase {
         assertNotNull(rmr);
     }
 
+    @Test
     public void testFailover() throws Exception {
         DependencyResolver resolver = settings.getResolver("failover");
         assertNotNull(resolver);
@@ -83,6 +92,7 @@ public class MirroredURLResolverTest extends TestCase {
         assertNotNull(rmr);
     }
 
+    @Test
     public void testFail() throws Exception {
         DependencyResolver resolver = settings.getResolver("fail");
         assertNotNull(resolver);

--- a/test/java/org/apache/ivy/plugins/resolver/MockResolver.java
+++ b/test/java/org/apache/ivy/plugins/resolver/MockResolver.java
@@ -94,8 +94,8 @@ public class MockResolver extends AbstractResolver {
 
     public DownloadReport download(Artifact[] artifacts, DownloadOptions options) {
         DownloadReport dr = new DownloadReport();
-        for (int i = 0; i < artifacts.length; i++) {
-            dr.addArtifactReport(new ArtifactDownloadReport(artifacts[i]));
+        for (Artifact artifact : artifacts) {
+            dr.addArtifactReport(new ArtifactDownloadReport(artifact));
         }
         return dr;
     }

--- a/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/PackagerResolverTest.java
@@ -41,6 +41,12 @@ import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
 /**
  * Tests PackagerResolver.
  */
@@ -58,7 +64,8 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
 
     private File cachedir;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         Message.setDefaultLogger(new DefaultMessageLogger(99));
 
         settings = new IvySettings();
@@ -79,7 +86,8 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         FileUtil.forceDelete(cache);
         cleanupTempDirs();
     }
@@ -88,6 +96,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
         FileUtil.forceDelete(workdir);
     }
 
+    @Test
     public void testFile() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -132,7 +141,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
             assertEquals(1, report.getArtifactsReports().length);
 
             ArtifactDownloadReport ar = report.getArtifactReport(artifact);
-            System.out.println("downloaddetails: " + ar.getDownloadDetails());
+            System.out.println("download details: " + ar.getDownloadDetails());
             assertNotNull(ar);
 
             assertEquals(artifact, ar.getArtifact());
@@ -170,6 +179,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testZipResourceInclusion() throws Exception {
         Locale oldLocale = Locale.getDefault();
 
@@ -217,6 +227,7 @@ public class PackagerResolverTest extends AbstractDependencyResolverTest {
         }
     }
 
+    @Test
     public void testTarResourceInclusion() throws Exception {
         Locale oldLocale = Locale.getDefault();
 

--- a/test/java/org/apache/ivy/plugins/resolver/ResolverTestHelper.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ResolverTestHelper.java
@@ -23,7 +23,7 @@ import org.apache.ivy.core.search.ModuleEntry;
 import org.apache.ivy.core.search.OrganisationEntry;
 import org.apache.ivy.core.search.RevisionEntry;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 /**
  * 
@@ -31,8 +31,8 @@ import junit.framework.Assert;
 public class ResolverTestHelper {
     static void assertOrganisationEntries(DependencyResolver resolver, String[] orgNames,
             OrganisationEntry[] orgs) {
-        Assert.assertNotNull(orgs);
-        Assert.assertEquals(
+        assertNotNull(orgs);
+        assertEquals(
             "invalid organisation entries: unmatched number: expected: " + Arrays.asList(orgNames)
                     + " but was " + Arrays.asList(orgs), orgNames.length, orgs.length);
         assertOrganisationEntriesContains(resolver, orgNames, orgs);
@@ -40,23 +40,23 @@ public class ResolverTestHelper {
 
     static void assertOrganisationEntriesContains(DependencyResolver resolver, String[] orgNames,
             OrganisationEntry[] orgs) {
-        Assert.assertNotNull(orgs);
-        for (int i = 0; i < orgNames.length; i++) {
+        assertNotNull(orgs);
+        for (String orgName : orgNames) {
             boolean found = false;
-            for (int j = 0; j < orgs.length; j++) {
-                if (orgNames[i].equals(orgs[j].getOrganisation())) {
+            for (OrganisationEntry org : orgs) {
+                if (orgName.equals(org.getOrganisation())) {
                     found = true;
-                    Assert.assertEquals(resolver, orgs[j].getResolver());
+                    assertEquals(resolver, org.getResolver());
                 }
             }
-            Assert.assertTrue("organisation not found: " + orgNames[i], found);
+            assertTrue("organisation not found: " + orgName, found);
         }
     }
 
     static void assertModuleEntries(DependencyResolver resolver, OrganisationEntry org,
             String[] names, ModuleEntry[] mods) {
-        Assert.assertNotNull(mods);
-        Assert.assertEquals(
+        assertNotNull(mods);
+        assertEquals(
             "invalid module entries: unmatched number: expected: " + Arrays.asList(names)
                     + " but was " + Arrays.asList(mods), names.length, mods.length);
         assertModuleEntriesContains(resolver, org, names, mods);
@@ -64,24 +64,24 @@ public class ResolverTestHelper {
 
     static void assertModuleEntriesContains(DependencyResolver resolver, OrganisationEntry org,
             String[] names, ModuleEntry[] mods) {
-        Assert.assertNotNull(mods);
-        for (int i = 0; i < names.length; i++) {
+        assertNotNull(mods);
+        for (String name : names) {
             boolean found = false;
-            for (int j = 0; j < mods.length; j++) {
-                if (names[i].equals(mods[j].getModule())) {
+            for (ModuleEntry mod : mods) {
+                if (name.equals(mod.getModule())) {
                     found = true;
-                    Assert.assertEquals(resolver, mods[j].getResolver());
-                    Assert.assertEquals(org, mods[j].getOrganisationEntry());
+                    assertEquals(resolver, mod.getResolver());
+                    assertEquals(org, mod.getOrganisationEntry());
                 }
             }
-            Assert.assertTrue("module not found: " + names[i], found);
+            assertTrue("module not found: " + name, found);
         }
     }
 
     static void assertRevisionEntries(DependencyResolver resolver, ModuleEntry mod, String[] names,
             RevisionEntry[] revs) {
-        Assert.assertNotNull(revs);
-        Assert.assertEquals(
+        assertNotNull(revs);
+        assertEquals(
             "invalid revision entries: unmatched number: expected: " + Arrays.asList(names)
                     + " but was " + Arrays.asList(revs), names.length, revs.length);
         assertRevisionEntriesContains(resolver, mod, names, revs);
@@ -89,37 +89,37 @@ public class ResolverTestHelper {
 
     static void assertRevisionEntriesContains(DependencyResolver resolver, ModuleEntry mod,
             String[] names, RevisionEntry[] revs) {
-        Assert.assertNotNull(revs);
-        for (int i = 0; i < names.length; i++) {
+        assertNotNull(revs);
+        for (String name : names) {
             boolean found = false;
-            for (int j = 0; j < revs.length; j++) {
-                if (names[i].equals(revs[j].getRevision())) {
+            for (RevisionEntry rev : revs) {
+                if (name.equals(rev.getRevision())) {
                     found = true;
-                    Assert.assertEquals(resolver, revs[j].getResolver());
-                    Assert.assertEquals(mod, revs[j].getModuleEntry());
+                    assertEquals(resolver, rev.getResolver());
+                    assertEquals(mod, rev.getModuleEntry());
                 }
             }
-            Assert.assertTrue("revision not found: " + names[i], found);
+            assertTrue("revision not found: " + name, found);
         }
     }
 
     static OrganisationEntry getEntry(OrganisationEntry[] orgs, String name) {
-        for (int i = 0; i < orgs.length; i++) {
-            if (name.equals(orgs[i].getOrganisation())) {
-                return orgs[i];
+        for (OrganisationEntry org : orgs) {
+            if (name.equals(org.getOrganisation())) {
+                return org;
             }
         }
-        Assert.fail("organisation not found: " + name);
+        fail("organisation not found: " + name);
         return null; // for compilation only
     }
 
     static ModuleEntry getEntry(ModuleEntry[] mods, String name) {
-        for (int i = 0; i < mods.length; i++) {
-            if (name.equals(mods[i].getModule())) {
-                return mods[i];
+        for (ModuleEntry mod : mods) {
+            if (name.equals(mod.getModule())) {
+                return mod;
             }
         }
-        Assert.fail("module not found: " + name);
+        fail("module not found: " + name);
         return null; // for compilation only
     }
 

--- a/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
@@ -41,6 +41,13 @@ import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests URLResolver. Http tests are based upon ibiblio site.
@@ -53,7 +60,8 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
 
     private ResolveData data;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         settings = new IvySettings();
         engine = new ResolveEngine(settings, new EventManager(), new SortEngine(settings));
         data = new ResolveData(engine, new ResolveOptions());
@@ -61,10 +69,12 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         settings.setDefaultCache(TestHelper.cache);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         TestHelper.cleanCache();
     }
 
+    @Test
     public void testFile() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
@@ -110,6 +120,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testLatestFile() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
@@ -130,6 +141,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testLatestFileWithOpaqueURL() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);
@@ -151,6 +163,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals(pubdate, rmr.getPublicationDate());
     }
 
+    @Test
     public void testIBiblio() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -195,6 +208,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testIBiblioArtifacts() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -258,6 +272,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
     }
 
+    @Test
     public void testLatestIBiblio() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -277,6 +292,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals("1.4.3", rmr.getId().getRevision());
     }
 
+    @Test
     public void testVersionRangeIBiblio() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -298,6 +314,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
         assertEquals("1.4.4", rmr.getId().getRevision());
     }
 
+    @Test
     public void testUnknown() throws Exception {
         String ibiblioRoot = IBiblioHelper.getIBiblioMirror();
         if (ibiblioRoot == null) {
@@ -316,6 +333,7 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
                 "1.0"), false), data));
     }
 
+    @Test
     public void testDownloadWithUseOriginIsTrue() throws Exception {
         URLResolver resolver = new URLResolver();
         resolver.setSettings(settings);

--- a/test/java/org/apache/ivy/plugins/resolver/VfsResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/VfsResolverTest.java
@@ -17,21 +17,31 @@
  */
 package org.apache.ivy.plugins.resolver;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 public class VfsResolverTest extends AbstractDependencyResolverTest {
     VfsResolver resolver = null;
 
+    @Before
     public void setUp() {
         resolver = new VfsResolver();
     }
 
+    @After
     public void tearDown() {
         resolver = null;
     }
 
+    @Test
     public void testInit() {
         assertEquals(resolver.getClass(), VfsResolver.class);
     }
 
+    @Test
     public void testTypeName() {
         assertEquals(resolver.getTypeName(), "vfs");
     }

--- a/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/util/ResolverHelperTest.java
@@ -22,10 +22,14 @@ import java.util.Arrays;
 
 import org.apache.ivy.plugins.repository.file.FileRepository;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class ResolverHelperTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+public class ResolverHelperTest {
+
+    @Test
     public void testListTokenValuesForIvy1238() {
         FileRepository rep = new FileRepository(new File(".").getAbsoluteFile());
         String[] revisions = ResolverHelper.listTokenValues(rep,

--- a/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
+++ b/test/java/org/apache/ivy/plugins/trigger/LogTriggerTest.java
@@ -26,10 +26,14 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MockMessageLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class LogTriggerTest extends TestCase {
+public class LogTriggerTest {
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     private StartResolveEvent ev;
@@ -38,7 +42,8 @@ public class LogTriggerTest extends TestCase {
 
     private File testDir;
 
-    protected void setUp() {
+    @Before
+    public void setUp() {
         ev = new StartResolveEvent(DefaultModuleDescriptor.newBasicInstance(
             ModuleRevisionId.parse("o#A;1"), new Date()), new String[] {"c"});
         trigger = new LogTrigger();
@@ -47,10 +52,12 @@ public class LogTriggerTest extends TestCase {
         testDir.mkdirs();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(testDir);
     }
 
+    @Test
     public void testMessage() throws Exception {
         trigger.setMessage("msg: ${organisation} ${module} ${revision}");
 
@@ -61,6 +68,7 @@ public class LogTriggerTest extends TestCase {
         mockLogger.assertLogInfoContains("msg: o A 1");
     }
 
+    @Test
     public void testFile() throws Exception {
         trigger.setMessage("msg: ${organisation} ${module} ${revision}");
         File f = new File(testDir, "test.log");
@@ -77,6 +85,7 @@ public class LogTriggerTest extends TestCase {
             FileUtil.readEntirely(f));
     }
 
+    @Test
     public void testFileNoAppend() throws Exception {
         trigger.setMessage("msg: ${organisation} ${module} ${revision}");
         File f = new File(testDir, "test.log");

--- a/test/java/org/apache/ivy/plugins/version/LatestVersionMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/version/LatestVersionMatcherTest.java
@@ -22,26 +22,33 @@ import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.module.status.Status;
 import org.apache.ivy.core.module.status.StatusManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class LatestVersionMatcherTest extends TestCase {
-    private LatestVersionMatcher vm = new LatestVersionMatcher();
+public class LatestVersionMatcherTest {
+    private final LatestVersionMatcher vm = new LatestVersionMatcher();
 
-    protected void setUp() {
+    @Before
+    public void setUp() {
         IvyContext.pushNewContext();
     }
 
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         IvyContext.popContext();
     }
 
+    @Test
     public void testNeedModuleDescriptorStandardStatus() throws Exception {
         assertNeed("latest.release", true);
         assertNeed("latest.milestone", true);
         assertNeed("latest.integration", false);
     }
 
+    @Test
     public void testNeedModuleDescriptorCustomStatus() throws Exception {
         StatusManager.getCurrent().addStatus(new Status("release", false));
         StatusManager.getCurrent().addStatus(new Status("snapshot", true));
@@ -50,18 +57,21 @@ public class LatestVersionMatcherTest extends TestCase {
         assertNeed("latest.snapshot", false);
     }
 
+    @Test
     public void testAcceptForStandardStatus() throws Exception {
         assertAccept("latest.release", "release", true);
         assertAccept("latest.release", "milestone", false);
         assertAccept("latest.release", "integration", false);
     }
 
+    @Test
     public void testAcceptForSameBranches() throws Exception {
         assertAccept("latest.release", "trunk", "release", "trunk", true);
         assertAccept("latest.release", "trunk", "milestone", "trunk", false);
         assertAccept("latest.release", "trunk", "integration", "trunk", false);
     }
 
+  @Test
     public void testAcceptForDifferentBranches() throws Exception {
         assertAccept("latest.release", "trunk", "release", "feature", false);
         assertAccept("latest.release", "trunk", "milestone", "feature", false);
@@ -74,6 +84,7 @@ public class LatestVersionMatcherTest extends TestCase {
             ModuleRevisionId.newInstance("org", "name", askedVersion), null));
     }
 
+    @SuppressWarnings("unused")
     private void assertNeed(String askedVersion, String askedBranch, boolean b) {
         assertEquals(b, vm.needModuleDescriptor(
             ModuleRevisionId.newInstance("org", "name", askedBranch, askedVersion), null));

--- a/test/java/org/apache/ivy/plugins/version/PatternVersionMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/version/PatternVersionMatcherTest.java
@@ -18,10 +18,12 @@
 package org.apache.ivy.plugins.version;
 
 import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class PatternVersionMatcherTest extends TestCase {
+public class PatternVersionMatcherTest {
+    @Test
     public void testSingleMatch() {
         PatternVersionMatcher pvm = new PatternVersionMatcher();
         pvm.addMatch(generateRegexpMatch1());
@@ -33,6 +35,7 @@ public class PatternVersionMatcherTest extends TestCase {
         assertAccept(pvm, "foo(1,3)", "1.3.1", true);
     }
 
+    @Test
     public void testMultipleMatchEqualRevisions() {
         PatternVersionMatcher pvm = new PatternVersionMatcher();
         pvm.addMatch(generateRegexpMatch1());
@@ -42,6 +45,7 @@ public class PatternVersionMatcherTest extends TestCase {
         assertAccept(pvm, "foo(1,3)", "1.3.1", true);
     }
 
+    @Test
     public void testMultipleMatchNonEqualRevisions() {
         PatternVersionMatcher pvm = new PatternVersionMatcher();
         pvm.addMatch(generateRegexpMatch1());
@@ -56,7 +60,7 @@ public class PatternVersionMatcherTest extends TestCase {
      * Generates a Match instance that has the following xml representation: <match revision="foo"
      * pattern="${major}\.${minor}\.\d+" args="major, minor" matcher="regexp" />
      * 
-     * @return
+     * @return Match
      */
     private Match generateRegexpMatch1() {
         Match match = new Match();
@@ -72,7 +76,7 @@ public class PatternVersionMatcherTest extends TestCase {
      * Generates a Match instance that has the following xml representation: <match revision="foo"
      * pattern="${major}\.${minor}" args="major, minor" matcher="regexp" />
      * 
-     * @return
+     * @return Match
      */
     private Match generateRegexpMatch2() {
         Match match = new Match();

--- a/test/java/org/apache/ivy/plugins/version/VersionRangeMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/version/VersionRangeMatcherTest.java
@@ -19,12 +19,14 @@ package org.apache.ivy.plugins.version;
 
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.plugins.latest.LatestRevisionStrategy;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class VersionRangeMatcherTest extends TestCase {
-    VersionMatcher vm = new VersionRangeMatcher("range", new LatestRevisionStrategy());
+public class VersionRangeMatcherTest {
+    final VersionMatcher vm = new VersionRangeMatcher("range", new LatestRevisionStrategy());
 
+    @Test
     public void testMavenExcludeParenthesis() throws Exception {
         assertAccept("[3.8,4.0)", "3.7", false);
         assertAccept("[3.8,4.0)", "3.8", true);
@@ -45,6 +47,7 @@ public class VersionRangeMatcherTest extends TestCase {
         assertAccept("(3.8,4.0)", "4.1", false);
     }
 
+    @Test
     public void testDynamic() {
         assertDynamic("lastest.integration", false);
         assertDynamic("[1.0]", false);
@@ -86,6 +89,7 @@ public class VersionRangeMatcherTest extends TestCase {
         assertDynamic("( , 1.0 ]", true);
     }
 
+    @Test
     public void testIncludingFinite() {
         assertAccept("[1.0,2.0]", "1.1", true);
         assertAccept("[1.0,2.0]", "0.9", false);
@@ -100,6 +104,7 @@ public class VersionRangeMatcherTest extends TestCase {
         assertAccept("[ 1.0 , 2.0 ]", "2.0", true);
     }
 
+    @Test
     public void testExcludingFinite() {
         assertAccept("]1.0,2.0[", "1.1", true);
         assertAccept("]1.0,2.0[", "0.9", false);
@@ -114,6 +119,7 @@ public class VersionRangeMatcherTest extends TestCase {
         assertAccept("]1.0,2.0]", "2.0", true);
     }
 
+    @Test
     public void testIncludingInfinite() {
         assertAccept("[1.0,)", "1.1", true);
         assertAccept("[1.0,)", "2.0", true);
@@ -135,6 +141,7 @@ public class VersionRangeMatcherTest extends TestCase {
         assertAccept("[ 1.0, )", "1.0", true);
     }
 
+    @Test
     public void testExcludingInfinite() {
         assertAccept("]1.0,)", "1.1", true);
         assertAccept("]1.0,)", "2.0", true);

--- a/test/java/org/apache/ivy/util/CacheCleaner.java
+++ b/test/java/org/apache/ivy/util/CacheCleaner.java
@@ -23,7 +23,7 @@ public class CacheCleaner {
 
     /**
      * Delete the directory and all it contains. Previously, we used the ant delete task, but it
-     * occasionaly failed (access denied) on my machine for unknown reason.
+     * occasionally failed (access denied) on my machine for unknown reason.
      **/
     public static void deleteDir(File toDelete) {
         FileUtil.forceDelete(toDelete);

--- a/test/java/org/apache/ivy/util/ConfiguratorTest.java
+++ b/test/java/org/apache/ivy/util/ConfiguratorTest.java
@@ -17,17 +17,21 @@
  */
 package org.apache.ivy.util;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
  */
-public class ConfiguratorTest extends TestCase {
+public class ConfiguratorTest {
 
     public static class FileTester {
         private File file;
@@ -42,9 +46,9 @@ public class ConfiguratorTest extends TestCase {
     }
 
     public static class City {
-        private List _housings = new ArrayList();
+        private final List<Housing> _housings = new ArrayList<Housing>();
 
-        private List _streets = new ArrayList();
+        private final List<Street> _streets = new ArrayList<Street>();
 
         private String _name;
 
@@ -56,11 +60,11 @@ public class ConfiguratorTest extends TestCase {
             _name = name;
         }
 
-        public List getHousings() {
+        public List<Housing> getHousings() {
             return _housings;
         }
 
-        public List getStreets() {
+        public List<Street> getStreets() {
             return _streets;
         }
 
@@ -74,13 +78,13 @@ public class ConfiguratorTest extends TestCase {
     }
 
     public static class Street {
-        private Class _clazz;
+        private Class<?> _clazz;
 
-        private List _trees = new ArrayList();
+        private final List<Tree> _trees = new ArrayList<Tree>();
 
-        private List _walkers = new ArrayList();
+        private final List<Person> _walkers = new ArrayList<Person>();
 
-        public List getTrees() {
+        public List<Tree> getTrees() {
             return _trees;
         }
 
@@ -88,31 +92,31 @@ public class ConfiguratorTest extends TestCase {
             _trees.add(tree);
         }
 
-        public List getWalkers() {
+        public List<Person> getWalkers() {
             return _walkers;
         }
 
-        public void addConfiguredWalker(Map walkerAttributes) {
-            _walkers.add(new Person((String) walkerAttributes.get("name")));
+        public void addConfiguredWalker(Map<String, String> walkerAttributes) {
+            _walkers.add(new Person(walkerAttributes.get("name")));
         }
 
-        public Class getClazz() {
+        public Class<?> getClazz() {
             return _clazz;
         }
 
-        public void setClazz(Class clazz) {
+        public void setClazz(Class<?> clazz) {
             _clazz = clazz;
         }
     }
 
     public static abstract class Housing {
-        private List _rooms = new ArrayList();
+        private final List<Room> _rooms = new ArrayList<Room>();
 
         private boolean _isEmpty;
 
         private Person _proprietary;
 
-        public List getRooms() {
+        public List<Room> getRooms() {
             return _rooms;
         }
 
@@ -177,7 +181,7 @@ public class ConfiguratorTest extends TestCase {
     }
 
     public static class Person {
-        private String _name;
+        private final String _name;
 
         public Person(String name) {
             _name = name;
@@ -190,16 +194,19 @@ public class ConfiguratorTest extends TestCase {
 
     private Configurator _conf;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         _conf = new Configurator();
     }
 
+    @Test
     public void testSetRoot() {
         City city = new City();
         _conf.setRoot(city);
         assertEquals(city, _conf.getCurrent());
     }
 
+    @Test
     public void testStringAttribute() {
         City city = new City();
         _conf.setRoot(city);
@@ -207,6 +214,7 @@ public class ConfiguratorTest extends TestCase {
         assertEquals("bordeaux", city.getName());
     }
 
+    @Test
     public void testIntAttribute() {
         Flat flat = new Flat();
         _conf.setRoot(flat);
@@ -214,6 +222,7 @@ public class ConfiguratorTest extends TestCase {
         assertEquals(4, flat.getStage());
     }
 
+    @Test
     public void testBooleanAttribute() {
         Housing housing = new House();
         _conf.setRoot(housing);
@@ -231,6 +240,7 @@ public class ConfiguratorTest extends TestCase {
         assertEquals(false, housing.isEmpty());
     }
 
+    @Test
     public void testClassAttribute() {
         Street street = new Street();
         _conf.setRoot(street);
@@ -238,6 +248,7 @@ public class ConfiguratorTest extends TestCase {
         assertEquals(getClass(), street.getClazz());
     }
 
+    @Test
     public void testPersonAttribute() {
         Housing housing = new House();
         _conf.setRoot(housing);
@@ -245,17 +256,19 @@ public class ConfiguratorTest extends TestCase {
         assertEquals("jean", housing.getProprietary().getName());
     }
 
+    @Test
     public void testAddRoom() {
         Housing housing = new House();
         _conf.setRoot(housing);
         _conf.startCreateChild("room");
         assertEquals(1, housing.getRooms().size());
         _conf.setAttribute("surface", "24");
-        assertEquals(24, ((Room) housing.getRooms().get(0)).getSurface());
+        assertEquals(24, housing.getRooms().get(0).getSurface());
         _conf.endCreateChild();
         assertEquals(housing, _conf.getCurrent());
     }
 
+    @Test
     public void testAddConfiguredTree() {
         Street street = new Street();
         _conf.setRoot(street);
@@ -264,10 +277,11 @@ public class ConfiguratorTest extends TestCase {
         _conf.setAttribute("age", "400");
         _conf.endCreateChild();
         assertEquals(1, street.getTrees().size());
-        assertEquals(400, ((Tree) street.getTrees().get(0)).getAge());
+        assertEquals(400, street.getTrees().get(0).getAge());
         assertEquals(street, _conf.getCurrent());
     }
 
+    @Test
     public void testAddConfiguredWalker() {
         Street street = new Street();
         _conf.setRoot(street);
@@ -276,10 +290,11 @@ public class ConfiguratorTest extends TestCase {
         _conf.setAttribute("name", "xavier");
         _conf.endCreateChild();
         assertEquals(1, street.getWalkers().size());
-        assertEquals("xavier", ((Person) street.getWalkers().get(0)).getName());
+        assertEquals("xavier", street.getWalkers().get(0).getName());
         assertEquals(street, _conf.getCurrent());
     }
 
+    @Test
     public void testAddWithTypeDef() throws Exception {
         City city = new City();
         _conf.typeDef("house", House.class.getName());
@@ -300,6 +315,7 @@ public class ConfiguratorTest extends TestCase {
         assertEquals(city, _conf.getCurrent());
     }
 
+    @Test
     public void testNested() throws Exception {
         City city = new City();
         _conf.typeDef("house", House.class.getName());
@@ -313,13 +329,12 @@ public class ConfiguratorTest extends TestCase {
         _conf.endCreateChild();
         _conf.endCreateChild();
         assertEquals(city, _conf.getCurrent());
-        assertEquals(2, ((Housing) city.getHousings().get(0)).getRooms().size());
-        assertEquals(20,
-            ((Room) ((Housing) city.getHousings().get(0)).getRooms().get(0)).getSurface());
-        assertEquals(25,
-            ((Room) ((Housing) city.getHousings().get(0)).getRooms().get(1)).getSurface());
+        assertEquals(2, city.getHousings().get(0).getRooms().size());
+        assertEquals(20, city.getHousings().get(0).getRooms().get(0).getSurface());
+        assertEquals(25, city.getHousings().get(0).getRooms().get(1).getSurface());
     }
 
+    @Test
     public void testMacro() throws Exception {
         City city = new City();
         _conf.typeDef("house", House.class.getName());
@@ -356,22 +371,18 @@ public class ConfiguratorTest extends TestCase {
         assertEquals(2, city.getHousings().size());
 
         // first castle : 2 default rooms of 10 of surface
-        assertEquals(2, ((Housing) city.getHousings().get(0)).getRooms().size());
-        assertEquals(10,
-            ((Room) ((Housing) city.getHousings().get(0)).getRooms().get(0)).getSurface());
-        assertEquals(10,
-            ((Room) ((Housing) city.getHousings().get(0)).getRooms().get(1)).getSurface());
+        assertEquals(2, city.getHousings().get(0).getRooms().size());
+        assertEquals(10, city.getHousings().get(0).getRooms().get(0).getSurface());
+        assertEquals(10, city.getHousings().get(0).getRooms().get(1).getSurface());
 
         // second castle : 2 default rooms of default surface 40, + one addroom of surface 20
-        assertEquals(3, ((Housing) city.getHousings().get(1)).getRooms().size());
-        assertEquals(40,
-            ((Room) ((Housing) city.getHousings().get(1)).getRooms().get(0)).getSurface());
-        assertEquals(40,
-            ((Room) ((Housing) city.getHousings().get(1)).getRooms().get(1)).getSurface());
-        assertEquals(20,
-            ((Room) ((Housing) city.getHousings().get(1)).getRooms().get(2)).getSurface());
+        assertEquals(3, city.getHousings().get(1).getRooms().size());
+        assertEquals(40, city.getHousings().get(1).getRooms().get(0).getSurface());
+        assertEquals(40, city.getHousings().get(1).getRooms().get(1).getSurface());
+        assertEquals(20, city.getHousings().get(1).getRooms().get(2).getSurface());
     }
 
+    @Test
     public void testFileAttribute() {
         FileTester root = new FileTester();
         _conf.setRoot(root);

--- a/test/java/org/apache/ivy/util/IvyPatternHelperTest.java
+++ b/test/java/org/apache/ivy/util/IvyPatternHelperTest.java
@@ -21,16 +21,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ivy.core.IvyPatternHelper;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-public class IvyPatternHelperTest extends TestCase {
+public class IvyPatternHelperTest {
+    @Test
     public void testSubstitute() {
         String pattern = "[organisation]/[module]/build/archives/[type]s/[artifact]-[revision].[ext]";
         assertEquals("apache/Test/build/archives/jars/test-1.0.jar",
             IvyPatternHelper.substitute(pattern, "apache", "Test", "1.0", "test", "jar", "jar"));
     }
 
+    @Test
     public void testCyclicSubstitute() {
         String pattern = "${var}";
         Map variables = new HashMap();
@@ -46,6 +50,7 @@ public class IvyPatternHelperTest extends TestCase {
         }
     }
 
+    @Test
     public void testOptionalSubstitute() {
         Map tokens = new HashMap();
         tokens.put("token", "");
@@ -57,23 +62,27 @@ public class IvyPatternHelperTest extends TestCase {
             IvyPatternHelper.substituteTokens("test(-[token])(-[othertoken])", tokens));
     }
 
+    @Test
     public void testOrganization() {
         String pattern = "[organization]/[module]/build/archives/[type]s/[artifact]-[revision].[ext]";
         assertEquals("apache/Test/build/archives/jars/test-1.0.jar",
             IvyPatternHelper.substitute(pattern, "apache", "Test", "1.0", "test", "jar", "jar"));
     }
 
+    @Test
     public void testSpecialCharsInsidePattern() {
         String pattern = "[organization]/[module]/build/archives (x86)/[type]s/[artifact]-[revision].[ext]";
         assertEquals("apache/Test/build/archives (x86)/jars/test-1.0.jar",
             IvyPatternHelper.substitute(pattern, "apache", "Test", "1.0", "test", "jar", "jar"));
     }
 
+    @Test
     public void testTokenRoot() {
         String pattern = "lib/[type]/[artifact].[ext]";
         assertEquals("lib/", IvyPatternHelper.getTokenRoot(pattern));
     }
 
+    @Test
     public void testTokenRootWithOptionalFirstToken() {
         String pattern = "lib/([type]/)[artifact].[ext]";
         assertEquals("lib/", IvyPatternHelper.getTokenRoot(pattern));

--- a/test/java/org/apache/ivy/util/IvyPatternHelperTest.java
+++ b/test/java/org/apache/ivy/util/IvyPatternHelperTest.java
@@ -34,20 +34,14 @@ public class IvyPatternHelperTest {
             IvyPatternHelper.substitute(pattern, "apache", "Test", "1.0", "test", "jar", "jar"));
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testCyclicSubstitute() {
         String pattern = "${var}";
         Map variables = new HashMap();
         variables.put("var", "${othervar}");
         variables.put("othervar", "${var}");
-        try {
-            IvyPatternHelper.substituteVariables(pattern, variables);
-            fail("cyclic var should raise an exception");
-        } catch (Exception ex) {
-            // ok
-        } catch (Error er) {
-            fail("cyclic var shouldn't raise an error: " + er);
-        }
+
+        IvyPatternHelper.substituteVariables(pattern, variables);
     }
 
     @Test

--- a/test/java/org/apache/ivy/util/MockMessageLogger.java
+++ b/test/java/org/apache/ivy/util/MockMessageLogger.java
@@ -18,18 +18,15 @@
 package org.apache.ivy.util;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-
-import junit.framework.AssertionFailedError;
 
 public class MockMessageLogger extends AbstractMessageLogger {
 
-    private List _endProgress = new ArrayList();
+    private final List<String> _endProgress = new ArrayList<String>();
 
-    private List _logs = new ArrayList();
+    private final List<String> _logs = new ArrayList<String>();
 
-    private List _rawLogs = new ArrayList();
+    private final List<String> _rawLogs = new ArrayList<String>();
 
     private int _progressCalls;
 
@@ -49,11 +46,11 @@ public class MockMessageLogger extends AbstractMessageLogger {
         _rawLogs.add(level + " " + msg);
     }
 
-    public List getEndProgress() {
+    public List<String> getEndProgress() {
         return _endProgress;
     }
 
-    public List getLogs() {
+    public List<String> getLogs() {
         return _logs;
     }
 
@@ -61,7 +58,7 @@ public class MockMessageLogger extends AbstractMessageLogger {
         return _progressCalls;
     }
 
-    public List getRawLogs() {
+    public List<String> getRawLogs() {
         return _rawLogs;
     }
 
@@ -73,21 +70,19 @@ public class MockMessageLogger extends AbstractMessageLogger {
     }
 
     public void assertLogContains(String message) {
-        for (Iterator iter = _logs.iterator(); iter.hasNext();) {
-            String log = (String) iter.next();
-            if (log.indexOf(message) != -1) {
+        for (String log : _logs) {
+            if (log.contains(message)) {
                 return;
             }
         }
-        throw new AssertionFailedError("logs do not contain expected message: expected='" + message
+        throw new AssertionError("logs do not contain expected message: expected='" + message
                 + "' logs='\n" + join(_logs) + "'");
     }
 
     public void assertLogDoesntContain(String message) {
-        for (Iterator iter = _logs.iterator(); iter.hasNext();) {
-            String log = (String) iter.next();
-            if (log.indexOf(message) != -1) {
-                throw new AssertionFailedError("logs contain unexpected message: '" + message
+        for (String log : _logs) {
+            if (log.contains(message)) {
+                throw new AssertionError("logs contain unexpected message: '" + message
                         + "' logs='\n" + join(_logs) + "'");
             }
         }
@@ -111,10 +106,9 @@ public class MockMessageLogger extends AbstractMessageLogger {
         assertLogContains(Message.MSG_ERR + " " + message);
     }
 
-    private String join(List logs) {
-        StringBuffer sb = new StringBuffer();
-        for (Iterator iter = logs.iterator(); iter.hasNext();) {
-            String log = (String) iter.next();
+    private String join(List<String> logs) {
+        StringBuilder sb = new StringBuilder();
+        for (String log : logs) {
             sb.append(log).append("\n");
         }
         return sb.toString();

--- a/test/java/org/apache/ivy/util/StringUtilsTest.java
+++ b/test/java/org/apache/ivy/util/StringUtilsTest.java
@@ -17,17 +17,22 @@
  */
 package org.apache.ivy.util;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class StringUtilsTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+public class StringUtilsTest {
+
+    @Test
     public void testGetStackTrace() throws Exception {
         String trace = StringUtils.getStackTrace(new Exception());
-        assertTrue(trace.indexOf("java.lang.Exception") != -1);
-        assertTrue(trace
-                .indexOf("at org.apache.ivy.util.StringUtilsTest.testGetStackTrace(StringUtilsTest.java") != -1);
+        assertTrue(trace.contains("java.lang.Exception"));
+        assertTrue(trace.contains("at org.apache.ivy.util.StringUtilsTest.testGetStackTrace(StringUtilsTest.java"));
     }
 
+    @Test
     public void testEncryption() {
         assertEquals("apache", StringUtils.decrypt(StringUtils.encrypt("apache")));
         assertEquals("yet another string with 126 digits and others :;%_-$& characters",

--- a/test/java/org/apache/ivy/util/url/AbstractURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/AbstractURLHandlerTest.java
@@ -24,13 +24,16 @@ import java.net.URL;
 
 import org.apache.ivy.util.CopyProgressListener;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class AbstractURLHandlerTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class AbstractURLHandlerTest {
 
     /**
      * JUnit test for IVY-923.
      */
+    @Test
     public void testNormalizeToStringWithSpaceURL() throws Exception {
         AbstractURLHandler handler = new TestURLHandler();
         String normalizedUrl = handler.normalizeToString(new URL(
@@ -41,6 +44,7 @@ public class AbstractURLHandlerTest extends TestCase {
     /**
      * JUnit test for IVY-923.
      */
+    @Test
     public void testNormalizeToStringWithPlusCharacter() throws Exception {
         AbstractURLHandler handler = new TestURLHandler();
         String normalizedUrl = handler.normalizeToString(new URL(
@@ -48,6 +52,7 @@ public class AbstractURLHandlerTest extends TestCase {
         assertEquals("http://ant.apache.org/ivy/ivy-1.%2B.xml", normalizedUrl);
     }
 
+    @Test
     public void testNormalizeToStringWithUnderscoreInHostname() throws Exception {
         AbstractURLHandler handler = new TestURLHandler();
         String normalizedUrl = handler.normalizeToString(new URL(
@@ -55,6 +60,7 @@ public class AbstractURLHandlerTest extends TestCase {
         assertEquals("http://peat_hal.users.sourceforge.net/m2repository", normalizedUrl);
     }
 
+    @Test
     public void testNormalizeToStringWithUnderscoreInHostnameAndSpaceInPath() throws Exception {
         AbstractURLHandler handler = new TestURLHandler();
         String normalizedUrl = handler.normalizeToString(new URL(

--- a/test/java/org/apache/ivy/util/url/ApacheURLListerTest.java
+++ b/test/java/org/apache/ivy/util/url/ApacheURLListerTest.java
@@ -21,18 +21,23 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link ApacheURLLister}.
  */
-public class ApacheURLListerTest extends TestCase {
+public class ApacheURLListerTest {
 
     /**
      * Tests {@link ApacheURLLister#retrieveListing(URL, boolean, boolean)}.
      * 
      * @throws Exception
      */
+    @Test
     public void testRetrieveListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 
@@ -62,6 +67,7 @@ public class ApacheURLListerTest extends TestCase {
      * 
      * @throws Exception
      */
+    @Test
     public void testRetrieveListingWithSpaces() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 
@@ -71,6 +77,7 @@ public class ApacheURLListerTest extends TestCase {
         assertTrue(files.size() > 0);
     }
 
+    @Test
     public void testRetrieveArtifactoryListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 
@@ -80,6 +87,7 @@ public class ApacheURLListerTest extends TestCase {
         assertEquals(1, files.size());
     }
 
+   @Test
     public void testRetrieveArchivaListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 
@@ -91,6 +99,7 @@ public class ApacheURLListerTest extends TestCase {
         // assertEquals(3, d.size());
     }
 
+    @Test
     public void testRetrieveFixedArchivaListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 
@@ -100,6 +109,7 @@ public class ApacheURLListerTest extends TestCase {
         assertEquals(3, d.size());
     }
 
+    @Test
     public void testRetrieveMavenProxyListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 

--- a/test/java/org/apache/ivy/util/url/ArtifactoryListingTest.java
+++ b/test/java/org/apache/ivy/util/url/ArtifactoryListingTest.java
@@ -17,14 +17,18 @@
  */
 package org.apache.ivy.util.url;
 
+import org.junit.Test;
+
 import java.net.URL;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class ArtifactoryListingTest extends TestCase {
+public class ArtifactoryListingTest {
     // remote.test
 
+    @Test
     public void testWicketListing() throws Exception {
         ApacheURLLister lister = new ApacheURLLister();
 

--- a/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
@@ -22,28 +22,36 @@ import java.net.URL;
 
 import org.apache.ivy.util.FileUtil;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test BasicURLHandler
  */
-public class BasicURLHandlerTest extends TestCase {
+public class BasicURLHandlerTest {
     // remote.test
     private File testDir;
 
     private BasicURLHandler handler;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         testDir = new File("build/BasicURLHandlerTest");
         testDir.mkdirs();
 
         handler = new BasicURLHandler();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(testDir);
     }
 
+   @Test
     public void testIsReachable() throws Exception {
         final int connectionTimeoutInMillis = 15000; // 15 seconds
         assertTrue(handler.isReachable(new URL("http://www.google.fr/"), connectionTimeoutInMillis));
@@ -57,6 +65,7 @@ public class BasicURLHandlerTest extends TestCase {
         assertFalse(handler.isReachable(new URL("ftp://ftp.mozilla.org/unknown.file"), connectionTimeoutInMillis));
     }
 
+    @Test
     public void testContentEncoding() throws Exception {
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), new File(
                 testDir, "gzip.txt"));

--- a/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/HttpclientURLHandlerTest.java
@@ -23,33 +23,43 @@ import java.net.URL;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.url.URLHandler.URLInfo;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test HttpClientHandler
  */
-public class HttpclientURLHandlerTest extends TestCase {
+public class HttpclientURLHandlerTest {
     // remote.test
     private File testDir;
 
     private HttpClientHandler handler;
 
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() {
         testDir = new File("build/HttpclientURLHandlerTest");
         testDir.mkdirs();
 
         handler = new HttpClientHandler();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         FileUtil.forceDelete(testDir);
     }
 
+    @Test
     public void testIsReachable() throws Exception {
         assertTrue(handler.isReachable(new URL("http://www.google.fr/")));
         assertFalse(handler.isReachable(new URL("http://www.google.fr/unknownpage.html")));
     }
 
+    @Test
     public void testGetURLInfo() throws Exception {
         // IVY-390
         URLHandler handler = new HttpClientHandler();
@@ -60,6 +70,7 @@ public class HttpclientURLHandlerTest extends TestCase {
         assertEquals(URLHandler.UNAVAILABLE, info);
     }
 
+    @Test
     public void testContentEncoding() throws Exception {
         assertDownloadOK(new URL("http://carsten.codimi.de/gzip.yaws/daniels.html"), new File(
                 testDir, "gzip.txt"));


### PR DESCRIPTION
JUnit 4 has primarily two benefits, clarity through annotations and more fine grained control of failures 