### PR TITLE
Fix IVY-982 by removing negated entries from wildcard bin

### DIFF
--- a/src/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptor.java
+++ b/src/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptor.java
@@ -356,6 +356,12 @@ public class DefaultDependencyDescriptor implements DependencyDescriptor {
         }
         if (defConfs != null) {
             ret.addAll(defConfs);
+
+            // Fixes bugs IVY-1547, IVY-982 which have to do with
+            // negation (e.g. `*, !foo`) not working on the left side of the maps-to operator.
+            List<String> excludedConfs = confs.get("!" + moduleConfiguration);
+            if (excludedConfs != null)
+                ret.removeAll(excludedConfs);
         }
 
         Collection<String> replacedRet = new LinkedHashSet<>();

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -4361,7 +4361,7 @@ public class ResolveTest {
         crp = report.getConfigurationReport("A");
         assertTrue(crp.getDependency(mod12) != null);
         assertTrue(Arrays.asList(crp.getDependency(mod12).getConfigurations(crp.getConfiguration()))
-            .containsAll(Arrays.asList("default")));
+            .containsAll(Collections.singletonList("default")));
         assertEquals(crp.getDependency(mod21), null);
         assertEquals(crp.getDependency(mod22), null);
 
@@ -4369,16 +4369,16 @@ public class ResolveTest {
         assertEquals(crp.getDependency(mod12), null);
         assertTrue(crp.getDependency(mod21) != null);
         assertTrue(Arrays.asList(crp.getDependency(mod21).getConfigurations(crp.getConfiguration()))
-            .containsAll(Arrays.asList("A")));
+            .containsAll(Collections.singletonList("A")));
         assertTrue(crp.getDependency(mod22) != null);
         assertTrue(Arrays.asList(crp.getDependency(mod22).getConfigurations(crp.getConfiguration()))
-            .containsAll(Arrays.asList("myconf1")));
+            .containsAll(Collections.singletonList("myconf1")));
 
         crp = report.getConfigurationReport("C");
         assertEquals(crp.getDependency(mod12), null);
         assertTrue(crp.getDependency(mod21) != null);
         assertTrue(Arrays.asList(crp.getDependency(mod21).getConfigurations(crp.getConfiguration()))
-            .containsAll(Arrays.asList("A")));
+            .containsAll(Collections.singletonList("A")));
         assertTrue(crp.getDependency(mod22) != null);
         assertTrue(Arrays.asList(crp.getDependency(mod22).getConfigurations(crp.getConfiguration()))
             .containsAll(Arrays.asList("myconf1", "myconf2")));

--- a/test/java/org/apache/ivy/core/resolve/ResolveTest.java
+++ b/test/java/org/apache/ivy/core/resolve/ResolveTest.java
@@ -4360,33 +4360,28 @@ public class ResolveTest {
 
         crp = report.getConfigurationReport("A");
         assertTrue(crp.getDependency(mod12) != null);
-        assertTrue(Arrays.equals(
-                crp.getDependency(mod12).getConfigurations(crp.getConfiguration()),
-                new String[] {"default"}));
+        assertTrue(Arrays.asList(crp.getDependency(mod12).getConfigurations(crp.getConfiguration()))
+            .containsAll(Arrays.asList("default")));
         assertEquals(crp.getDependency(mod21), null);
         assertEquals(crp.getDependency(mod22), null);
 
         crp = report.getConfigurationReport("B");
         assertEquals(crp.getDependency(mod12), null);
         assertTrue(crp.getDependency(mod21) != null);
-        assertTrue(Arrays.equals(
-                crp.getDependency(mod21).getConfigurations(crp.getConfiguration()),
-                new String[] {"A"}));
+        assertTrue(Arrays.asList(crp.getDependency(mod21).getConfigurations(crp.getConfiguration()))
+            .containsAll(Arrays.asList("A")));
         assertTrue(crp.getDependency(mod22) != null);
-        assertTrue(Arrays.equals(
-                crp.getDependency(mod22).getConfigurations(crp.getConfiguration()),
-                new String[] {"myconf1"}));
+        assertTrue(Arrays.asList(crp.getDependency(mod22).getConfigurations(crp.getConfiguration()))
+            .containsAll(Arrays.asList("myconf1")));
 
         crp = report.getConfigurationReport("C");
         assertEquals(crp.getDependency(mod12), null);
         assertTrue(crp.getDependency(mod21) != null);
-        assertTrue(Arrays.equals(
-                crp.getDependency(mod21).getConfigurations(crp.getConfiguration()),
-                new String[] {"A"}));
+        assertTrue(Arrays.asList(crp.getDependency(mod21).getConfigurations(crp.getConfiguration()))
+            .containsAll(Arrays.asList("A")));
         assertTrue(crp.getDependency(mod22) != null);
-        assertTrue(Arrays.equals(
-                crp.getDependency(mod22).getConfigurations(crp.getConfiguration()),
-                new String[] {"myconf1", "myconf2"}));
+        assertTrue(Arrays.asList(crp.getDependency(mod22).getConfigurations(crp.getConfiguration()))
+            .containsAll(Arrays.asList("myconf1", "myconf2")));
     }
 
     @Test

