### PR TITLE
IVY-1561 - Enhancement to take into account environment and system properties while evaluation Maven pom property references

### DIFF
--- a/test/java/org/apache/ivy/plugins/parser/m2/test-system-properties.pom
+++ b/test/java/org/apache/ivy/plugins/parser/m2/test-system-properties.pom
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>foo.bar</groupId>
+    <artifactId>hello-world</artifactId>
+    <packaging>jar</packaging>
+    <version>2.0.2</version>
+
+    <properties>
+        <version.aopalliance>1.0</version.aopalliance>
+        <version.commons-logging>${env.THIS_WILL_BE_REPLACED_IN_TEST_BY_A_ENV_VAR}</version.commons-logging>
+        <version.test.system.property.b>2.3.4</version.test.system.property.b>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>a</groupId>
+            <artifactId>b</artifactId>
+            <version>${version.test.system.property.b}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+            <version>${version.aopalliance}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${version.commons-logging}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hello-world-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+</project>


### PR DESCRIPTION
The commit in this PR introduces the enhancement requested in https://issues.apache.org/jira/browse/IVY-1561 and includes a test case to verify it.

Maven allows developers to refer to system properties and environment variables in the pom.xml file and those properties (of the form `${property}`) are evaluated by Maven by taking into account any environment variables or system properties set during that run. 

Ivy, while creating a module descriptor out of pom.xml, didn't so far have this ability to account for environment variables and system properties while evaluating pom properties. The commit here introduces that ability.
