### PR TITLE
IVY-735 Support timeouts on resolvers

### DIFF
--- a/asciidoc/settings/resolvers.adoc
+++ b/asciidoc/settings/resolvers.adoc
@@ -104,6 +104,13 @@ Any standard resolver can be used in `force` mode, which is used mainly to handl
 By using such a resolver at the beginning of a chain, you can be sure that Ivy will pick up whatever module is available in this resolver (usually a private local build) instead of the real requested revision. This allows to handle use case like a developer working on modules `A` and `C`, where `A -> B -> C`, and pick up the local build for `C` without having to publish a local version of `B`.
 *__since 2.0__*
 
+==== timeoutConstraint
+
+*__since 2.5__*
+
+All standard resolvers support the `timeoutConstraint` attribute. The value for this attribute is the name of the link:timeout-constraint.html[timeout-constraint] that's been defined in the Ivy settings.
+
+Resolvers can be optionally configured to use a `timeoutConstraint` so that the timeouts defined on that constraint dictate how the resolvers behave when it comes to dealing with timeouts while establishing connections and reading content, during module descriptor and artifact resolutions.
 
 ==== Maven
 
@@ -130,12 +137,13 @@ And setting the property `ivy.maven.lookup.javadoc` to `false` disable the looku
 |namespace|The name of the namespace to which this resolver belongs *__since 1.3__*|No, defaults to 'system'|Yes|Yes
 |checkconsistency|true to check consistency of module descriptors found by this resolver, false to avoid consistency check *__since 1.3__*|No, defaults to true|No|Yes
 |descriptor|'optional' if a module descriptor (usually an ivy file) is optional for this resolver, 'required' to refuse modules without module descriptor *__since 2.0__*|No, defaults to 'optional'|No (except dual)|Yes
-|allownomd|_DEPRECATED. Use descriptor="required | optional" instead._
+|allownomd|_DEPRECATED. Use descriptor="required \| optional" instead._
     true if the absence of module descriptor (usually an ivy file) is authorised for this resolver, false to refuse modules without module descriptor *__since 1.4__*|No, defaults to true|No (except dual)|Yes
 |checksums|a comma separated list of link:../concept.html#checksum[checksum algorithms] to use both for publication and checking *__since 1.4__*|No, defaults to ${ivy.checksums}|No|Yes
 |latest|The name of the latest strategy to use.|No, defaults to 'default'|Yes|Yes
 |cache|The name of the cache manager to use.|No, defaults to the value of the default attribute of caches|No|Yes
 |signer|The name of the link:../settings/signers.html[detached signature generator] to use when publishing artifacts. *__(since 2.2)__*|No, by default published artifacts will not get signed by Ivy.|No|Yes
+|timeoutConstraint|The name of the link:timeout-constraint.html[timeout-constraint] to use for the resolver. *__(since 2.5)__*|No. In the absence of a `timeoutConstraint`, the resolver's behaviour with timeouts is implementation specific.|No|Yes
 |=======
 
 

--- a/asciidoc/settings/timeout-constraint.adoc
+++ b/asciidoc/settings/timeout-constraint.adoc
@@ -1,0 +1,61 @@
+////
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+////
+
+= timeout-constraint
+
+*Tag:* timeout-constraint
+
+Defines a named timeout constraint that can then be referenced from other places of the Ivy settings file, like the link:resolvers.html[resolvers].
+
+== Attributes
+
+
+[options="header",cols="15%,50%,35%"]
+|=======
+|Attribute|Description|Required
+|name|name of timeout constraint|Yes
+|connectionTimeout|An integer value, in milli seconds, that will be used as the timeout while establishing a connection. +
+A value greater than `0` is used literally as the timeout. +
+A value of `0` indicates no timeout and typically translates to wait-forever kind of semantics. +
+A value lesser than `0` lets the users of this timeout constraint decide what semantics to use. That effectively, implies implementation specific semantics|No, defaults to `-1`
+|readTimeout|An integer value, in milli seconds, that will be used as the timeout while reading content from a resource to which an connection has been established. +
+A value greater than `0` is used literally as the timeout. +
+A value of `0` indicates no timeout and typically translates to wait-forever kind of semantics. +
+A value lesser than `0` lets the users of this timeout constraint decide what semantics to use. That effectively, implies implementation specific semantics|No, defaults to `-1`
+|=======
+
+== Examples
+
+[source, xml]
+----
+    <timeout-constraints>
+        <timeout-constraint name="test-timeout-1" connectionTimeout="100" readTimeout="500"/>
+        <timeout-constraint name="test-timeout-2" readTimeout="20"/>
+        <timeout-constraint name="test-timeout-3" connectionTimeout="400"/>
+        <timeout-constraint name="test-timeout-4"/>
+    </timeout-constraints>
+----
+Here we see 4 timeout constraints defined:
+
+    - `test-timeout-1` uses a connection timeout of 200 milli seconds and read timeout of 500 milli seconds.
+    - `test-timeout-2` uses a read timeout of 20 milli seconds and lets the connection timeout default to -1.
+    - `test-timeout-3` uses a connection timeout of 400 milli seconds and lets the read timeout default to -1.
+    - `test-timeout-4` lets both the connection timeout and read timeout default to -1.
+
+

--- a/asciidoc/settings/timeout-constraints.adoc
+++ b/asciidoc/settings/timeout-constraints.adoc
@@ -1,0 +1,54 @@
+////
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+////
+
+= timeout-constraints
+
+*__since 2.5__*
+
+Ivy, internally, communicates with various remote systems for dealing with module descriptors and artifacts. This is done through various link:../concept.html[dependency resolvers] that are configured in the Ivy settings. This communication typically involves opening a connection to the target system and reading content from those systems. As with all remote communication, certain systems can sometimes be slow or even unavailable on some occasions. `timeout-constraints` in Ivy settings allows you to configure timeouts that can then be used by Ivy while communicating with remote systems.
+
+NOTE: Although, timeouts are most likely to be used by dependency resolvers, the setting up of timeouts through the use of `timeout-constraints` doesn't really bother about where those timeouts are used. As such, it's _not_ an error to have `timeout-constraints` within a Ivy settings file which may never be referred to by any resolver.
+
+== Child elements
+
+
+[options="header"]
+|=======
+|Element|Description|Cardinality
+|link:../settings/timeout-constraint.html[timeout-constraint]|defines a new timeout-constraint|0..n
+|=======
+
+
+== Examples
+
+
+[source, xml]
+----
+
+<timeout-constraints>
+        <timeout-constraint name="test-timeout-1" connectionTimeout="100" readTimeout="500"/>
+        <timeout-constraint name="test-timeout-2" readTimeout="20"/>
+        <timeout-constraint name="test-timeout-3" connectionTimeout="400"/>
+        <timeout-constraint name="test-timeout-4"/>
+</timeout-constraints>
+
+----
+
+Defines 4 `timeout-constraint`, each with a name and values for `connectionTimeout` and `readTimeout`. More details about the `timeout-constraint` element is explained in link:../settings/timeout-constraint.html[its documentation].
+

--- a/asciidoc/toc.json
+++ b/asciidoc/toc.json
@@ -479,6 +479,19 @@
                           "children": [
 
                             ]
+                        },
+                        {
+                          "id":"settings/timeout-constraints",
+                          "title":"timeout-constraints",
+                          "children": [
+                              {
+                                "id":"settings/timeout-constraint",
+                                "title":"timeout-constraint",
+                                "children": [
+
+                                  ]
+                              }
+                            ]
                         }
                       ]
                   },

--- a/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultResolutionCacheManager.java
@@ -36,6 +36,7 @@ import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.module.status.StatusManager;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.IvySettingsAware;
 import org.apache.ivy.plugins.conflict.ConflictManager;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
@@ -282,6 +283,11 @@ public class DefaultResolutionCacheManager implements ResolutionCacheManager, Iv
 
         public String getVariable(String value) {
             return delegate.getVariable(value);
+        }
+
+        @Override
+        public TimeoutConstraint getTimeoutConstraint(final String name) {
+            return this.delegate.getTimeoutConstraint(name);
         }
     }
 

--- a/src/java/org/apache/ivy/core/cache/ParserSettingsMonitor.java
+++ b/src/java/org/apache/ivy/core/cache/ParserSettingsMonitor.java
@@ -26,6 +26,7 @@ import org.apache.ivy.core.RelativeUrlResolver;
 import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.module.status.StatusManager;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.conflict.ConflictManager;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.ivy.plugins.namespace.Namespace;
@@ -147,6 +148,11 @@ class ParserSettingsMonitor {
 
         public String getVariable(String value) {
             return delegatedSettings.getVariable(value);
+        }
+
+        @Override
+        public TimeoutConstraint getTimeoutConstraint(final String name) {
+            return delegatedSettings.getTimeoutConstraint(name);
         }
     };
 }

--- a/src/java/org/apache/ivy/core/settings/IvySettings.java
+++ b/src/java/org/apache/ivy/core/settings/IvySettings.java
@@ -17,26 +17,6 @@
  */
 package org.apache.ivy.core.settings;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.AccessControlException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.apache.ivy.core.NormalRelativeUrlResolver;
@@ -110,8 +90,29 @@ import org.apache.ivy.plugins.version.VersionRangeMatcher;
 import org.apache.ivy.util.Checks;
 import org.apache.ivy.util.FileUtil;
 import org.apache.ivy.util.Message;
+import org.apache.ivy.util.StringUtils;
 import org.apache.ivy.util.filter.Filter;
 import org.apache.ivy.util.url.URLHandlerRegistry;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.AccessControlException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
 
 public class IvySettings implements SortEngineSettings, PublishEngineSettings, ParserSettings,
         DeliverEngineSettings, CheckEngineSettings, InstallEngineSettings, ResolverSettings,
@@ -211,6 +212,8 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
     private PackingRegistry packingRegistry = new PackingRegistry();
 
     private AbstractWorkspaceResolver workspaceResolver;
