### PR TITLE
A few loose bits in JUnit 4 migration

### DIFF
--- a/src/example/configurations/multi-projects/filter-framework/test/filter/AbstractTestFilter.java
+++ b/src/example/configurations/multi-projects/filter-framework/test/filter/AbstractTestFilter.java
@@ -17,54 +17,45 @@
  */
 package filter;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public abstract class AbstractTestFilter extends TestCase {
-    
-    public void testFilterNull() {
-        Exception err = null;
-        try {
-            getIFilter().filter(null, null);
-        } catch (NullPointerException npe) {
-            err = npe;
-        }
-        assertNull(err);
-    }
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+public abstract class AbstractTestFilter {
     /**
-     * @return
+     * @return IFilter
      */
     public abstract IFilter getIFilter();
-    
-    public void testFilterNullValues() {
-        Exception err = null;
-        try {
-            getIFilter().filter(null, "test");
-        } catch (NullPointerException npe) {
-            err = npe;
-        }
-        assertNull(err);
+
+    @Test(expected = NullPointerException.class)
+    public void testFilterNull() {
+            getIFilter().filter(null, null);
     }
-    
+
+    @Test(expected = NullPointerException.class)
+    public void testFilterNullValues() {
+        getIFilter().filter(null, "test");
+    }
+
+    @Test(expected = NullPointerException.class)
     public void testFilterNullPrefix() {
-        Exception err = null;
-        try {
-            getIFilter().filter(new String[]{"test"}, null);
-        } catch (NullPointerException npe) {
-            err = npe;
-        }
-        assertNull(err);
+        getIFilter().filter(new String[]{"test"}, null);
     } 
-    
+
+    @Test
     public void testFilter() {
-        String[] result = getIFilter().filter(
-            new String[]{"test", "nogood", "mustbe filtered"}, "t");
+        String[] result = getIFilter().filter(new String[]{"test",
+                "nogood", "mustbe filtered"}, "t");
         assertNotNull(result);
         assertEquals(result.length, 1);
     }    
-    
+
+    @Test
     public void testFilterWithNullValues() {
-        String[] result = getIFilter().filter(new String[]{"test", null, "mustbe filtered"}, "t");
+        String[] result = getIFilter().filter(new String[]{"test",
+                null, "mustbe filtered"}, "t");
         assertNotNull(result);
         assertEquals(result.length, 1);
     }

--- a/test/java/org/apache/ivy/TestFixture.java
+++ b/test/java/org/apache/ivy/TestFixture.java
@@ -35,7 +35,7 @@ import org.apache.ivy.plugins.resolver.util.ResolvedResource;
  * Fixture easing the development of tests requiring to set up a simple repository with some
  * modules, using micro ivy format to describe the repository. <br/>
  * Example of use:
- * 
+ *
  * <pre>
  * public class MyTest {
  *     private TestFixture fixture;

--- a/test/java/org/apache/ivy/TestHelper.java
+++ b/test/java/org/apache/ivy/TestHelper.java
@@ -88,7 +88,7 @@ public class TestHelper {
      * <p>
      * Expected mrids is given as a String of comma separated string representations of
      * {@link ModuleRevisionId}.
-     * 
+     *
      * @param expectedMrids
      *            the expected set of mrids
      * @param mrids
@@ -103,7 +103,7 @@ public class TestHelper {
     /**
      * Returns a Set of {@link ModuleRevisionId} corresponding to the given comma separated list of
      * their text representation.
-     * 
+     *
      * @param mrids
      *            the text representation of the {@link ModuleRevisionId}
      * @return a collection of {@link ModuleRevisionId}

--- a/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
+++ b/test/java/org/apache/ivy/ant/AntCallTriggerTest.java
@@ -163,7 +163,7 @@ public class AntCallTriggerTest {
     /**
      * Adds the listeners specified in the command line arguments, along with the default listener,
      * to the specified project.
-     * 
+     *
      * @param project
      *            The project to add listeners to. Must not be <code>null</code>.
      */
@@ -176,7 +176,7 @@ public class AntCallTriggerTest {
 
     /**
      * Creates the InputHandler and adds it to the project.
-     * 
+     *
      * @param project
      *            the project instance.
      * @param inputHandlerClassname
@@ -191,7 +191,7 @@ public class AntCallTriggerTest {
             handler = new DefaultInputHandler();
         } else {
             try {
-                handler = (InputHandler) (Class.forName(inputHandlerClassname).newInstance());
+                handler = (InputHandler) Class.forName(inputHandlerClassname).newInstance();
                 if (project != null) {
                     project.setProjectReference(handler);
                 }
@@ -214,7 +214,7 @@ public class AntCallTriggerTest {
     // loggers could have failed to be created due to this failure)?
     /**
      * Creates the default build logger for sending build events to the ant log.
-     * 
+     *
      * @return the logger instance for this build.
      */
     private BuildLogger createLogger(int level) {

--- a/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
+++ b/test/java/org/apache/ivy/ant/BuildOBRTaskTest.java
@@ -84,6 +84,7 @@ public class BuildOBRTaskTest {
         assertEquals(14, CollectionUtils.toList(obr.getModules()).size());
     }
 
+    @Test
     public void testEmptyDir() throws Exception {
         buildObr.setBaseDir(new File("test/test-p2/composite"));
         File obrFile = new File("build/cache/obr.xml");
@@ -95,6 +96,7 @@ public class BuildOBRTaskTest {
         assertEquals(0, CollectionUtils.toList(obr.getModules()).size());
     }
 
+    @Test
     public void testResolve() throws Exception {
         Project otherProject = TestHelper.newProject();
         otherProject.setProperty("ivy.settings.file", "test/test-repo/bundlerepo/ivysettings.xml");

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -28,7 +28,11 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Parallel;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;

--- a/test/java/org/apache/ivy/ant/testutil/AntTestListener.java
+++ b/test/java/org/apache/ivy/ant/testutil/AntTestListener.java
@@ -44,7 +44,7 @@ public class AntTestListener implements BuildListener {
     /**
      * Fired after the last target has finished. This event will still be thrown if an error
      * occurred during the build.
-     * 
+     *
      * @see BuildEvent#getException()
      */
     public void buildFinished(BuildEvent event) {
@@ -52,7 +52,7 @@ public class AntTestListener implements BuildListener {
 
     /**
      * Fired when a target is started.
-     * 
+     *
      * @see BuildEvent#getTarget()
      */
     public void targetStarted(BuildEvent event) {
@@ -62,7 +62,7 @@ public class AntTestListener implements BuildListener {
     /**
      * Fired when a target has finished. This event will still be thrown if an error occurred during
      * the build.
-     * 
+     *
      * @see BuildEvent#getException()
      */
     public void targetFinished(BuildEvent event) {
@@ -71,7 +71,7 @@ public class AntTestListener implements BuildListener {
 
     /**
      * Fired when a task is started.
-     * 
+     *
      * @see BuildEvent#getTask()
      */
     public void taskStarted(BuildEvent event) {
@@ -81,7 +81,7 @@ public class AntTestListener implements BuildListener {
     /**
      * Fired when a task has finished. This event will still be throw if an error occurred during
      * the build.
-     * 
+     *
      * @see BuildEvent#getException()
      */
     public void taskFinished(BuildEvent event) {
@@ -90,7 +90,7 @@ public class AntTestListener implements BuildListener {
 
     /**
      * Fired whenever a message is logged.
-     * 
+     *
      * @see BuildEvent#getMessage()
      * @see BuildEvent#getPriority()
      */

--- a/test/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManagerTest.java
+++ b/test/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.Message;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -57,7 +58,7 @@ import static org.junit.Assert.assertTrue;
  * @see DefaultResolutionCacheManager
  */
 public class DefaultRepositoryCacheManagerTest {
-    
+
     private DefaultRepositoryCacheManager cacheManager;
     private Artifact artifact;
     private ArtifactOrigin origin;
@@ -70,7 +71,7 @@ public class DefaultRepositoryCacheManagerTest {
         ivy.configureDefault();
         ivy.getLoggerEngine().setDefaultLogger(new DefaultMessageLogger(Message.MSG_DEBUG));
         IvyContext.pushNewContext().setIvy(ivy);
-        
+
         IvySettings settings = ivy.getSettings();
         f.delete(); // we want to use the file as a directory, so we delete the file itself
         cacheManager = new DefaultRepositoryCacheManager();

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -782,7 +782,7 @@ public class ResolveTest {
      * Configures an Ivy instance using a resolver locating modules on file system, in a
      * build/testCache2 location which is created for the test and removed after, and can thus
      * easily simulate a repository availability problem
-     * 
+     *
      * @return the configured ivy instance
      */
     private Ivy ivyTestCache() {
@@ -4694,11 +4694,11 @@ public class ResolveTest {
     @Test
     public void testResolveMaven2ParentPomDualResolver() throws Exception {
         // test has a dependency on test2 but there is no version listed. test
-		// has a parent of parent(2.0) then parent2. Both parents have a
-		// dependencyManagement element for test2, and each list the version as
+        // has a parent of parent(2.0) then parent2. Both parents have a
+        // dependencyManagement element for test2, and each list the version as
         // ${pom.version}. The parent version should take precedence over
-		// parent2, so the version should be test2 version 2.0. Test3 is also a
-		// dependency of parent, and it's version is listed
+        // parent2, so the version should be test2 version 2.0. Test3 is also a
+        // dependency of parent, and it's version is listed
         // as 1.0 in parent2. (dependencies inherited from parent comes after)
 
         // now run tests with dual resolver
@@ -4759,12 +4759,12 @@ public class ResolveTest {
         // test;2.0 has a dependency on test2;3.0.
         // test has a parent of parent(2.0) then parent2.
         // Both parents have a dependencyManagement element for test2, and each
-		// list the version as ${pom.version}. The version for test2 in test
-		// should take precedence, so the version should be test2 version 3.0.
+        // list the version as ${pom.version}. The version for test2 in test
+        // should take precedence, so the version should be test2 version 3.0.
         // test2;3.0 -> test4;2.0, but parent has a dependencyManagement
-		// section specifying test4;1.0.
+        // section specifying test4;1.0.
         // since maven 2.0.6, the information in parent should override
-		// transitive dependency version, and thus we should get test4;1.0
+        // transitive dependency version, and thus we should get test4;1.0
         Ivy ivy = new Ivy();
         ivy.configure(new File("test/repositories/parentPom/ivysettings.xml"));
         ivy.getSettings().setDefaultResolver("parentChain");
@@ -5700,13 +5700,13 @@ public class ResolveTest {
             "releasebranch", "1");
 
         // check that the resolve report has the expected results, namely that
-		// trunk/5 is considered later than branch/1 purely because 5>1. Of
-		// course it is more likely that we would want to consider this a
+        // trunk/5 is considered later than branch/1 purely because 5>1. Of
+        // course it is more likely that we would want to consider this a
         // 'bad comparison', but this Unit Test is not about that. It is about
-		// inconsistency of results between the resolve report and the
+        // inconsistency of results between the resolve report and the
         // delivered descriptor. In fact the delivered descriptor is out of
-		// step, because retrieve and the report both agree that trunk/5 is
-		// selected. Deliver begs to differ.
+        // step, because retrieve and the report both agree that trunk/5 is
+        // selected. Deliver begs to differ.
 
         Set<ModuleRevisionId> reportMrids = report.getConfigurationReport("default")
                 .getModuleRevisionIds();

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -255,7 +255,7 @@ public class XmlSettingsParserTest {
     }
 
     /**
-     * Test of esolver referencing a non existent cache.
+     * Test of resolver referencing a non existent cache.
      *
      * @throws Exception
      */

--- a/test/java/org/apache/ivy/core/sort/SortTest.java
+++ b/test/java/org/apache/ivy/core/sort/SortTest.java
@@ -300,7 +300,7 @@ public class SortTest {
 
     /**
      * Verifies that sorted in one of the list of listOfPossibleSort.
-     * 
+     *
      * @param listOfPossibleSort
      *            array of possible sort result
      * @param sorted

--- a/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
+++ b/test/java/org/apache/ivy/plugins/circular/IgnoreCircularDependencyStrategyTest.java
@@ -22,6 +22,8 @@ import org.apache.ivy.core.IvyContext;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.MessageLoggerEngine;
 import org.apache.ivy.util.MockMessageLogger;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +43,8 @@ public class IgnoreCircularDependencyStrategyTest {
         messageLoggerEngine = setupMockLogger(mockMessageImpl);
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         resetMockLogger(messageLoggerEngine);
     }
 

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorWriterTest.java
@@ -188,9 +188,9 @@ public class XmlModuleDescriptorWriterTest {
 
     /**
      * Test that the transitive attribute is written for non-transitive configurations.
-     * 
+     *
      * <code><conf ... transitive="false" ... /></code>
-     * 
+     *
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1207">IVY-1207</a>
      * @throws Exception
      */
@@ -215,10 +215,10 @@ public class XmlModuleDescriptorWriterTest {
 
     /**
      * Test that the transitive attribute is not written when the configuration IS transitive.
-     * 
+     *
      * This is the default and writing it will only add noise and cause a deviation from the known
      * behavior (before fixing IVY-1207).
-     * 
+     *
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1207">IVY-1207</a>
      * @throws Exception
      */

--- a/test/java/org/apache/ivy/plugins/parser/xml/test-info.xml
+++ b/test/java/org/apache/ivy/plugins/parser/xml/test-info.xml
@@ -19,7 +19,7 @@
 <ivy-module version="1.0">
 	<info organisation="myorg"
 	       module="mymodule">
-		<license name="Apache Sofware License" url="http://www.apache.org/licenses/LICENSE-2.0.txt" />
+		<license name="Apache Software License" url="http://www.apache.org/licenses/LICENSE-2.0.txt" />
 		<description homepage="http://myorg.com/mymodule">
 		My module description.
 		</description>

--- a/test/java/org/apache/ivy/plugins/parser/xml/test-write-info.xml
+++ b/test/java/org/apache/ivy/plugins/parser/xml/test-write-info.xml
@@ -24,7 +24,7 @@
 		status="integration"
 		publication="20050501110000"
 	>
-		<license name="Apache Sofware License" url="http://www.apache.org/licenses/LICENSE-2.0.txt" />
+		<license name="Apache Software License" url="http://www.apache.org/licenses/LICENSE-2.0.txt" />
 		<description homepage="http://myorg.com/mymodule">
 		My module description.
 		</description>

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsRepositoryTest.java
@@ -70,7 +70,7 @@ public class VfsRepositoryTest {
 
     /**
      * Basic validation of happy path put - valid VFS URI and no conflict with existing file
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -100,7 +100,7 @@ public class VfsRepositoryTest {
 
     /**
      * Validate that we can overwrite an existing file
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -138,7 +138,7 @@ public class VfsRepositoryTest {
 
     /**
      * Validate that we put will respect a request not to overwrite an existing file
-     * 
+     *
      * @throws Exception
      */
     @Test(expected = IOException.class)
@@ -159,7 +159,7 @@ public class VfsRepositoryTest {
 
     /**
      * Test the retrieval of an artifact from the repository creating a new artifact
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -187,7 +187,7 @@ public class VfsRepositoryTest {
 
     /**
      * Test the retrieval of an artifact from the repository overwriting an existing artifact
-     * 
+     *
      * @throws Exception
      */
     @Test

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsResourceTest.java
@@ -75,7 +75,7 @@ public class VfsResourceTest {
 
     /**
      * Escape invalid URL characters (Copied from Wicket, just use StringUtils instead of Strings)
-     * 
+     *
      * @param queryString
      *            The original querystring
      * @return url The querystring with invalid characters escaped

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsTestHelper.java
@@ -70,7 +70,7 @@ public class VfsTestHelper {
 
     /**
      * Generate a set of well-formed VFS resource identifiers
-     * 
+     *
      * @param resource
      *            name of the resource
      * @return <class>List</class> of well-formed VFS resource identifiers

--- a/test/java/org/apache/ivy/plugins/repository/vfs/VfsURI.java
+++ b/test/java/org/apache/ivy/plugins/repository/vfs/VfsURI.java
@@ -84,7 +84,7 @@ public class VfsURI {
 
     /**
      * Create a wellformed VFS resource identifier
-     * 
+     *
      * @param scheme
      *            the name of the scheme used to access the resource
      * @param user
@@ -122,7 +122,7 @@ public class VfsURI {
 
     /**
      * Return a well-formed VFS Resource identifier
-     * 
+     *
      * @return <code>String<code> representing a well formed VFS resource identifier
      */
     public String getVfsURI() {
@@ -153,7 +153,7 @@ public class VfsURI {
 
     /**
      * Convert a resource path to the format required for a VFS resource identifier
-     * 
+     *
      * @param path
      *            <code>String</code> path to the resource
      * @return <code>String</code> representing a normalized resource path

--- a/test/java/org/apache/ivy/plugins/resolver/BintrayResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/BintrayResolverTest.java
@@ -136,7 +136,6 @@ public class BintrayResolverTest extends AbstractDependencyResolverTest {
 
     @Test
     public void testBintray() throws Exception {
-
         BintrayResolver resolver = new BintrayResolver();
         resolver.setSettings(_settings);
         ModuleRevisionId mrid = ModuleRevisionId

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -265,7 +265,7 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
      * Tests that <code>SHA-256</code> algorithm can be used for checksums on resolvers
      * @throws Exception
      */
-	@Test
+    @Test
     public void testSHA256Checksum() throws Exception {
         final FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("sha256-checksum-resolver");

--- a/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IBiblioResolverTest.java
@@ -54,7 +54,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * 
+ *
  */
 public class IBiblioResolverTest extends AbstractDependencyResolverTest {
     // remote.test

--- a/test/java/org/apache/ivy/plugins/resolver/ResolverTestHelper.java
+++ b/test/java/org/apache/ivy/plugins/resolver/ResolverTestHelper.java
@@ -26,7 +26,7 @@ import org.apache.ivy.core.search.RevisionEntry;
 import static org.junit.Assert.*;
 
 /**
- * 
+ *
  */
 public class ResolverTestHelper {
     static void assertOrganisationEntries(DependencyResolver resolver, String[] orgNames,
@@ -122,5 +122,4 @@ public class ResolverTestHelper {
         fail("module not found: " + name);
         return null; // for compilation only
     }
-
 }

--- a/test/java/org/apache/ivy/plugins/version/PatternVersionMatcherTest.java
+++ b/test/java/org/apache/ivy/plugins/version/PatternVersionMatcherTest.java
@@ -59,7 +59,7 @@ public class PatternVersionMatcherTest {
     /**
      * Generates a Match instance that has the following xml representation: <match revision="foo"
      * pattern="${major}\.${minor}\.\d+" args="major, minor" matcher="regexp" />
-     * 
+     *
      * @return Match
      */
     private Match generateRegexpMatch1() {
@@ -75,7 +75,7 @@ public class PatternVersionMatcherTest {
     /**
      * Generates a Match instance that has the following xml representation: <match revision="foo"
      * pattern="${major}\.${minor}" args="major, minor" matcher="regexp" />
-     * 
+     *
      * @return Match
      */
     private Match generateRegexpMatch2() {

--- a/test/java/org/apache/ivy/util/url/ApacheURLListerTest.java
+++ b/test/java/org/apache/ivy/util/url/ApacheURLListerTest.java
@@ -31,10 +31,9 @@ import static org.junit.Assert.assertTrue;
  * Tests {@link ApacheURLLister}.
  */
 public class ApacheURLListerTest {
-
     /**
      * Tests {@link ApacheURLLister#retrieveListing(URL, boolean, boolean)}.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -64,7 +63,7 @@ public class ApacheURLListerTest {
 
     /**
      * Tests {@link ApacheURLLister#retrieveListing(URL, boolean, boolean)}.
-     * 
+     *
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
This adds annotations that are missing, migrates example code and fixes whitespace