### PR TITLE
Ivy main/standalone: Patch to include 'makepom' function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/repositories/norevision/ivy-mod1.1.xml
 test/repositories/norevision/mod1.1.jar
 test/test-repo/bundlerepo/*.jar
 test/test-repo/ivyrepo/org.apache.ivy.osgi
+out/

--- a/src/java/org/apache/ivy/Main.java
+++ b/src/java/org/apache/ivy/Main.java
@@ -47,6 +47,8 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolveProcessException;
 import org.apache.ivy.core.retrieve.RetrieveOptions;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorWriter;
+import org.apache.ivy.plugins.parser.m2.PomWriterOptions;
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorWriter;
 import org.apache.ivy.plugins.report.XmlReportParser;
 import org.apache.ivy.util.DefaultMessageLogger;
@@ -198,6 +200,10 @@ public final class Main {
                 .addOption(
                     new OptionBuilder("cp").arg("cp")
                             .description("extra classpath to use when launching process").create())
+
+                .addCategory("maven compatibility options")
+                .addOption(new OptionBuilder("pomfile").arg("pomfile").countArgs(false)
+                            .description("makepom as standalone tasks").create())
 
                 .addCategory("message options")
                 .addOption(
@@ -418,6 +424,10 @@ public final class Main {
                                     "ivy-[revision].xml")))
                             .setOverwrite(line.hasOption("overwrite")));
             }
+        }
+        if (line.hasOption("pomfile")) {
+            String pomFile = line.getOptionValue("pomfile", "pom.xml");
+            PomModuleDescriptorWriter.write(md, new File(pomFile), new PomWriterOptions());
         }
         if (line.hasOption("main")) {
             // check if the option cp has been set


### PR DESCRIPTION
Hello,

I added the pomfile option to main/standalone. This allows creating an (maven) pom file from outside an ant task.

Example of use:

```sh
$ pwd
~/.ivy2/cache/org.typelevel/cats-core_2.11
$ java -jar ~/scm/github/ant-ivy/build/artifact/org.apache.ivy_2.5.0.alpha_20180327212209.jar -ivy ivy-1.0.1.xml -pomfile cats-core.xml
$ ls
cats-core-2.11.xml  ivy-1.0.1.xml  ivy-1.0.1.xml.original  ivydata-1.0.1.properties  jars  srcs
```
Feedback is welcome. What should I do to get this patch into mainline?

Kind regards,

aanno