### PR TITLE
suppressed warnings

### DIFF
--- a/src/java/org/apache/ivy/core/settings/IvySettings.java
+++ b/src/java/org/apache/ivy/core/settings/IvySettings.java
@@ -323,7 +323,7 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
                 try {
                     URL url = new URL("http://ant.apache.org/ivy/repository.properties");
                     Message.verbose("configuring repositories with " + url);
-                    props.load(URLHandlerRegistry.getDefault().openStream(url));
+                    props.load(URLHandlerRegistry.getDefault().openStream(url, null));
                     configured = true;
                 } catch (Exception ex) {
                     Message.verbose("unable to use remote repository configuration", ex);

--- a/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
+++ b/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
@@ -150,7 +150,7 @@ public class XmlSettingsParser extends DefaultHandler {
         this.settings = settingsUrl;
         InputStream stream = null;
         try {
-            stream = URLHandlerRegistry.getDefault().openStream(settingsUrl);
+            stream = URLHandlerRegistry.getDefault().openStream(settingsUrl, null);
             InputSource inSrc = new InputSource(stream);
             inSrc.setSystemId(settingsUrl.toExternalForm());
             SAXParserFactory.newInstance().newSAXParser().parse(settingsUrl.toExternalForm(), this);

--- a/src/java/org/apache/ivy/osgi/core/ManifestParser.java
+++ b/src/java/org/apache/ivy/osgi/core/ManifestParser.java
@@ -75,9 +75,9 @@ public class ManifestParser {
 
     public static BundleInfo parseJarManifest(InputStream jarStream) throws IOException,
             ParseException {
-    @SuppressWarnings("resource")
         JarInputStream jis = new JarInputStream(jarStream);
         Manifest manifest = jis.getManifest();
+        jis.close();
         if (manifest == null) {
             return null;
         }

--- a/src/java/org/apache/ivy/plugins/parser/m2/PomReader.java
+++ b/src/java/org/apache/ivy/plugins/parser/m2/PomReader.java
@@ -119,7 +119,7 @@ public class PomReader {
 
     public PomReader(final URL descriptorURL, final Resource res) throws IOException, SAXException {
         InputStream stream = new AddDTDFilterInputStream(
-                URLHandlerRegistry.getDefault().openStream(descriptorURL));
+                URLHandlerRegistry.getDefault().openStream(descriptorURL, null));
         InputSource source = new InputSource(stream);
         source.setSystemId(XMLHelper.toSystemId(descriptorURL));
         try {

--- a/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/Scp.java
@@ -275,7 +275,6 @@ public class Scp {
         fileInfo.setLastModified(modtime);
     }
 
-    @SuppressWarnings("resource")
     private void sendFile(Channel channel, String localFile, String remoteName, String mode)
             throws IOException, RemoteScpException {
         byte[] buffer = new byte[BUFFER_SIZE];
@@ -310,11 +309,7 @@ public class Scp {
 
         readResponse(is);
 
-        FileInputStream fis = null;
-
-        try {
-            fis = new FileInputStream(f);
-
+        try (FileInputStream fis = new FileInputStream(f)) {
             while (remain > 0) {
                 int trans;
                 if (remain > buffer.length) {
@@ -332,11 +327,6 @@ public class Scp {
             }
 
             fis.close();
-        } catch (IOException e) {
-            if (fis != null) {
-                fis.close();
-            }
-            throw (e);
         }
 
         os.write(0);

--- a/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
+++ b/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
@@ -107,7 +107,7 @@ public class URLResource implements LocalizableResource {
     }
 
     public InputStream openStream() throws IOException {
-        return URLHandlerRegistry.getDefault().openStream(url);
+        return URLHandlerRegistry.getDefault().openStream(url, null);
     }
 
     public File getFile() {

--- a/src/java/org/apache/ivy/util/XMLHelper.java
+++ b/src/java/org/apache/ivy/util/XMLHelper.java
@@ -118,7 +118,7 @@ public abstract class XMLHelper {
 
     public static void parse(URL xmlURL, URL schema, DefaultHandler handler, LexicalHandler lHandler)
             throws SAXException, IOException, ParserConfigurationException {
-        InputStream xmlStream = URLHandlerRegistry.getDefault().openStream(xmlURL);
+        InputStream xmlStream = URLHandlerRegistry.getDefault().openStream(xmlURL, null);
         try {
             InputSource inSrc = new InputSource(xmlStream);
             inSrc.setSystemId(toSystemId(xmlURL));
@@ -148,7 +148,7 @@ public abstract class XMLHelper {
         InputStream schemaStream = null;
         try {
             if (schema != null) {
-                schemaStream = URLHandlerRegistry.getDefault().openStream(schema);
+                schemaStream = URLHandlerRegistry.getDefault().openStream(schema, null);
             }
             SAXParser parser = XMLHelper.newSAXParser(schema, schemaStream, loadExternalDtds);
 

--- a/src/java/org/apache/ivy/util/url/AbstractURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/AbstractURLHandler.java
@@ -191,7 +191,7 @@ public abstract class AbstractURLHandler implements URLHandler {
         return result;
     }
 
-    protected static TimeoutConstraint createTimeoutConstraints(final int connectionTimeout) {
+    public static TimeoutConstraint createTimeoutConstraints(final int connectionTimeout) {
         return new TimeoutConstraint() {
             @Override
             public int getConnectionTimeout() {

--- a/src/java/org/apache/ivy/util/url/ApacheURLLister.java
+++ b/src/java/org/apache/ivy/util/url/ApacheURLLister.java
@@ -109,14 +109,14 @@ public class ApacheURLLister {
         }
 
         URLHandler urlHandler = URLHandlerRegistry.getDefault();
-        URLInfo urlInfo = urlHandler.getURLInfo(url);
+        URLInfo urlInfo = urlHandler.getURLInfo(url, null);
         if (urlInfo == URLHandler.UNAVAILABLE) {
             return urlList; // not found => return empty list
         }
         // here, urlInfo is valid
         String charset = urlInfo.getBodyCharset();
 
-        InputStream contentStream = urlHandler.openStream(url);
+        InputStream contentStream = urlHandler.openStream(url, null);
         BufferedReader r = null;
         if (charset == null) {
             r = new BufferedReader(new InputStreamReader(contentStream));

--- a/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
+++ b/test/java/org/apache/ivy/osgi/obr/OBRResolverTest.java
@@ -313,11 +313,12 @@ public class OBRResolverTest {
         genericTestResolve(jarName, conf, expectedMrids, null);
     }
 
-    @SuppressWarnings("resource")
     private void genericTestResolve(String jarName, String conf, ModuleRevisionId[] expectedMrids,
             ModuleRevisionId[] expected2Mrids) throws Exception {
-        Manifest manifest = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
-                + jarName)).getManifest();
+        JarInputStream jis = new JarInputStream(
+                new FileInputStream("test/test-repo/bundlerepo/" + jarName));
+        Manifest manifest = jis.getManifest();
+        jis.close();
         BundleInfo bundleInfo = ManifestParser.parseManifest(manifest);
         bundleInfo.addArtifact(new BundleArtifact(false, new File("test/test-repo/bundlerepo/"
                 + jarName).toURI(), null));
@@ -346,10 +347,11 @@ public class OBRResolverTest {
         assertEquals(expected, actual);
     }
 
-    @SuppressWarnings("resource")
     private void genericTestFailingResolve(String jarName, String conf) throws Exception {
-        Manifest manifest = new JarInputStream(new FileInputStream("test/test-repo/bundlerepo/"
-                + jarName)).getManifest();
+        JarInputStream jis = new JarInputStream(
+                new FileInputStream("test/test-repo/bundlerepo/" + jarName));
+        Manifest manifest = jis.getManifest();
+        jis.close();
         BundleInfo bundleInfo = ManifestParser.parseManifest(manifest);
         bundleInfo.addArtifact(new BundleArtifact(false, new File("test/test-repo/bundlerepo/"
                 + jarName).toURI(), null));

--- a/test/java/org/apache/ivy/plugins/resolver/IBiblioHelper.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IBiblioHelper.java
@@ -22,6 +22,8 @@ import java.net.URL;
 import org.apache.ivy.util.url.URLHandler;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
+import static org.apache.ivy.util.url.AbstractURLHandler.createTimeoutConstraints;
+
 /**
  * TODO write javadoc
  */
@@ -40,7 +42,7 @@ public class IBiblioHelper {
             long best = -1;
             for (int i = 0; i < mirrors.length; i++) {
                 long start = System.currentTimeMillis();
-                if (handler.isReachable(new URL(mirrors[i]), 500)) {
+                if (handler.isReachable(new URL(mirrors[i]), createTimeoutConstraints(500))) {
                     long took = System.currentTimeMillis() - start;
                     System.out.println("reached " + mirrors[i] + " in " + took + "ms");
                     if (best == -1 || took < best) {


### PR DESCRIPTION
As described in previous PR, all compiler warnings are annotated.
This PR removes a few of them, along with some refactoring.
Changes are grouped in separate commits which are hopefully self-describing.