--- a/test/java/org/apache/ivy/core/resolve/ivy-982.xml
+++ b/test/java/org/apache/ivy/core/resolve/ivy-982.xml
@@ -1,0 +1,37 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<ivy-module version="1.0" xmlns:e="http://ant.apache.org/ivy/extra">
+  <info organisation="org.apache"
+         module="ivy-982"
+         revision="0.1"
+  />
+  <configurations>
+    <conf name="A"/>
+    <conf name="B"/>
+    <conf name="C"/>
+  </configurations>
+  <dependencies>
+    <dependency org="org1" name="mod1.2" rev="2.0"
+      conf="A->default"/>
+    <dependency org="org2" name="mod2.1" rev="0.5"
+      conf="*,!A->A"/>
+    <dependency org="org2" name="mod2.2" rev="0.9"
+      conf="*,!A->myconf1; *,!A,!B->myconf2"/>
+  </dependencies>
+</ivy-module>


### PR DESCRIPTION
### Issue
Configurations negation (exclusion) as in `conf="*, !foo->@"` does not work,
This issue is reported in [IVY-982](https://issues.apache.org/jira/browse/IVY-982) and [IVY-1547](https://issues.apache.org/jira/browse/IVY-1547).

### Why does it happen?
Resolve engine silently disrespects negation on the left part of maps-to operator because the exclusion was not implemented. When parsing dependency, e.g. `conf="*, !foo → bar1; foo → bar2, bar3; % → bar4"`, all dependency configurations are collected into bins (map entries):

- *all-wildcard bin* with all configurations required for `*` superset, 
such as `bar1` in bin `*`;
- *others-wildcard bin* with all configurations required for `%` superset, 
such as `bar4` in bin `%`;
- *explicit bins* for all explicit mappings, 
such as `bar2` and `bar3` in bin `foo`, and `bar1` in bin `!foo`.

Resolving list of dependency configurations required for some target configuration `X` is done as follows:

1. All configurations from `X`'s *explicit bin* [are added](https://github.com/apache/ant-ivy/blob/89583444040dc5423bb143435f23ae0814f24542/src/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptor.java#L347).
2. All configurations from *others-wildcard bin* [are added](https://github.com/apache/ant-ivy/blob/89583444040dc5423bb143435f23ae0814f24542/src/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptor.java#L350) in case `X`'s *explicit bin* is empty.
3. All configurations from *all-wildcard bin* [are added](https://github.com/apache/ant-ivy/blob/89583444040dc5423bb143435f23ae0814f24542/src/java/org/apache/ivy/core/module/descriptor/DefaultDependencyDescriptor.java#L358).

Note that explicit bins for negated target configurations *are not referenced, and thus silently ignored*. This fix introduces fourth step:

4. All configurations from `!X`'s *explicit bin* are removed.