### PR TITLE
Why no new Ivy version yet?

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -15,7 +15,7 @@
 #	 * KIND, either express or implied.  See the License for the
 #	 * specific language governing permissions and limitations
 #	 * under the License.
-#	 ***************************************************************
+#	 **************************************************************
 target.ivy.version=2.5.0
 # Following OSGi spec: have to be 3 numbers separated by dots
 target.ivy.bundle.version=2.5.0


### PR DESCRIPTION
I'm just making this PR because the mailing list is a pain to use and there's no issue tracker here on GitHub for the project...but why isn't there a new release for Ivy yet, given the project has resumed development for so long now?