+
+    private final Map<String, TimeoutConstraint> timeoutConstraints = new HashMap<>();
 
     public IvySettings() {
         this(new IvyVariableContainerImpl());
@@ -1072,6 +1075,20 @@ public class IvySettings implements SortEngineSettings, PublishEngineSettings, P
     public synchronized void addNamespace(Namespace ns) {
         init(ns);
         namespaces.put(ns.getName(), ns);
+    }
+
+    public void addConfigured(final NamedTimeoutConstraint timeoutConstraint) {
+        if (timeoutConstraint == null) {
+            return;
+        }
+        final String name = timeoutConstraint.getName();
+        StringUtils.assertNotNullNotEmpty(name, "Name of a timeout constraint cannot be null or empty string");
+        this.timeoutConstraints.put(name, timeoutConstraint);
+    }
+
+    @Override
+    public TimeoutConstraint getTimeoutConstraint(final String name) {
+        return this.timeoutConstraints.get(name);
     }
 
     public synchronized void addConfigured(PatternMatcher m) {

--- a/src/java/org/apache/ivy/core/settings/NamedTimeoutConstraint.java
+++ b/src/java/org/apache/ivy/core/settings/NamedTimeoutConstraint.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ivy.core.settings;
+
+import org.apache.ivy.util.StringUtils;
+
+/**
+ * An implementation of {@link TimeoutConstraint} which can be identified by a name
+ */
+public class NamedTimeoutConstraint implements TimeoutConstraint {
+
+
+    private String name;
+
+    private int connectionTimeout = -1;
+
+    private int readTimeout = -1;
+
+    public NamedTimeoutConstraint() {
+
+    }
+
+    public NamedTimeoutConstraint(final String name) {
+        StringUtils.assertNotNullNotEmpty(name, "Name of a timeout constraint cannot be null or empty string");
+        this.name = name;
+    }
+
+    public void setName(final String name) {
+        StringUtils.assertNotNullNotEmpty(name, "Name of a timeout constraint cannot be null or empty string");
+        this.name = name;
+    }
+
+    /**
+     * @return Returns the name of the timeout constraint
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return this.connectionTimeout;
+    }
+
+    @Override
+    public int getReadTimeout() {
+        return this.readTimeout;
+    }
+
+    /**
+     * Sets the connection timeout of this timeout constraint
+     * @param connectionTimeout The connection timeout in milli seconds.
+     */
+    public void setConnectionTimeout(final int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    /**
+     * Sets the read timeout of this timeout constraint
+     * @param readTimeout The read timeout in milli seconds.
+     */
+    public void setReadTimeout(final int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+}

--- a/src/java/org/apache/ivy/core/settings/TimeoutConstraint.java
+++ b/src/java/org/apache/ivy/core/settings/TimeoutConstraint.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ivy.core.settings;
+
+/**
+ * Represents the timeouts that are applicable while dealing with resources.
+ * <p>
+ * An example of its usage is {@link org.apache.ivy.plugins.resolver.DependencyResolver dependency resolvers}
+ * when they are resolving module descriptor and/or are downloading the artifacts.
+ */
+public interface TimeoutConstraint {
+
+    /**
+     * @return Returns the timeout, in milli seconds, that's to be used while establishing a connection to a resource.
+     * A value greater than zero indicates the specific timeout to be used. A value of 0 indicates no timeout
+     * and essentially translates to wait-forever semantics. A value lesser than 0 lets the users of this {@link TimeoutConstraint}
+     * decide what kind of timeout semantics to use while establishing a connection (for example, some implementations
+     * can decide to use some default value).
+     */
+    int getConnectionTimeout();
+
+    /**
+     * @return Returns the timeout, in milli seconds, that's to be used while reading content from a resource.
+     * A value greater than zero indicates the specific timeout to be used. A value of 0 indicates no timeout
+     * and essentially translates to wait-forever semantics. A value lesser than 0 lets the users of this {@link TimeoutConstraint}
+     * decide what kind of timeout semantics to use reading from the resource (for example, some implementations
+     * can decide to use some default value).
+     */
+    int getReadTimeout();
+
+}

--- a/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
+++ b/src/java/org/apache/ivy/core/settings/XmlSettingsParser.java
@@ -105,7 +105,7 @@ public class XmlSettingsParser extends DefaultHandler {
 
     private List<String> configuratorTags = Arrays.asList("resolvers", "namespaces", "parsers",
         "latest-strategies", "conflict-managers", "outputters", "version-matchers", "statuses",
-        "circular-dependency-strategies", "triggers", "lock-strategies", "caches", "signers");
+        "circular-dependency-strategies", "triggers", "lock-strategies", "caches", "signers", "timeout-constraints");
 
     private IvySettings ivy;
 
@@ -180,6 +180,7 @@ public class XmlSettingsParser extends DefaultHandler {
         doParse(configuration);
     }
 
+    @Override
     public void startElement(String uri, String localName, String qName, Attributes att)
             throws SAXException {
         // we first copy attributes in a Map to be able to modify them
@@ -596,6 +597,7 @@ public class XmlSettingsParser extends DefaultHandler {
         }
     }
 
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if (configurator.getCurrent() != null) {
             if (configuratorTags.contains(qName) && configurator.getDepth() == 1) {
@@ -610,6 +612,7 @@ public class XmlSettingsParser extends DefaultHandler {
         }
     }
 
+    @Override
     public void endDocument() throws SAXException {
         if (defaultResolver != null) {
             ivy.setDefaultResolver(ivy.substitute(defaultResolver));

--- a/src/java/org/apache/ivy/core/settings/typedef.properties
+++ b/src/java/org/apache/ivy/core/settings/typedef.properties
@@ -65,3 +65,6 @@ cache			= org.apache.ivy.core.cache.DefaultRepositoryCacheManager
 pgp             = org.apache.ivy.plugins.signer.bouncycastle.OpenPGPSignatureGenerator
 
 osgi-manifest-parser = org.apache.ivy.osgi.core.OSGiManifestParser
+
+timeout-constraint = org.apache.ivy.core.settings.NamedTimeoutConstraint
+

--- a/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
+++ b/src/java/org/apache/ivy/osgi/obr/OBRResolver.java
@@ -85,7 +85,7 @@ public class OBRResolver extends AbstractOSGiResolver {
                 if (eventManager != null) {
                     getRepository().addTransferListener(eventManager);
                 }
-                Resource obrResource = new URLResource(url);
+                final Resource obrResource = new URLResource(url, this.getTimeoutConstraint());
                 CacheResourceOptions options = new CacheResourceOptions();
                 if (metadataTtl != null) {
                     options.setTtl(metadataTtl);

--- a/src/java/org/apache/ivy/osgi/repo/AbstractOSGiResolver.java
+++ b/src/java/org/apache/ivy/osgi/repo/AbstractOSGiResolver.java
@@ -296,7 +296,7 @@ public abstract class AbstractOSGiResolver extends BasicResolver {
         }
         Message.verbose("\tusing url for " + artifact + ": " + url);
         logArtifactAttempt(artifact, url.toExternalForm());
-        Resource resource = new URLResource(url);
+        final Resource resource = new URLResource(url, this.getTimeoutConstraint());
         return new ResolvedResource(resource, artifact.getModuleRevisionId().getRevision());
     }
 

--- a/src/java/org/apache/ivy/osgi/repo/RelativeURLRepository.java
+++ b/src/java/org/apache/ivy/osgi/repo/RelativeURLRepository.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.url.URLRepository;
 import org.apache.ivy.plugins.repository.url.URLResource;
@@ -37,10 +38,21 @@ public class RelativeURLRepository extends URLRepository {
         baseUrl = null;
     }
 
+    /**
+     *
+     * @param baseUrl
+     * @deprecated Since 2.5. Use {@link #RelativeURLRepository(URL, TimeoutConstraint)} instead
+     */
+    @Deprecated
     public RelativeURLRepository(URL baseUrl) {
-        super();
+        this(baseUrl, null);
+    }
+
+    public RelativeURLRepository(final URL baseUrl, final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
         this.baseUrl = baseUrl;
     }
+
 
     private Map<String, Resource> resourcesCache = new HashMap<>();
 
@@ -56,9 +68,9 @@ public class RelativeURLRepository extends URLRepository {
                 uri = null;
             }
             if (uri == null || uri.isAbsolute()) {
-                res = new URLResource(new URL(source));
+                res = new URLResource(new URL(source), getTimeoutConstraint());
             } else {
-                res = new URLResource(new URL(baseUrl + source));
+                res = new URLResource(new URL(baseUrl + source), getTimeoutConstraint());
             }
             resourcesCache.put(source, res);
         }

--- a/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoader.java
+++ b/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoader.java
@@ -32,6 +32,7 @@ import org.apache.ivy.core.cache.RepositoryCacheManager;
 import org.apache.ivy.core.event.EventManager;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.core.report.DownloadStatus;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.osgi.core.ExecutionEnvironmentProfileProvider;
 import org.apache.ivy.osgi.p2.P2ArtifactParser;
 import org.apache.ivy.osgi.p2.P2CompositeParser;
@@ -57,12 +58,16 @@ public class UpdateSiteLoader {
 
     private final CacheResourceOptions options;
 
+    private final TimeoutConstraint timeoutConstraint;
+
     private int logLevel = Message.MSG_INFO;
 
-    public UpdateSiteLoader(RepositoryCacheManager repositoryCacheManager,
-            EventManager eventManager, CacheResourceOptions options) {
+    public UpdateSiteLoader(final RepositoryCacheManager repositoryCacheManager,
+                            final EventManager eventManager, final CacheResourceOptions options,
+                            final TimeoutConstraint timeoutConstraint) {
         this.repositoryCacheManager = repositoryCacheManager;
         this.options = options;
+        this.timeoutConstraint = timeoutConstraint;
         if (eventManager != null) {
             urlRepository.addTransferListener(eventManager);
         }
@@ -177,7 +182,7 @@ public class UpdateSiteLoader {
         InputStream readIn = null; // the input stream from which the xml should be read
 
         URL contentUrl = repoUri.resolve(baseName + ".jar").toURL();
-        URLResource res = new URLResource(contentUrl);
+        URLResource res = new URLResource(contentUrl, this.timeoutConstraint);
 
         ArtifactDownloadReport report = repositoryCacheManager.downloadRepositoryResource(res,
             baseName, baseName, "jar", options, urlRepository);
@@ -185,7 +190,7 @@ public class UpdateSiteLoader {
         if (report.getDownloadStatus() == DownloadStatus.FAILED) {
             // no jar file, try the xml one
             contentUrl = repoUri.resolve(baseName + ".xml").toURL();
-            res = new URLResource(contentUrl);
+            res = new URLResource(contentUrl, this.timeoutConstraint);
 
             report = repositoryCacheManager.downloadRepositoryResource(res, baseName, baseName,
                 "xml", options, urlRepository);
@@ -226,7 +231,7 @@ public class UpdateSiteLoader {
         URI siteUri = normalizeSiteUri(repoUri, null);
         URL u = siteUri.resolve("site.xml").toURL();
 
-        URLResource res = new URLResource(u);
+        final URLResource res = new URLResource(u, this.timeoutConstraint);
         ArtifactDownloadReport report = repositoryCacheManager.downloadRepositoryResource(res,
             "site", "updatesite", "xml", options, urlRepository);
         if (report.getDownloadStatus() == DownloadStatus.FAILED) {
@@ -272,7 +277,7 @@ public class UpdateSiteLoader {
         URL digest = digestBaseUri.resolve("digest.zip").toURL();
         Message.verbose("\tReading " + digest);
 
-        URLResource res = new URLResource(digest);
+        final URLResource res = new URLResource(digest, this.timeoutConstraint);
         ArtifactDownloadReport report = repositoryCacheManager.downloadRepositoryResource(res,
             "digest", "digest", "zip", options, urlRepository);
         if (report.getDownloadStatus() == DownloadStatus.FAILED) {
@@ -294,7 +299,7 @@ public class UpdateSiteLoader {
         for (EclipseFeature feature : site.getFeatures()) {
             URL url = site.getUri().resolve(feature.getUrl()).toURL();
 
-            URLResource res = new URLResource(url);
+            final URLResource res = new URLResource(url, this.timeoutConstraint);
             ArtifactDownloadReport report = repositoryCacheManager.downloadRepositoryResource(res,
                 feature.getId(), "feature", "jar", options, urlRepository);
             if (report.getDownloadStatus() == DownloadStatus.FAILED) {

--- a/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolver.java
+++ b/src/java/org/apache/ivy/osgi/updatesite/UpdateSiteResolver.java
@@ -115,8 +115,8 @@ public class UpdateSiteResolver extends AbstractOSGiResolver {
                 }
             }
         });
-        UpdateSiteLoader loader = new UpdateSiteLoader(getRepositoryCacheManager(),
-                getEventManager(), options);
+        final UpdateSiteLoader loader = new UpdateSiteLoader(getRepositoryCacheManager(),
+                getEventManager(), options, this.getTimeoutConstraint());
         loader.setLogLevel(log);
         RepoDescriptor repoDescriptor;
         try {

--- a/src/java/org/apache/ivy/plugins/parser/ParserSettings.java
+++ b/src/java/org/apache/ivy/plugins/parser/ParserSettings.java
@@ -17,18 +17,19 @@
  */
 package org.apache.ivy.plugins.parser;
 
-import java.io.File;
-import java.util.Map;
-
 import org.apache.ivy.core.RelativeUrlResolver;
 import org.apache.ivy.core.cache.ResolutionCacheManager;
 import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.module.status.StatusManager;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.conflict.ConflictManager;
 import org.apache.ivy.plugins.matcher.PatternMatcher;
 import org.apache.ivy.plugins.namespace.Namespace;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
+
+import java.io.File;
+import java.util.Map;
 
 public interface ParserSettings {
 
@@ -60,4 +61,11 @@ public interface ParserSettings {
     Namespace getContextNamespace();
 
     String getVariable(String string);
+
+    /**
+     * @param name The name of the {@link TimeoutConstraint}
+     * @return Returns a {@link TimeoutConstraint} which is identified by the passed <code>name</code>. Returns null
+     * if no such {@link TimeoutConstraint} exists
+     */
+    TimeoutConstraint getTimeoutConstraint(String name);
 }

--- a/src/java/org/apache/ivy/plugins/repository/AbstractRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/AbstractRepository.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import javax.swing.event.EventListenerList;
 
 import org.apache.ivy.core.module.descriptor.Artifact;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 
 public abstract class AbstractRepository implements Repository {
     private EventListenerList listeners = new EventListenerList();
@@ -31,6 +32,16 @@ public abstract class AbstractRepository implements Repository {
     private String name;
 
     private TransferEvent evt;
+
+    private final TimeoutConstraint timeoutConstraint;
+
+    public AbstractRepository() {
+        this(null);
+    }
+
+    protected AbstractRepository(final TimeoutConstraint timeoutConstraint) {
+        this.timeoutConstraint = timeoutConstraint;
+    }
 
     public void addTransferListener(TransferListener listener) {
         listeners.add(TransferListener.class, listener);
@@ -119,6 +130,10 @@ public abstract class AbstractRepository implements Repository {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public TimeoutConstraint getTimeoutConstraint() {
+        return this.timeoutConstraint;
     }
 
     @Override

--- a/src/java/org/apache/ivy/plugins/repository/jar/JarRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/jar/JarRepository.java
@@ -27,6 +27,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.AbstractRepository;
 import org.apache.ivy.plugins.repository.RepositoryCopyProgressListener;
 import org.apache.ivy.plugins.repository.Resource;
@@ -38,6 +39,14 @@ public class JarRepository extends AbstractRepository {
     private RepositoryCopyProgressListener progress = new RepositoryCopyProgressListener(this);
 
     private JarFile jarFile;
+
+    public JarRepository() {
+
+    }
+
+    public JarRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
+    }
 
     public void setJarFile(JarFile jarFile) {
         this.jarFile = jarFile;

--- a/src/java/org/apache/ivy/plugins/repository/sftp/SFTPRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/sftp/SFTPRepository.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.BasicResource;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.plugins.repository.TransferEvent;
@@ -70,6 +71,10 @@ public class SFTPRepository extends AbstractSshBasedRepository {
     }
 
     public SFTPRepository() {
+    }
+
+    public SFTPRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
     }
 
     public Resource getResource(String source) {

--- a/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/AbstractSshBasedRepository.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.AbstractRepository;
 import org.apache.ivy.util.Credentials;
 import org.apache.ivy.util.CredentialsUtil;
@@ -57,6 +58,10 @@ public abstract class AbstractSshBasedRepository extends AbstractRepository {
 
     public AbstractSshBasedRepository() {
         super();
+    }
+
+    public AbstractSshBasedRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
     }
 
     /**

--- a/src/java/org/apache/ivy/plugins/repository/ssh/SshRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/ssh/SshRepository.java
@@ -29,6 +29,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.util.Message;
 
@@ -56,6 +57,14 @@ public class SshRepository extends AbstractSshBasedRepository {
     private String createDirCommand = "mkdir";
 
     private String publishPermissions = null;
+
+    public SshRepository() {
+
+    }
+
+    public SshRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
+    }
 
     /**
      * create a new resource with lazy initializing

--- a/src/java/org/apache/ivy/plugins/repository/url/URLRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/url/URLRepository.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.AbstractRepository;
 import org.apache.ivy.plugins.repository.RepositoryCopyProgressListener;
 import org.apache.ivy.plugins.repository.Resource;
@@ -40,10 +41,17 @@ public class URLRepository extends AbstractRepository {
 
     private final Map<String, Resource> resourcesCache = new HashMap<>();
 
+    public URLRepository() {
+    }
+
+    public URLRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
+    }
+
     public Resource getResource(String source) throws IOException {
         Resource res = resourcesCache.get(source);
         if (res == null) {
-            res = new URLResource(new URL(source));
+            res = new URLResource(new URL(source), this.getTimeoutConstraint());
             resourcesCache.put(source, res);
         }
         return res;
@@ -57,7 +65,7 @@ public class URLRepository extends AbstractRepository {
             if (totalLength > 0) {
                 progress.setTotalLength(totalLength);
             }
-            FileUtil.copy(new URL(source), destination, progress);
+            FileUtil.copy(new URL(source), destination, progress, getTimeoutConstraint());
         } catch (IOException | RuntimeException ex) {
             fireTransferError(ex);
             throw ex;
@@ -77,7 +85,7 @@ public class URLRepository extends AbstractRepository {
             if (totalLength > 0) {
                 progress.setTotalLength(totalLength);
             }
-            FileUtil.copy(source, new URL(destination), progress);
+            FileUtil.copy(source, new URL(destination), progress, getTimeoutConstraint());
         } catch (IOException | RuntimeException ex) {
             fireTransferError(ex);
             throw ex;

--- a/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
+++ b/src/java/org/apache/ivy/plugins/repository/url/URLResource.java
@@ -24,13 +24,15 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.LocalizableResource;
 import org.apache.ivy.plugins.repository.Resource;
 import org.apache.ivy.util.url.URLHandler.URLInfo;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
 public class URLResource implements LocalizableResource {
-    private URL url;
+    private final URL url;
+    private final TimeoutConstraint timeoutConstraint;
 
     private boolean init = false;
 
@@ -40,8 +42,13 @@ public class URLResource implements LocalizableResource {
 
     private boolean exists;
 
-    public URLResource(URL url) {
+    public URLResource(final URL url) {
+        this(url, null);
+    }
+
+    public URLResource(final URL url, final TimeoutConstraint timeoutConstraint) {
         this.url = url;
+        this.timeoutConstraint = timeoutConstraint;
     }
 
     public String getName() {
@@ -65,7 +72,7 @@ public class URLResource implements LocalizableResource {
     }
 
     private void init() {
-        URLInfo info = URLHandlerRegistry.getDefault().getURLInfo(url);
+        final URLInfo info = URLHandlerRegistry.getDefault().getURLInfo(url, this.timeoutConstraint);
         contentLength = info.getContentLength();
         lastModified = info.getLastModified();
         exists = info.isReachable();

--- a/src/java/org/apache/ivy/plugins/repository/vfs/VfsRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/vfs/VfsRepository.java
@@ -31,6 +31,7 @@ import org.apache.commons.vfs.FileSystemException;
 import org.apache.commons.vfs.FileSystemManager;
 import org.apache.commons.vfs.FileType;
 import org.apache.commons.vfs.impl.StandardFileSystemManager;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.AbstractRepository;
 import org.apache.ivy.plugins.repository.RepositoryCopyProgressListener;
 import org.apache.ivy.plugins.repository.Resource;
@@ -56,6 +57,10 @@ public class VfsRepository extends AbstractRepository {
      * Create a new Ivy VFS Repository Instance
      */
     public VfsRepository() {
+    }
+
+    public VfsRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
     }
 
     private FileSystemManager getVFSManager() throws IOException {

--- a/src/java/org/apache/ivy/plugins/repository/vsftp/VsftpRepository.java
+++ b/src/java/org/apache/ivy/plugins/repository/vsftp/VsftpRepository.java
@@ -34,6 +34,7 @@ import org.apache.ivy.core.IvyThread;
 import org.apache.ivy.core.event.IvyEvent;
 import org.apache.ivy.core.event.IvyListener;
 import org.apache.ivy.core.event.resolve.EndResolveEvent;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.plugins.repository.AbstractRepository;
 import org.apache.ivy.plugins.repository.BasicResource;
 import org.apache.ivy.plugins.repository.Resource;
@@ -118,6 +119,14 @@ public class VsftpRepository extends AbstractRepository {
     private volatile long errorsLastUpdateTime;
 
     private Ivy ivy = null;
+
+    public VsftpRepository() {
+
+    }
+
+    public VsftpRepository(final TimeoutConstraint timeoutConstraint) {
+        super(timeoutConstraint);
+    }
 
     public Resource getResource(String source) throws IOException {
         initIvy();

--- a/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/BasicResolver.java
@@ -1037,7 +1037,7 @@ public abstract class BasicResolver extends AbstractResolver {
                     }
                     resource = new FileResource(new FileRepository(), f);
                 } else {
-                    resource = new URLResource(url);
+                    resource = new URLResource(url, this.getTimeoutConstraint());
                 }
                 ret = new ResolvedResource(resource, artifact.getModuleRevisionId().getRevision());
             }

--- a/src/java/org/apache/ivy/plugins/resolver/JarResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/JarResolver.java
@@ -37,7 +37,7 @@ public class JarResolver extends RepositoryResolver {
     private URL url;
 
     public JarResolver() {
-        setRepository(new JarRepository());
+        setRepository(new JarRepository(new LazyTimeoutConstraint(this)));
     }
 
     @Override
@@ -84,7 +84,7 @@ public class JarResolver extends RepositoryResolver {
                 if (eventManager != null) {
                     getRepository().addTransferListener(eventManager);
                 }
-                Resource jarResource = new URLResource(url);
+                Resource jarResource = new URLResource(url, this.getTimeoutConstraint());
                 CacheResourceOptions options = new CacheResourceOptions();
                 report = getRepositoryCacheManager().downloadRepositoryResource(jarResource,
                     "jarrepository", "jar", "jar", options, new URLRepository());

--- a/src/java/org/apache/ivy/plugins/resolver/LazyTimeoutConstraint.java
+++ b/src/java/org/apache/ivy/plugins/resolver/LazyTimeoutConstraint.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ivy.plugins.resolver;
+
+import org.apache.ivy.core.settings.TimeoutConstraint;
+
+/**
+ * A {@link TimeoutConstraint} which determines the timeouts by invoking the {@link AbstractResolver underlying resolver}'s
+ * {@link AbstractResolver#getTimeoutConstraint()}, whenever the timeouts are requested for.
+ * This class can be used when the {@link TimeoutConstraint} is to be created but the underlying resolver, which decides the timeouts,
+ * hasn't yet been fully initialized
+ */
+final class LazyTimeoutConstraint implements TimeoutConstraint {
+
+    private final AbstractResolver resolver;
+
+    public LazyTimeoutConstraint(final AbstractResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        final TimeoutConstraint resolverTimeoutConstraint = resolver.getTimeoutConstraint();
+        return resolverTimeoutConstraint == null ? -1 : resolverTimeoutConstraint.getConnectionTimeout();
+    }
+
+    @Override
+    public int getReadTimeout() {
+        final TimeoutConstraint resolverTimeoutConstraint = resolver.getTimeoutConstraint();
+        return resolverTimeoutConstraint == null ? -1 : resolverTimeoutConstraint.getReadTimeout();
+    }
+}

--- a/src/java/org/apache/ivy/plugins/resolver/MirroredURLResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/MirroredURLResolver.java
@@ -67,7 +67,7 @@ public class MirroredURLResolver extends RepositoryResolver {
                         + ", an incorrect url has been found and will then not be used: " + baseUrl);
             }
             if (url != null) {
-                RelativeURLRepository repo = new RelativeURLRepository(url);
+                final RelativeURLRepository repo = new RelativeURLRepository(url, this.getTimeoutConstraint());
                 repositories.add(repo);
             }
         }
@@ -75,11 +75,11 @@ public class MirroredURLResolver extends RepositoryResolver {
     }
 
     private File downloadMirrorList() {
-        URLRepository urlRepository = new URLRepository();
+        final URLRepository urlRepository = new URLRepository(this.getTimeoutConstraint());
         if (getEventManager() != null) {
             urlRepository.addTransferListener(getEventManager());
         }
-        URLResource mirrorResource = new URLResource(mirrorListUrl);
+        final URLResource mirrorResource = new URLResource(mirrorListUrl, this.getTimeoutConstraint());
         CacheResourceOptions options = new CacheResourceOptions();
         ArtifactDownloadReport report = getRepositoryCacheManager().downloadRepositoryResource(
             mirrorResource, "mirrorlist", "text", "txt", options, urlRepository);

--- a/src/java/org/apache/ivy/plugins/resolver/SFTPResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/SFTPResolver.java
@@ -28,7 +28,7 @@ import org.apache.ivy.plugins.repository.sftp.SFTPRepository;
 public class SFTPResolver extends AbstractSshBasedResolver {
 
     public SFTPResolver() {
-        setRepository(new SFTPRepository());
+        setRepository(new SFTPRepository(new LazyTimeoutConstraint(this)));
     }
 
     @Override

--- a/src/java/org/apache/ivy/plugins/resolver/SshResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/SshResolver.java
@@ -25,7 +25,7 @@ import org.apache.ivy.plugins.repository.ssh.SshRepository;
 public class SshResolver extends AbstractSshBasedResolver {
 
     public SshResolver() {
-        setRepository(new SshRepository());
+        setRepository(new SshRepository(new LazyTimeoutConstraint(this)));
     }
 
     /**

--- a/src/java/org/apache/ivy/plugins/resolver/URLResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/URLResolver.java
@@ -25,11 +25,12 @@ import org.apache.ivy.plugins.repository.url.URLRepository;
  */
 public class URLResolver extends RepositoryResolver {
     public URLResolver() {
-        setRepository(new URLRepository());
+        setRepository(new URLRepository(new LazyTimeoutConstraint(this)));
     }
 
     @Override
     public String getTypeName() {
         return "url";
     }
+
 }

--- a/src/java/org/apache/ivy/plugins/resolver/VfsResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/VfsResolver.java
@@ -31,7 +31,7 @@ public class VfsResolver extends RepositoryResolver {
     private static final int PASSWORD_GROUP = 2;
 
     public VfsResolver() {
-        setRepository(new VfsRepository());
+        setRepository(new VfsRepository(new LazyTimeoutConstraint(this)));
     }
 
     @Override

--- a/src/java/org/apache/ivy/plugins/resolver/VsftpResolver.java
+++ b/src/java/org/apache/ivy/plugins/resolver/VsftpResolver.java
@@ -25,7 +25,7 @@ import org.apache.ivy.plugins.repository.vsftp.VsftpRepository;
  */
 public class VsftpResolver extends RepositoryResolver {
     public VsftpResolver() {
-        setRepository(new VsftpRepository());
+        setRepository(new VsftpRepository(new LazyTimeoutConstraint(this)));
     }
 
     @Override

--- a/src/java/org/apache/ivy/util/FileUtil.java
+++ b/src/java/org/apache/ivy/util/FileUtil.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipInputStream;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.util.url.URLHandlerRegistry;
 
 /**
@@ -271,12 +272,14 @@ public final class FileUtil {
         return true;
     }
 
-    public static void copy(URL src, File dest, CopyProgressListener l) throws IOException {
-        URLHandlerRegistry.getDefault().download(src, dest, l);
+    public static void copy(final URL src, final File dest, final CopyProgressListener listener,
+                            final TimeoutConstraint timeoutConstraint) throws IOException {
+        URLHandlerRegistry.getDefault().download(src, dest, listener, timeoutConstraint);
     }
 
-    public static void copy(File src, URL dest, CopyProgressListener l) throws IOException {
-        URLHandlerRegistry.getDefault().upload(src, dest, l);
+    public static void copy(final File src, final URL dest, final CopyProgressListener listener,
+                            final TimeoutConstraint timeoutConstraint) throws IOException {
+        URLHandlerRegistry.getDefault().upload(src, dest, listener, timeoutConstraint);
     }
 
     public static void copy(InputStream src, File dest, CopyProgressListener l) throws IOException {

--- a/src/java/org/apache/ivy/util/StringUtils.java
+++ b/src/java/org/apache/ivy/util/StringUtils.java
@@ -189,4 +189,18 @@ public final class StringUtils {
         return sb.toString();
     }
 
+    /**
+     * Asserts that the passed <code>value</code> is not null and not an empty {@link String}. The implementation
+     * of this method {@link String#trim() trims} the (non-null) <code>value</code> to check whether the value is an
+     * empty string. If the <code>value</code> is either null or empty, then this method throws an {@link IllegalArgumentException}
+     * with the passed <code>errorMessage</code> as the message in the exception.
+     *
+     * @param value        The value to check for
+     * @param errorMessage The error message
+     */
+    public static void assertNotNullNotEmpty(final String value, final String errorMessage) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
 }

--- a/src/java/org/apache/ivy/util/url/AbstractURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/AbstractURLHandler.java
@@ -31,6 +31,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import org.apache.ivy.Ivy;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 
 public abstract class AbstractURLHandler implements URLHandler {
 
@@ -39,28 +40,49 @@ public abstract class AbstractURLHandler implements URLHandler {
     // the request method to use. TODO: don't use a static here
     private static int requestMethod = REQUEST_METHOD_HEAD;
 
-    public boolean isReachable(URL url) {
-        return getURLInfo(url).isReachable();
+    @Override
+    public boolean isReachable(final URL url) {
+        return this.isReachable(url, null);
     }
 
-    public boolean isReachable(URL url, int timeout) {
-        return getURLInfo(url, timeout).isReachable();
+    @Override
+    public boolean isReachable(final URL url, final int timeout) {
+        return this.isReachable(url, createTimeoutConstraints(timeout));
     }
 
-    public long getContentLength(URL url) {
-        return getURLInfo(url).getContentLength();
+    @Override
+    public boolean isReachable(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getURLInfo(url, timeoutConstraint).isReachable();
     }
 
-    public long getContentLength(URL url, int timeout) {
-        return getURLInfo(url, timeout).getContentLength();
+    @Override
+    public long getContentLength(final URL url) {
+        return this.getContentLength(url, null);
     }
 
-    public long getLastModified(URL url) {
-        return getURLInfo(url).getLastModified();
+    @Override
+    public long getContentLength(final URL url, final int timeout) {
+        return this.getContentLength(url, createTimeoutConstraints(timeout));
     }
 
-    public long getLastModified(URL url, int timeout) {
-        return getURLInfo(url, timeout).getLastModified();
+    @Override
+    public long getContentLength(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getURLInfo(url, timeoutConstraint).getContentLength();
+    }
+
+    @Override
+    public long getLastModified(final URL url) {
+        return this.getLastModified(url, null);
+    }
+
+    @Override
+    public long getLastModified(final URL url, final int timeout) {
+        return this.getLastModified(url, createTimeoutConstraints(timeout));
+    }
+
+    @Override
+    public long getLastModified(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getURLInfo(url, timeoutConstraint).getLastModified();
     }
 
     protected String getUserAgent() {
@@ -173,4 +195,17 @@ public abstract class AbstractURLHandler implements URLHandler {
         return result;
     }
 
+    protected static TimeoutConstraint createTimeoutConstraints(final int connectionTimeout) {
+        return new TimeoutConstraint() {
+            @Override
+            public int getConnectionTimeout() {
+                return connectionTimeout;
+            }
+
+            @Override
+            public int getReadTimeout() {
+                return -1;
+            }
+        };
+    }
 }

--- a/src/java/org/apache/ivy/util/url/URLHandler.java
+++ b/src/java/org/apache/ivy/util/url/URLHandler.java
@@ -17,12 +17,13 @@
  */
 package org.apache.ivy.util.url;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
+import org.apache.ivy.util.CopyProgressListener;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-
-import org.apache.ivy.util.CopyProgressListener;
 
 /**
  * This interface is responsible for handling some URL manipulation (stream opening, downloading,
@@ -34,14 +35,14 @@ public interface URLHandler {
      * Using the slower REQUEST method for getting the basic URL infos. Use this when getting errors
      * behind a problematic/special proxy or firewall chain.
      */
-    public static final int REQUEST_METHOD_GET = 1;
+    int REQUEST_METHOD_GET = 1;
 
     /**
      * Using the faster HEAD method for getting the basic URL infos. Works for most common networks.
      */
-    public static final int REQUEST_METHOD_HEAD = 2;
+    int REQUEST_METHOD_HEAD = 2;
 
-    public static class URLInfo {
+    class URLInfo {
         private long contentLength;
 
         private long lastModified;
@@ -55,7 +56,7 @@ public interface URLHandler {
         }
 
         protected URLInfo(boolean available, long contentLength, long lastModified,
-                String bodyCharset) {
+                          String bodyCharset) {
             this.available = available;
             this.contentLength = contentLength;
             this.lastModified = lastModified;
@@ -79,86 +80,210 @@ public interface URLHandler {
         }
     }
 
-    public static final URLInfo UNAVAILABLE = new URLInfo(false, 0, 0);
+    URLInfo UNAVAILABLE = new URLInfo(false, 0, 0);
 
     /**
      * Please prefer getURLInfo when several infos are needed.
      *
      * @param url the url to check
      * @return true if the target is reachable
+     * @deprecated Use {@link #isReachable(URL, TimeoutConstraint)} instead
      */
-    public boolean isReachable(URL url);
+    @Deprecated
+    boolean isReachable(URL url);
 
     /**
      * Please prefer getURLInfo when several infos are needed.
      *
-     * @param url the url to check
+     * @param url     the url to check
      * @param timeout the timeout in milliseconds
      * @return true if the target is reachable
+     * @deprecated Use {@link #isReachable(URL, TimeoutConstraint)} instead
      */
-    public boolean isReachable(URL url, int timeout);
+    @Deprecated
+    boolean isReachable(URL url, int timeout);
+
+    /**
+     * Returns true if the passed <code>URL</code> is reachable. Else returns false. Uses the
+     * passed <code>timeoutConstraint</code> for determining the connectivity to the URL.
+     * <p>
+     * Please use {@link #getURLInfo(URL, TimeoutConstraint)} if more one information about the <code>url</code>
+     * is needed
+     *
+     * @param url                The URL to access
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @return
+     * @since 2.5
+     */
+    boolean isReachable(URL url, TimeoutConstraint timeoutConstraint);
 
     /**
      * Please prefer getURLInfo when several infos are needed.
      *
      * @param url the url to check
      * @return the length of the target if the given url is reachable, 0 otherwise. No error code in
-     *         case of http urls.
+     * case of http urls.
+     * @deprecated Use {@link #getContentLength(URL, TimeoutConstraint)} instead
      */
-    public long getContentLength(URL url);
+    @Deprecated
+    long getContentLength(URL url);
 
     /**
-     * @param url
-     *            the url to check
-     * @param timeout
-     *            the maximum time before considering an url is not reachable a
-     *            timeout of zero indicates no timeout
+     * @param url     the url to check
+     * @param timeout the maximum time before considering an url is not reachable a
+     *                timeout of zero indicates no timeout
      * @return the length of the target if the given url is reachable, 0 otherwise. No error code in
-     *         case of http urls.
+     * case of http urls.
+     * @deprecated Use {@link #getContentLength(URL, TimeoutConstraint)} instead
      */
-    public long getContentLength(URL url, int timeout);
+    @Deprecated
+    long getContentLength(URL url, int timeout);
+
+    /**
+     * Returns the number of bytes of data that's available for the resource at the passed <code>url</code>.
+     * Returns 0 if the passed <code>url</code> isn't reachable
+     *
+     * @param url                The URL to access
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @return
+     * @since 2.5
+     */
+    long getContentLength(URL url, TimeoutConstraint timeoutConstraint);
 
     /**
      * Please prefer getURLInfo when several infos are needed.
      *
-     * @param url
-     *            the url to check
+     * @param url the url to check
      * @return last modified timestamp of the given url
+     * @deprecated Use {@link #getLastModified(URL, TimeoutConstraint)} instead
      */
-    public long getLastModified(URL url);
+    @Deprecated
+    long getLastModified(URL url);
 
     /**
      * Please prefer getURLInfo when several infos are needed.
      *
-     * @param url the url to check
+     * @param url     the url to check
      * @param timeout the timeout in milliseconds
      * @return last modified timestamp of the given url
+     * @deprecated Use {@link #getLastModified(URL, TimeoutConstraint)} instead
      */
-    public long getLastModified(URL url, int timeout);
+    @Deprecated
+    long getLastModified(URL url, int timeout);
 
     /**
-     * @param url
-     *            The url from which information is retrieved.
+     * Returns the last modified timestamp of the resource accessible at the passed <code>url</code>.
+     * <p>
+     * Please use {@link #getURLInfo(URL, TimeoutConstraint)} if more one information about the <code>url</code>
+     * is needed
+     *
+     * @param url                The URL to access
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @return
+     * @since 2.5
+     */
+    long getLastModified(URL url, TimeoutConstraint timeoutConstraint);
+
+    /**
+     * @param url The url from which information is retrieved.
      * @return The URLInfo extracted from the given url, or {@link #UNAVAILABLE} instance when the
-     *         url is not reachable.
+     * url is not reachable.
+     * @deprecated Use {@link #getURLInfo(URL, TimeoutConstraint)} instead
      */
-    public URLInfo getURLInfo(URL url);
+    @Deprecated
+    URLInfo getURLInfo(URL url);
+
+    /**
+     * @param url     The url from which information is retrieved.
+     * @param timeout The timeout in milliseconds.
+     * @return The URLInfo extracted from the given url, or {@link #UNAVAILABLE} when the url is not
+     * reachable, never null.
+     * @deprecated Use {@link #getURLInfo(URL, TimeoutConstraint)} instead
+     */
+    @Deprecated
+    URLInfo getURLInfo(URL url, int timeout);
+
+    /**
+     * Returns the {@link URLInfo} extracted from the given url, or {@link #UNAVAILABLE} when the url is not
+     * reachable. Never returns null.
+     *
+     * @param url                The URL for which the information is to be retrieved
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @return
+     * @since 2.5
+     */
+    URLInfo getURLInfo(URL url, TimeoutConstraint timeoutConstraint);
 
     /**
      * @param url
-     *            The url from which information is retrieved.
-     * @param timeout
-     *            The timeout in milliseconds.
-     * @return The URLInfo extracted from the given url, or {@link #UNAVAILABLE} when the url is not
-     *         reachable, never null.
+     * @return
+     * @throws IOException
+     * @deprecated Use {@link #openStream(URL, TimeoutConstraint)} instead
      */
-    public URLInfo getURLInfo(URL url, int timeout);
+    @Deprecated
+    InputStream openStream(URL url) throws IOException;
 
-    public InputStream openStream(URL url) throws IOException;
+    /**
+     * Opens and returns an {@link InputStream} to the passed <code>url</code>.
+     *
+     * @param url                The URL to which an {@link InputStream} has to be opened
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @return
+     * @throws IOException
+     * @since 2.5
+     */
+    InputStream openStream(URL url, TimeoutConstraint timeoutConstraint) throws IOException;
 
-    public void download(URL src, File dest, CopyProgressListener l) throws IOException;
+    /**
+     * @param src
+     * @param dest
+     * @param l
+     * @throws IOException
+     * @deprecated Use {@link #download(URL, File, CopyProgressListener, TimeoutConstraint)} instead
+     */
+    @Deprecated
+    void download(URL src, File dest, CopyProgressListener l) throws IOException;
 
-    public void upload(File src, URL dest, CopyProgressListener l) throws IOException;
+    /**
+     * Downloads the resource available at <code>src</code> to the target <code>dest</code>
+     *
+     * @param src                The source URL to download the resource from
+     * @param dest               The destination {@link File} to download the resource to
+     * @param listener           The listener that will be notified of the download progress
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @throws IOException
+     * @since 2.5
+     */
+    void download(URL src, File dest, CopyProgressListener listener, TimeoutConstraint timeoutConstraint) throws IOException;
 
-    public void setRequestMethod(int requestMethod);
+    /**
+     * @param src
+     * @param dest
+     * @param l
+     * @throws IOException
+     * @deprecated Use {@link #upload(File, URL, CopyProgressListener, TimeoutConstraint)} instead
+     */
+    @Deprecated
+    void upload(File src, URL dest, CopyProgressListener l) throws IOException;
+
+    /**
+     * Uploads the <code>src</code> {@link File} to the target <code>dest</code> {@link URL}
+     *
+     * @param src                The source {@link File} to upload
+     * @param dest               The target URL where the {@link File} has to be uploaded
+     * @param listener           The listener that will be notified of the upload progress
+     * @param timeoutConstraint The connectivity timeout constraints. Can be null, in which case the timeouts
+     *                           are implementation specific
+     * @throws IOException
+     * @since 2.5
+     */
+    void upload(File src, URL dest, CopyProgressListener listener, TimeoutConstraint timeoutConstraint) throws IOException;
+
+    void setRequestMethod(int requestMethod);
 }

--- a/src/java/org/apache/ivy/util/url/URLHandlerDispatcher.java
+++ b/src/java/org/apache/ivy/util/url/URLHandlerDispatcher.java
@@ -17,14 +17,15 @@
  */
 package org.apache.ivy.util.url;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
+import org.apache.ivy.util.CopyProgressListener;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.ivy.util.CopyProgressListener;
 
 /**
  * This class is used to dispatch downloading requests
@@ -37,48 +38,94 @@ public class URLHandlerDispatcher implements URLHandler {
     public URLHandlerDispatcher() {
     }
 
-    public boolean isReachable(URL url) {
-        return getHandler(url.getProtocol()).isReachable(url);
+    @Override
+    public boolean isReachable(final URL url) {
+        return this.isReachable(url, null);
     }
 
-    public boolean isReachable(URL url, int timeout) {
-        return getHandler(url.getProtocol()).isReachable(url, timeout);
+    @Override
+    public boolean isReachable(final URL url, final int timeout) {
+        return this.isReachable(url, createTimeoutConstraints(timeout));
     }
 
-    public long getContentLength(URL url) {
-        return getHandler(url.getProtocol()).getContentLength(url);
+    @Override
+    public boolean isReachable(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getHandler(url.getProtocol()).isReachable(url, timeoutConstraint);
     }
 
-    public long getContentLength(URL url, int timeout) {
-        return getHandler(url.getProtocol()).getContentLength(url, timeout);
+    @Override
+    public long getContentLength(final URL url) {
+        return this.getContentLength(url, null);
     }
 
-    public long getLastModified(URL url) {
-        return getHandler(url.getProtocol()).getLastModified(url);
+    @Override
+    public long getContentLength(final URL url, final int timeout) {
+        return this.getContentLength(url, createTimeoutConstraints(timeout));
     }
 
-    public long getLastModified(URL url, int timeout) {
-        return getHandler(url.getProtocol()).getLastModified(url, timeout);
+    @Override
+    public long getContentLength(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getHandler(url.getProtocol()).getContentLength(url, timeoutConstraint);
     }
 
-    public URLInfo getURLInfo(URL url) {
-        return getHandler(url.getProtocol()).getURLInfo(url);
+    @Override
+    public long getLastModified(final URL url) {
+        return this.getLastModified(url, null);
     }
 
-    public URLInfo getURLInfo(URL url, int timeout) {
-        return getHandler(url.getProtocol()).getURLInfo(url, timeout);
+    @Override
+    public long getLastModified(final URL url, final int timeout) {
+        return this.getLastModified(url, createTimeoutConstraints(timeout));
     }
 
-    public InputStream openStream(URL url) throws IOException {
-        return getHandler(url.getProtocol()).openStream(url);
+    @Override
+    public long getLastModified(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getHandler(url.getProtocol()).getLastModified(url, timeoutConstraint);
     }
 
-    public void download(URL src, File dest, CopyProgressListener l) throws IOException {
-        getHandler(src.getProtocol()).download(src, dest, l);
+    @Override
+    public URLInfo getURLInfo(final URL url) {
+        return this.getURLInfo(url, null);
     }
 
-    public void upload(File src, URL dest, CopyProgressListener l) throws IOException {
-        getHandler(dest.getProtocol()).upload(src, dest, l);
+    @Override
+    public URLInfo getURLInfo(final URL url, final int timeout) {
+        return this.getURLInfo(url, createTimeoutConstraints(timeout));
+    }
+
+    @Override
+    public URLInfo getURLInfo(final URL url, final TimeoutConstraint timeoutConstraint) {
+        return this.getHandler(url.getProtocol()).getURLInfo(url, timeoutConstraint);
+    }
+
+    @Override
+    public InputStream openStream(final URL url) throws IOException {
+        return this.openStream(url, null);
+    }
+
+    @Override
+    public InputStream openStream(final URL url, final TimeoutConstraint timeoutConstraint) throws IOException {
+        return this.getHandler(url.getProtocol()).openStream(url, timeoutConstraint);
+    }
+
+    @Override
+    public void download(final URL src, final File dest, final CopyProgressListener l) throws IOException {
+        this.download(src, dest, l);
+    }
+
+    @Override
+    public void download(final URL src, final File dest, final CopyProgressListener listener, final TimeoutConstraint timeoutConstraint) throws IOException {
+        this.getHandler(src.getProtocol()).download(src, dest, listener, timeoutConstraint);
+    }
+
+    @Override
+    public void upload(final File src, final URL dest, final CopyProgressListener l) throws IOException {
+        this.upload(src, dest, l);
+    }
+
+    @Override
+    public void upload(final File src, final URL dest, final CopyProgressListener listener, final TimeoutConstraint timeoutConstraint) throws IOException {
+        this.getHandler(dest.getProtocol()).upload(src, dest, listener, timeoutConstraint);
     }
 
     public void setRequestMethod(int requestMethod) {
@@ -103,5 +150,20 @@ public class URLHandlerDispatcher implements URLHandler {
 
     public void setDefault(URLHandler default1) {
         defaultHandler = default1;
+    }
+
+    private static TimeoutConstraint createTimeoutConstraints(final int connectionTimeout) {
+        return new TimeoutConstraint() {
+            @Override
+            public int getConnectionTimeout() {
+                return connectionTimeout;
+            }
+
+            @Override
+            public int getReadTimeout() {
+                return -1;
+            }
+
+        };
     }
 }

--- a/test/java/org/apache/ivy/LocalFileRepoOverHttp.java
+++ b/test/java/org/apache/ivy/LocalFileRepoOverHttp.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ivy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.apache.ivy.util.Message;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A {@link HttpHandler} that can be used in tests to serve local file system based resources over HTTP
+ * NOTE: This handler reads the complete file contents, all into memory while serving it and thus isn't suitable
+ * with very large files. Use this handler only in test cases where the files to serve are reasonably small in size
+ */
+final class LocalFileRepoOverHttp implements HttpHandler {
+
+    private final String webContextRoot;
+    private final Path localFileRepoRoot;
+
+    LocalFileRepoOverHttp(final String webContextRoot, final Path localFileRepoRoot) {
+        if (!Files.isDirectory(localFileRepoRoot)) {
+            throw new IllegalArgumentException(localFileRepoRoot + " is either missing or not a directory");
+        }
+        this.webContextRoot = webContextRoot;
+        this.localFileRepoRoot = localFileRepoRoot;
+    }
+
+    @Override
+    public void handle(final HttpExchange httpExchange) throws IOException {
+        final URI requestURI = httpExchange.getRequestURI();
+        Message.info("Handling " + httpExchange.getRequestMethod() + " request " + requestURI);
+        final URI artifactURI;
+        try {
+            artifactURI = new URI(webContextRoot).relativize(requestURI);
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
+        final Path localFilePath = localFileRepoRoot.resolve(artifactURI.toString());
+        if (httpExchange.getRequestMethod().equals("HEAD")) {
+            final boolean available = this.isPresent(localFilePath);
+            if (!available) {
+                httpExchange.sendResponseHeaders(404, -1);
+            } else {
+                httpExchange.sendResponseHeaders(200, -1);
+            }
+            return;
+        }
+        if (!httpExchange.getRequestMethod().equals("GET")) {
+            throw new IOException("Cannot handle " + httpExchange.getRequestMethod() + " HTTP method");
+        }
+        final OutputStream responseStream = httpExchange.getResponseBody();
+        final int numBytes = this.serve(httpExchange, localFilePath, responseStream);
+        responseStream.close();
+    }
+
+    private boolean isPresent(final Path localFile) {
+        return Files.isRegularFile(localFile);
+    }
+
+    private int serve(final HttpExchange httpExchange, final Path localFile, final OutputStream os) throws IOException {
+        if (!Files.isRegularFile(localFile)) {
+            throw new IOException("No such file at path " + localFile);
+        }
+        Message.debug("Serving contents of " + localFile + " for request " + httpExchange.getRequestURI());
+        final byte[] data = Files.readAllBytes(localFile);
+        httpExchange.sendResponseHeaders(200, data.length);
+        os.write(data);
+        return data.length;
+    }
+}

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -840,7 +840,7 @@ public class ResolveTest {
         // put necessary stuff in cache, and it should now be ok
         File ivyfile = getIvyFileInCache(ModuleRevisionId.newInstance("org1", "mod1.2", "2.0"));
         File art = getArchiveFileInCache(ivy, "org1", "mod1.2", "2.0", "mod1.2", "jar", "jar");
-        FileUtil.copy(ResolveTest.class.getResource("ivy-mod1.2.xml"), ivyfile, null);
+        FileUtil.copy(ResolveTest.class.getResource("ivy-mod1.2.xml"), ivyfile, null, null);
         FileUtil.copy(new File("test/repositories/1/org1/mod1.2/jars/mod1.2-2.0.jar"), art, null);
 
         ResolveReport report = ivy.resolve(new File(

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -17,16 +17,6 @@
  */
 package org.apache.ivy.core.settings;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.List;
-
 import org.apache.ivy.core.cache.DefaultRepositoryCacheManager;
 import org.apache.ivy.core.cache.ResolutionCacheManager;
 import org.apache.ivy.core.module.descriptor.Artifact;
@@ -47,6 +37,7 @@ import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.MockResolver;
+import org.apache.ivy.plugins.resolver.URLResolver;
 import org.apache.ivy.plugins.resolver.packager.PackagerResolver;
 import org.apache.ivy.plugins.version.ChainVersionMatcher;
 import org.apache.ivy.plugins.version.MockVersionMatcher;
@@ -55,8 +46,19 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 /**
- * TODO write javadoc
+ * Test the parsing of Ivy settings file through the {@link XmlSettingsParser}
  */
 public class XmlSettingsParserTest {
     @Rule
@@ -77,7 +79,7 @@ public class XmlSettingsParserTest {
 
         assertEquals("[module]/ivys/ivy-[revision].xml", settings.getDefaultCacheIvyPattern());
         assertEquals("[module]/[type]s/[artifact]-[revision].[ext]",
-            settings.getDefaultCacheArtifactPattern());
+                settings.getDefaultCacheArtifactPattern());
 
         LatestStrategy latest = settings.getLatestStrategy("mylatest-revision");
         assertNotNull(latest);
@@ -95,7 +97,7 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals("lib/[organisation]/[module]/ivys/ivy-[revision].xml",
-            ivyPatterns.get(0));
+                ivyPatterns.get(0));
 
         LatestStrategy strategy = fsres.getLatestStrategy();
         assertNotNull(strategy);
@@ -120,15 +122,15 @@ public class XmlSettingsParserTest {
         assertTrue(strategy instanceof LatestTimeStrategy);
 
         assertEquals("libraries",
-            settings.getResolver(ModuleRevisionId.newInstance("unknown", "lib", "1.0")).getName());
+                settings.getResolver(ModuleRevisionId.newInstance("unknown", "lib", "1.0")).getName());
         assertEquals("internal",
-            settings.getResolver(ModuleRevisionId.newInstance("apache", "ant", "1.0")).getName());
+                settings.getResolver(ModuleRevisionId.newInstance("apache", "ant", "1.0")).getName());
         assertEquals("int2",
-            settings.getResolver(ModuleRevisionId.newInstance("apache", "ivy", "2.0")).getName());
+                settings.getResolver(ModuleRevisionId.newInstance("apache", "ivy", "2.0")).getName());
         assertEquals("int1",
-            settings.getResolver(ModuleRevisionId.newInstance("apache", "ivy", "1.0")).getName());
+                settings.getResolver(ModuleRevisionId.newInstance("apache", "ivy", "1.0")).getName());
         assertEquals("int1",
-            settings.getResolver(ModuleRevisionId.newInstance("apache", "ivyde", "1.0")).getName());
+                settings.getResolver(ModuleRevisionId.newInstance("apache", "ivyde", "1.0")).getName());
     }
 
     @Test
@@ -217,7 +219,7 @@ public class XmlSettingsParserTest {
 
         assertEquals("[module]/ivys/ivy-[revision].xml", settings.getDefaultCacheIvyPattern());
         assertEquals("[module]/[type]s/[artifact]-[revision].[ext]",
-            settings.getDefaultCacheArtifactPattern());
+                settings.getDefaultCacheArtifactPattern());
         assertEquals(true, settings.isDefaultUseOrigin());
 
         DefaultRepositoryCacheManager c = (DefaultRepositoryCacheManager) settings
@@ -226,13 +228,13 @@ public class XmlSettingsParserTest {
         assertEquals("mycache", c.getName());
         assertEquals(1000, c.getDefaultTTL());
         assertEquals(200,
-            c.getTTL(ModuleRevisionId.newInstance("apache", "ivy", "latest.integration")));
+                c.getTTL(ModuleRevisionId.newInstance("apache", "ivy", "latest.integration")));
         assertEquals(10 * 60 * 1000 + 20 * 1000, // 10m 20s
-            c.getTTL(ModuleRevisionId.newInstance("org1", "A", "A")));
+                c.getTTL(ModuleRevisionId.newInstance("org1", "A", "A")));
         assertEquals(5 * 3600 * 1000, // 5h
-            c.getTTL(ModuleRevisionId.newInstance("org2", "A", "A")));
+                c.getTTL(ModuleRevisionId.newInstance("org2", "A", "A")));
         assertEquals(60 * 3600 * 1000, // 2d 12h = 60h
-            c.getTTL(ModuleRevisionId.newInstance("org3", "A", "A")));
+                c.getTTL(ModuleRevisionId.newInstance("org3", "A", "A")));
         assertEquals(new File("mycache").getCanonicalFile(), c.getBasedir().getCanonicalFile());
         assertEquals(false, c.isUseOrigin());
         assertEquals("no-lock", c.getLockStrategy().getName());
@@ -328,7 +330,7 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals("sharedrep/[organisation]/[module]/ivys/ivy-[revision].xml",
-            ivyPatterns.get(0));
+                ivyPatterns.get(0));
 
         DependencyResolver external = settings.getResolver("external");
         assertNotNull(external);
@@ -344,7 +346,7 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals("sharedrep/[organisation]/[module]/ivys/ivy-[revision].xml",
-            ivyPatterns.get(0));
+                ivyPatterns.get(0));
     }
 
     @Test
@@ -367,8 +369,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
-            ivyPatterns.get(0));
+                "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
+                ivyPatterns.get(0));
 
         FileSystemResolver fsInt2 = (FileSystemResolver) subresolvers.get(1);
         assertEquals("default-fs2", fsInt2.getName());
@@ -377,8 +379,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "path/to/secondrep/[organisation]/[module]/[type]s/ivy-[revision].xml",
-            ivyPatterns.get(0));
+                "path/to/secondrep/[organisation]/[module]/[type]s/ivy-[revision].xml",
+                ivyPatterns.get(0));
 
         DependencyResolver other = settings.getResolver("other");
         assertNotNull(other);
@@ -395,7 +397,7 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals("path/to/secondrep/[module]/[type]s/ivy-[revision].xml",
-            ivyPatterns.get(0));
+                ivyPatterns.get(0));
     }
 
     @Test
@@ -476,8 +478,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
-            ivyPatterns.get(0));
+                "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
+                ivyPatterns.get(0));
 
         DependencyResolver inc = settings.getResolver("includeworks");
         assertNotNull(inc);
@@ -494,8 +496,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "included/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
-            ivyPatterns.get(0));
+                "included/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
+                ivyPatterns.get(0));
 
         // properties defined in included file should be available to including file (IVY-780)
         assertEquals("myvalue", settings.getVariable("ivy.test.prop"));
@@ -543,8 +545,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
-            ivyPatterns.get(0));
+                "path/to/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
+                ivyPatterns.get(0));
 
         DependencyResolver inc = settings.getResolver("includeworks");
         assertNotNull(inc);
@@ -561,8 +563,8 @@ public class XmlSettingsParserTest {
         assertNotNull(ivyPatterns);
         assertEquals(1, ivyPatterns.size());
         assertLocationEquals(
-            "included/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
-            ivyPatterns.get(0));
+                "included/myrep/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]",
+                ivyPatterns.get(0));
 
         // properties defined in included file should be available to including file (IVY-780)
         assertEquals("myvalue", settings.getVariable("ivy.test.prop"));
@@ -584,7 +586,7 @@ public class XmlSettingsParserTest {
         XmlSettingsParser parser = new XmlSettingsParser(settings);
         parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-parser.xml"));
         assertEquals(ModuleDescriptorParserRegistryTest.MyParser.class.getName(),
-            ModuleDescriptorParserRegistry.getInstance().getParsers()[0].getClass().getName());
+                ModuleDescriptorParserRegistry.getInstance().getParsers()[0].getClass().getName());
     }
 
     @Test
@@ -633,14 +635,14 @@ public class XmlSettingsParserTest {
         settings.setBaseDir(new File("test/base/dir"));
         assertEquals(new File("test/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
         assertEquals(new File("test/base/dir").getAbsolutePath(),
-            settings.getVariable("ivy.basedir"));
+                settings.getVariable("ivy.basedir"));
 
         settings = new IvySettings();
         settings.setVariable("basedir", new File("other/base/dir").getAbsolutePath());
         settings.setBaseDir(new File("test/base/dir"));
         assertEquals(new File("other/base/dir").getAbsolutePath(), settings.getVariable("basedir"));
         assertEquals(new File("test/base/dir").getAbsolutePath(),
-            settings.getVariable("ivy.basedir"));
+                settings.getVariable("ivy.basedir"));
     }
 
     /**
@@ -668,9 +670,79 @@ public class XmlSettingsParserTest {
         assertEquals("Unexpected ttl for module " + module2 + " on cache manager", 60000, module2SpecificTTL);
     }
 
+    /**
+     * Tests that the <code>timeout-constraint</code> elements in a Ivy settings file are parsed correctly
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTimeoutConstraints() throws Exception {
+        final IvySettings settings = new IvySettings();
+        settings.setBaseDir(new File("test/base/dir"));
+        final XmlSettingsParser parser = new XmlSettingsParser(settings);
+        parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-timeout-constraints.xml"));
+
+        final TimeoutConstraint timeout1 = settings.getTimeoutConstraint("test-timeout-1");
+        assertNotNull("test-timeout-1 timeout constraint is missing", timeout1);
+        assertEquals("Unexpected connection timeout " + timeout1.getConnectionTimeout() + " on time constraint test-timeout-1", 100, timeout1.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + timeout1.getReadTimeout() + " on time constraint test-timeout-1", 500, timeout1.getReadTimeout());
+
+
+        final TimeoutConstraint timeout2 = settings.getTimeoutConstraint("test-timeout-2");
+        assertNotNull("test-timeout-2 timeout constraint is missing", timeout2);
+        assertEquals("Unexpected connection timeout " + timeout2.getConnectionTimeout() + " on time constraint test-timeout-2", -1, timeout2.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + timeout2.getReadTimeout() + " on time constraint test-timeout-2", 20, timeout2.getReadTimeout());
+
+
+        final TimeoutConstraint timeout3 = settings.getTimeoutConstraint("test-timeout-3");
+        assertNotNull("test-timeout-3 timeout constraint is missing", timeout3);
+        assertEquals("Unexpected connection timeout " + timeout3.getConnectionTimeout() + " on time constraint test-timeout-3", 400, timeout3.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + timeout3.getReadTimeout() + " on time constraint test-timeout-3", -1, timeout3.getReadTimeout());
+
+        final TimeoutConstraint timeout4 = settings.getTimeoutConstraint("test-timeout-4");
+        assertNotNull("test-timeout-4 timeout constraint is missing", timeout4);
+        assertEquals("Unexpected connection timeout " + timeout4.getConnectionTimeout() + " on time constraint test-timeout-4", -1, timeout4.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + timeout4.getReadTimeout() + " on time constraint test-timeout-4", -1, timeout4.getReadTimeout());
+
+    }
+
+    /**
+     * Tests that timeout constraints referenced by resolvers, in an ivy settings file, are processed correctly and the
+     * corresponding resolvers use the right timeout constraints
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testResolverTimeoutConstraintRefs() throws Exception {
+        final IvySettings settings = new IvySettings();
+        settings.setBaseDir(new File("test/base/dir"));
+        final XmlSettingsParser parser = new XmlSettingsParser(settings);
+        parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-timeout-constraints.xml"));
+
+        final URLResolver resolver1 = (URLResolver) settings.getResolver("urlresolver-1");
+        assertNotNull("Missing resolver urlresolver-1", resolver1);
+        final TimeoutConstraint resolver1Timeouts = resolver1.getTimeoutConstraint();
+        assertNotNull("Timeout constraint missing on resolver " + resolver1.getName(), resolver1Timeouts);
+        assertEquals("Unexpected connection timeout " + resolver1Timeouts.getConnectionTimeout() + " on resolver " + resolver1.getName(), 400, resolver1Timeouts.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + resolver1Timeouts.getReadTimeout() + " on resolver " + resolver1.getName(), -1, resolver1Timeouts.getReadTimeout());
+
+        final IBiblioResolver resolver2 = (IBiblioResolver) settings.getResolver("ibiblio-resolver");
+        assertNotNull("Missing resolver ibiblio-resolver", resolver2);
+        final TimeoutConstraint resolver2Timeouts = resolver2.getTimeoutConstraint();
+        assertNotNull("Timeout constraint missing on resolver " + resolver2.getName(), resolver2Timeouts);
+        assertEquals("Unexpected connection timeout " + resolver2Timeouts.getConnectionTimeout() + " on resolver " + resolver2.getName(), 100, resolver2Timeouts.getConnectionTimeout());
+        assertEquals("Unexpected read timeout " + resolver2Timeouts.getReadTimeout() + " on resolver " + resolver2.getName(), 500, resolver2Timeouts.getReadTimeout());
+
+        final FileSystemResolver resolver3 = (FileSystemResolver) settings.getResolver("fs");
+        assertNotNull("Missing resolver fs", resolver3);
+        final TimeoutConstraint resolver3Timeouts = resolver3.getTimeoutConstraint();
+        assertNull("No timeout was expected on resolver " + resolver3.getName(), resolver3Timeouts);
+
+    }
+
     public static class MyOutputter implements ReportOutputter {
         public void output(ResolveReport report, ResolutionCacheManager cacheMgr,
-                ResolveOptions options) {
+                           ResolveOptions options) {
         }
 
         public String getName() {
@@ -691,6 +763,6 @@ public class XmlSettingsParserTest {
 
     private void assertLocationEquals(String expected, Object pattern) throws IOException {
         assertEquals(new File(expected).getCanonicalFile(),
-            new File((String) pattern).getCanonicalFile());
+                new File((String) pattern).getCanonicalFile());
     }
 }

--- a/test/java/org/apache/ivy/core/settings/ivysettings-timeout-constraints.xml
+++ b/test/java/org/apache/ivy/core/settings/ivysettings-timeout-constraints.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ivysettings>
+    <timeout-constraints>
+        <timeout-constraint name="test-timeout-1" connectionTimeout="100" readTimeout="500"/>
+        <timeout-constraint name="test-timeout-2" readTimeout="20"/>
+        <timeout-constraint name="test-timeout-3" connectionTimeout="400"/>
+        <timeout-constraint name="test-timeout-4"/>
+    </timeout-constraints>
+
+    <resolvers>
+        <url name="urlresolver-1" timeoutConstraint="test-timeout-3"/>
+        <ibiblio name="ibiblio-resolver" timeoutConstraint="test-timeout-1"/>
+        <filesystem name="fs"/>
+    </resolvers>
+</ivysettings>

--- a/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
+++ b/test/java/org/apache/ivy/osgi/updatesite/UpdateSiteLoaderTest.java
@@ -53,7 +53,7 @@ public class UpdateSiteLoaderTest {
         cache.mkdirs();
         ivySettings.setDefaultCache(cache);
         CacheResourceOptions options = new CacheResourceOptions();
-        loader = new UpdateSiteLoader(ivySettings.getDefaultRepositoryCacheManager(), null, options);
+        loader = new UpdateSiteLoader(ivySettings.getDefaultRepositoryCacheManager(), null, options, null);
     }
 
     @After

--- a/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorParserTest.java
@@ -1396,7 +1396,7 @@ public class XmlModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertTrue(resolveRoot.exists() || resolveRoot.mkdirs());
 
         FileUtil.copy(getClass().getResource("test-extends-parent.xml"), new File(resolveRoot,
-                "myorg/myparent/ivy.xml"), null);
+                "myorg/myparent/ivy.xml"), null, null);
 
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setSettings(settings);

--- a/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/URLResolverTest.java
@@ -17,10 +17,6 @@
  */
 package org.apache.ivy.plugins.resolver;
 
-import java.io.File;
-import java.util.Date;
-import java.util.GregorianCalendar;
-
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.cache.DefaultRepositoryCacheManager;
 import org.apache.ivy.core.event.EventManager;
@@ -28,6 +24,7 @@ import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.core.module.descriptor.DefaultArtifact;
 import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DefaultIncludeRule;
+import org.apache.ivy.core.module.descriptor.DependencyDescriptor;
 import org.apache.ivy.core.module.id.ArtifactId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
@@ -39,15 +36,30 @@ import org.apache.ivy.core.resolve.ResolveEngine;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.core.settings.NamedTimeoutConstraint;
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.core.sort.SortEngine;
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests URLResolver. Http tests are based upon ibiblio site.
@@ -366,5 +378,131 @@ public class URLResolverTest extends AbstractDependencyResolverTest {
 
         assertEquals(artifact, ar.getArtifact());
         assertEquals(DownloadStatus.NO, ar.getDownloadStatus());
+    }
+
+    /**
+     * Tests that the timeout constraint set on the URL resolver is used correctly by the resolver
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTimeoutConstraint() throws Exception {
+        final NamedTimeoutConstraint highTimeout = new NamedTimeoutConstraint("test-high-timeout");
+        highTimeout.setConnectionTimeout(60000);
+        settings.addConfigured(highTimeout);
+        final NamedTimeoutConstraint extremelyLowTimeout = new NamedTimeoutConstraint("test-extremely-low-timeout");
+        extremelyLowTimeout.setConnectionTimeout(10);
+        extremelyLowTimeout.setReadTimeout(20);
+        settings.addConfigured(extremelyLowTimeout);
+
+        // setup a HTTP backed repo
+        // TODO: Right now the port is hard coded, but we need to find a "available" port to which can be bind to.
+        // Else this can lead to occasional bind failures
+        final InetSocketAddress fastServerBindAddr = new InetSocketAddress("localhost", 12345);
+        final String contextRoot = "/testTimeouts";
+        final Path repoRoot = new File("test/repositories/1").toPath();
+        assertTrue(repoRoot + " is not a directory", Files.isDirectory(repoRoot));
+        final DependencyDescriptor dependency = new DefaultDependencyDescriptor(ModuleRevisionId.newInstance("org1", "mod1.1", "2.0"), false);
+        try (final AutoCloseable httpServer = TestHelper.createHttpServerBackedRepository(fastServerBindAddr, contextRoot, repoRoot)) {
+            final String ivyPattern = "http://" + fastServerBindAddr.getHostName() + ":" + fastServerBindAddr.getPort() +
+                    "/testTimeouts/[organisation]/[module]/ivys/ivy-[revision].xml";
+            final String artifactPattern = "http://" + fastServerBindAddr.getHostName() + ":" + fastServerBindAddr.getPort() +
+                    "/testTimeouts/[organisation]/[module]/[type]s/[artifact]-[revision].[type]";
+            // first use a resolver with a high timeout to make sure it can actually fetch the resources
+            final URLResolver highTimeoutResolver = new URLResolver();
+            highTimeoutResolver.setName("high-timeout-resolver");
+            highTimeoutResolver.setAllownomd(false);
+            highTimeoutResolver.setTimeoutConstraint("test-high-timeout");
+            highTimeoutResolver.setSettings(settings);
+            highTimeoutResolver.setIvyPatterns(Collections.singletonList(ivyPattern));
+            highTimeoutResolver.setArtifactPatterns(Collections.singletonList(artifactPattern));
+            highTimeoutResolver.validate();
+
+            final TimeoutConstraint resolverTimeoutConstraint = highTimeoutResolver.getTimeoutConstraint();
+            assertNotNull("Timeout constraint is missing on resolver " + highTimeoutResolver.getName(), resolverTimeoutConstraint);
+            assertEquals("Unexpected connection timeout on resolver", 60000, resolverTimeoutConstraint.getConnectionTimeout());
+            assertEquals("Unexpected read timeout on resolver", -1, resolverTimeoutConstraint.getReadTimeout());
+
+            // do the fetch (expected to work fine)
+            final ResolvedModuleRevision resolvedModule = highTimeoutResolver.getDependency(dependency, data);
+            assertNotNull("Dependency wasn't resolved by resolver " + highTimeoutResolver.getName(), resolvedModule);
+            assertEquals("Unexpected dependency resolved by resolver " + highTimeoutResolver.getName(), dependency.getDependencyRevisionId(), resolvedModule.getId());
+        }
+
+        // now test this whole fetch using a resolver with a very low connection timeout and by starting the repo server
+        // with a delay so that the connection request can timeout
+
+        // clean the cache before testing to ensure the resource isn't fetched from cache
+        settings.getDefaultRepositoryCacheManager().clean();
+        settings.getResolutionCacheManager().clean();
+
+        final InetSocketAddress slowServerAddr = new InetSocketAddress("localhost", 23456);
+        final String ivyPattern = "http://" + slowServerAddr.getHostName() + ":" + slowServerAddr.getPort() +
+                "/testTimeouts/[organisation]/[module]/ivys/ivy-[revision].xml";
+        final String artifactPattern = "http://" + slowServerAddr.getHostName() + ":" + slowServerAddr.getPort() +
+                "/testTimeouts/[organisation]/[module]/[type]s/[artifact]-[revision].[type]";
+        final URLResolver lowTimeoutResolver = new URLResolver();
+        lowTimeoutResolver.setAllownomd(false);
+        lowTimeoutResolver.setName("low-timeout-resolver");
+        lowTimeoutResolver.setTimeoutConstraint("test-extremely-low-timeout");
+        lowTimeoutResolver.setSettings(settings);
+        lowTimeoutResolver.setIvyPatterns(Collections.singletonList(ivyPattern));
+        lowTimeoutResolver.setArtifactPatterns(Collections.singletonList(artifactPattern));
+        lowTimeoutResolver.validate();
+
+        final TimeoutConstraint lowTimeoutConstraint = lowTimeoutResolver.getTimeoutConstraint();
+        assertNotNull("Timeout constraint is missing on resolver " + lowTimeoutResolver.getName(), lowTimeoutConstraint);
+        assertEquals("Unexpected connection timeout on resolver", 10, lowTimeoutConstraint.getConnectionTimeout());
+        assertEquals("Unexpected read timeout on resolver", 20, lowTimeoutConstraint.getReadTimeout());
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final long serverStartupDelayInMillis = 500;
+        final Future<AutoCloseable> httpServer = executor.submit(new ServerManager(slowServerAddr, contextRoot, repoRoot, serverStartupDelayInMillis));
+        try {
+            // do the fetch (resolution *isn't* expected to return resolved module)
+            final ResolvedModuleRevision resolvedModuleFromLowTimeouts = lowTimeoutResolver.getDependency(dependency, data);
+            assertNull("Dependency wasn't expected to be resolved by resolver " + lowTimeoutResolver.getName(), resolvedModuleFromLowTimeouts);
+        } finally {
+            try {
+                // stop the server
+                httpServer.get().close();
+            } catch (Exception e) {
+                // ignore
+                // TODO: Better log it too. But I don't see usage of loggers in test cases currently. So need to get to this later
+            }
+            try {
+                executor.shutdownNow();
+            } catch (Exception e) {
+                // ignore
+                // TODO: Better log it too. But I don't see usage of loggers in test cases currently. So need to get to this later
+            }
+        }
+    }
+
+    private final class ServerManager implements Callable<AutoCloseable> {
+
+        private final InetSocketAddress serverBindAddress;
+        private final long startupDelayInMillis;
+        private final String contextRoot;
+        private final Path localRepoRoot;
+
+        ServerManager(final InetSocketAddress serverBindAddress, final String contextRoot,
+                      final Path localRepoRoot, final long startupDelayInMillis) {
+            this.serverBindAddress = serverBindAddress;
+            this.contextRoot = contextRoot;
+            this.localRepoRoot = localRepoRoot;
+            this.startupDelayInMillis = startupDelayInMillis;
+        }
+
+        @Override
+        public AutoCloseable call() throws Exception {
+            if (startupDelayInMillis <= 0) {
+                return TestHelper.createHttpServerBackedRepository(serverBindAddress, contextRoot, localRepoRoot);
+            }
+            // wait for the specified amount of startup delay
+            Thread.sleep(startupDelayInMillis);
+            // start the server
+            return TestHelper.createHttpServerBackedRepository(serverBindAddress, contextRoot, localRepoRoot);
+        }
     }
 }

--- a/test/java/org/apache/ivy/util/url/AbstractURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/AbstractURLHandlerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import org.apache.ivy.core.settings.TimeoutConstraint;
 import org.apache.ivy.util.CopyProgressListener;
 
 import org.junit.Test;
@@ -74,6 +75,11 @@ public class AbstractURLHandlerTest {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public void download(final URL src, final File dest, final CopyProgressListener listener, final TimeoutConstraint timeoutConstraint) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
         public URLInfo getURLInfo(URL url) {
             throw new UnsupportedOperationException();
         }
@@ -82,11 +88,26 @@ public class AbstractURLHandlerTest {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public URLInfo getURLInfo(final URL url, final TimeoutConstraint timeoutConstraint) {
+            throw new UnsupportedOperationException();
+        }
+
         public InputStream openStream(URL url) throws IOException {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public InputStream openStream(final URL url, final TimeoutConstraint timeoutConstraint) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
         public void upload(File src, URL dest, CopyProgressListener l) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void upload(final File src, final URL dest, final CopyProgressListener listener, final TimeoutConstraint timeoutConstraint) throws IOException {
             throw new UnsupportedOperationException();
         }
 

--- a/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
+++ b/test/java/org/apache/ivy/util/url/BasicURLHandlerTest.java
@@ -62,7 +62,7 @@ public class BasicURLHandlerTest {
 
         // to test ftp we should know of an anonymous ftp site... !
         // assertTrue(handler.isReachable(new URL("ftp://ftp.mozilla.org/pub/dir.sizes")));
-        assertFalse(handler.isReachable(new URL("ftp://ftp.mozilla.org/unknown.file"), connectionTimeoutInMillis));
+        assertFalse(handler.isReachable(new URL("ftp://ftp.mozilla.org/unknown.file"), 5000));
     }
 
     @Test


### PR DESCRIPTION
The commit in this PR adds support for specifying connection and read timeouts for resolvers, so that users have control over how the resolvers behave when it comes to slow/unresponsive repositories. This feature has been requested in https://issues.apache.org/jira/browse/IVY-735

This commit introduces the concept of "timeout-constraints" within a Ivy settings file. There can be any number of named timeout constraints, each with (optional) values for connection and read timeouts. These named timeout constraints can then be referred to by the individual resolvers via the `timeoutConstraint` attribute on them. Standard resolvers all have been updated to support this new attribute.

An example usage looks something like this:

```
<ivysettings>
    <timeout-constraints>
        <timeout-constraint name="test-timeout-1" connectionTimeout="100" readTimeout="500"/>
        <timeout-constraint name="test-timeout-2" readTimeout="20"/>
        <timeout-constraint name="test-timeout-3" connectionTimeout="400"/>
        <timeout-constraint name="test-timeout-4"/>
    </timeout-constraints>

    <resolvers>
        <url name="urlresolver-1" timeoutConstraint="test-timeout-3"/>
        <ibiblio name="ibiblio-resolver" timeoutConstraint="test-timeout-1"/>
        <filesystem name="fs"/>
    </resolvers>
</ivysettings>

```
(explanation of what these settings signify are available in the docs here https://github.com/jaikiran/ant-ivy/commit/c0ffb23ae29197e7f47c140deb991139d0688421#diff-e094f56ed4707eb73f8621abe7bfb4e5R54)

The commit also contains updates to documentation to include details of this new feature, plus test cases to verify the basic functionality of this feature on some specific resolvers. 

I need to check a few standard resolvers (like the ssh based ones) to make sure they honour this new timeout semantics too and include tests (if possible) for them. But at this point, this commit should cover the support and the code flow for most of the relevant resolvers like the `URLResolver`. In fact, one of the tests in this commit, actually simulates a HTTP backed repo being down, in a test case to verify the `URLResolver` honours these timeout constraints.



