### PR TITLE
IVY-1475 Throw an explicit BuildException if cachefileset cannot determine a common base directory

### DIFF
--- a/doc/use/cachefileset.html
+++ b/doc/use/cachefileset.html
@@ -32,7 +32,13 @@ Please prefer the use of retrieve + standard ant path creation, which make your 
 more independent from ivy (once artifacts are properly retrieved, ivy is not required any more).<br/><br/>
 Built fileset is registered in ant with a given id, and can thus be used like any other ant fileset using
 refid.
-  
+
+<h2>Limitation</h2>
+A fileset, in Ant, requires a base directory from within which the files are included/excluded. The cachefileset task, in Ivy, internally tries to determine a common base directory across all the resolved artifacts' files that have been downloaded in the Ivy repository cache(s). Given that Ivy can be configured to consist multiple repository caches and each one can potentially be on a different filesystem root, there are times, when cachefileset cannot determine a common base directory for these resolved artifacts. The cachefileset throws an exception in such cases.
+
+<h2>Alternative task</h2>
+If cachefileset doesn't fit the need of your use case (maybe due to the limitations noted above), the [[use/resources]] task could be an alternative task to use in certain cases.
+
 <table class="ant">
 <thead>
     <tr><th class="ant-att">Attribute</th><th class="ant-desc">Description</th><th class="ant-req">Required</th></tr>

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -664,6 +665,49 @@ public final class FileUtil {
         unpacker.unpack(new UncloseInputStream(in), jar);
         jar.close();
         return new ByteArrayInputStream(baos.toByteArray());
+    }
+
+    /**
+     * Returns the common base directory between the passed <code>file1</code> and <code>file2</code>.
+     * <p>
+     * The returned base directory must be a parent of both the <code>file1</code> and <code>file2</code>.
+     * </p>
+     *
+     * @param file1 One of the files, for which the common base directory is being sought, may be null.
+     * @param file2 The other file for which the common base directory should be returned.
+     * @return the common base directory between a <code>file1</code> and <code>file2</code>. Returns null
+     * if no common base directory could be determined or if either <code>file1</code> or <code>file2</code>
+     * is null
+     */
+    public static File getBaseDir(final File file1, final File file2) {
+        if (file1 == null || file2 == null) {
+            return null;
+        }
+        final Iterator bases = getParents(file1).iterator();
+        final Iterator fileParents = getParents(file2.getAbsoluteFile()).iterator();
+        File result = null;
+        while (bases.hasNext() && fileParents.hasNext()) {
+            File next = (File) bases.next();
+            if (next.equals(fileParents.next())) {
+                result = next;
+            } else {
+                break;
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * @return a list of files, starting with the root and ending with the file itself
+     */
+    private static LinkedList<File> getParents(File file) {
+        final LinkedList r = new LinkedList();
+        while (file != null) {
+            r.addFirst(file);
+            file = file.getParentFile();
+        }
+        return r;
     }
 
     /**

--- a/test/java/org/apache/ivy/ant/FileUtilTest.java
+++ b/test/java/org/apache/ivy/ant/FileUtilTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -89,4 +90,51 @@ public class FileUtilTest {
         }
     }
 
+
+    /**
+     * Tests {@link FileUtil#getBaseDir(File, File)}
+     */
+    @Test
+    public void testGetBaseDir() {
+        File base = null;
+        base = FileUtil.getBaseDir(base, new File("x/aa/b/c"));
+        assertNull("Base directory was expected to be null", base);
+
+        base = new File("x/aa/b/c").getParentFile().getAbsoluteFile();
+
+        base = FileUtil.getBaseDir(base, new File("x/aa/b/d/e"));
+        assertEquals(new File("x/aa/b").getAbsoluteFile(), base);
+
+        base = FileUtil.getBaseDir(base, new File("x/ab/b/d"));
+        assertEquals(new File("x").getAbsoluteFile(), base);
+
+        final File[] filesytemRoots = File.listRoots();
+        final File root1 = filesytemRoots[0];
+        final File file1 = new File(root1, "abcd/xyz");
+        final File file2 = new File(root1, "pqrs/xyz");
+        final File commonBase = FileUtil.getBaseDir(file1, file2);
+        assertEquals("Unexpected common base dir between '" + file1 + "' and '" + file2 + "'", root1.getAbsoluteFile(), commonBase.getAbsoluteFile());
+
+    }
+
+    /**
+     * Tests that the {@link FileUtil#getBaseDir(File, File)} returns null for files that don't have a common
+     * base directory
+     */
+    @Test
+    public void testNoCommonBaseDir() {
+        final File[] fileSystemRoots = File.listRoots();
+        if (fileSystemRoots.length == 1) {
+            // single file system root isn't what we are interested in, in this test method
+            return;
+        }
+        final File root1 = fileSystemRoots[0];
+        final File root2 = fileSystemRoots[1];
+        final File fileOnRoot1 = new File(root1, "abc/file1");
+        final File fileOnRoot2 = new File(root2, "abc/file2");
+        final File commonBase = FileUtil.getBaseDir(fileOnRoot1, fileOnRoot2);
+        assertNull("No common base directory was expected for files belonging to different" +
+                " filesystem roots, but got " + commonBase, commonBase);
+        ;
+    }
 }

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -168,17 +168,4 @@ public class IvyCacheFilesetTest {
             del.execute();
         }
     }
-
-    @Test
-    public void testGetBaseDir() {
-        File base = null;
-        base = fileset.getBaseDir(base, new File("x/aa/b/c"));
-        assertEquals(new File("x/aa/b").getAbsoluteFile(), base);
-
-        base = fileset.getBaseDir(base, new File("x/aa/b/d/e"));
-        assertEquals(new File("x/aa/b").getAbsoluteFile(), base);
-
-        base = fileset.getBaseDir(base, new File("x/ab/b/d"));
-        assertEquals(new File("x").getAbsoluteFile(), base);
-    }
 }


### PR DESCRIPTION
The commit here enhances the implementation of `cachefileset` task to throw an explicit `BuildException` in cases where it cannot determine a common base directory for the `fileset` it is trying to create. Furthermore, the documentation of this task has been updated to add details about the limitation of this task and also  a pointer to an alternate task that can be used in certain cases.

This issue was raised in JIRA https://issues.apache.org/jira/browse/IVY-1475 and discussed in the ant-dev mailing list https://www.mail-archive.com/dev@ant.apache.org/msg45656.html