### PR TITLE
IVY-1566 - Store External form of URL in cached files

### DIFF
--- a/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
+++ b/src/java/org/apache/ivy/core/cache/DefaultRepositoryCacheManager.java
@@ -1455,7 +1455,16 @@ public class DefaultRepositoryCacheManager implements RepositoryCacheManager, Iv
         // it's important to say the origin is not local to make sure it won't ever be used for
         // anything else than original token
         return new ArtifactOrigin(DefaultArtifact.newIvyArtifact(mrid, null), false,
-                getIvyFileInCache(mrid).getPath());
+                getIvyFileInCacheLocation(mrid));
+    }
+
+    private String getIvyFileInCacheLocation(ModuleRevisionId mrid) {
+        File ivyFileInCache = getIvyFileInCache(mrid);
+        try {
+            return ivyFileInCache.toURI().toURL().toExternalForm();
+        } catch (MalformedURLException e) {
+            return ivyFileInCache.getPath();
+        }
     }
 
     private Artifact getDefaultMetadataArtifact(ModuleRevisionId mrid) {


### PR DESCRIPTION
So hard to configure the project in my IvyIDE, cannot launch test individually so I abandoned the to search how to write a test.

I tested manually in my use case and I don't have anymore MalformedURlException

the ivydata*.properties now contaisn always "file:"

```
artifact\:ivy\#ivy\#xml\#-455539479.location=file\:C\:/Users/Aurelien Pupier/.m2/repository/org/apache/camel/camel/2.17.2/camel-2.17.2.pom
resolver=localm2
artifact\:ivy\#ivy\#xml\#-455539479.is-local=true
artifact\:ivy\#ivy\#xml\#-455539479.original=artifact\:camel\#pom.original\#pom\#1474703200
artifact\:camel\#pom.original\#pom\#1474703200.exists=true
artifact\:ivy\#ivy\#xml\#-455539479.exists=true
artifact.resolver=localm2
artifact\:camel\#pom.original\#pom\#1474703200.is-local=true
artifact\:camel\#pom.original\#pom\#1474703200.location=file\:C\:/Users/Aurelien Pupier/.m2/repository/org/apache/camel/camel/2.17.2/camel-2.17.2.pom
artifact\:camel\#pom.original\#pom\#1474703200.original=artifact\:camel\#pom.original\#pom\#1474703200
```