### PR TITLE
Don't pollute the source lib folder during ivy retrieval in test

### DIFF
--- a/test/java/org/apache/ivy/ant/IvyRetrieveBuildFile.xml
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveBuildFile.xml
@@ -19,17 +19,21 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" basedir="../../../../../..">
   <target name="setUp">
     <property name="ivy.cache.repository" value="build/cache" />
+    <property name="build.retrieve.dir" value="build/retrieve"/>
   </target>
 
   <target name="tearDown">
   	<delete dir="build/cache" />
+    <delete dir="${build.retrieve.dir}"/>
   </target>
 
   <target name="testMultipleInlineRetrievesWithCacheCleaning">
   	<ivy:settings file="test/repositories/ivysettings.xml" />
-  	<ivy:retrieve organisation="org1" module="mod1.2" revision="2.0" inline="true" keep="true" />
+  	<ivy:retrieve pattern="${build.retrieve.dir}/[organisation]/[module]/[artifact]-[rev].[ext]"
+                  organisation="org1" module="mod1.2" revision="2.0" inline="true" keep="true" />
   	<ivy:cleancache />
-  	<ivy:retrieve organisation="org1" module="mod1.2" revision="2.0" inline="true" keep="true" />
+  	<ivy:retrieve pattern="${build.retrieve.dir}/[organisation]/[module]/[artifact]-[rev].[ext]"
+            organisation="org1" module="mod1.2" revision="2.0" inline="true" keep="true" />
   </target>
 
 </project>


### PR DESCRIPTION
The `IvyRetrieveBuildFileTest` triggers a Ant project build during the test case and issues a `ivy:retrieve` through the build file. The retrieve ends up putting these test files (some of which are dummy files) into the `${lib.dir}` of the project source and causes issues like the one noted in https://github.com/apache/ant-ivy/pull/36

>> I found out that JUnit tests polute run.classpath by placing an empty jar in /lib, which breaks eg javadoc. Any ideas which test may do that?

The commit in this PR fixes that issue to use a test build specific directory to retrieve these test specific artifacts.
