### PR TITLE
Invoking Ivy Standalone with SCP Resolver plugin causes error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@
 				
 for detailed view of each issue, please consult http://jira.jayasoft.org/
 
+   version 1.4.2 - not yet released
+=====================================
+- FIX: Static revision replacement is not working when delivering an artifact with a dependency having extra attributes (IVY-415)
+- FIX: Static revision replacement is not working when delivering an artifact with a dependency on a branch (IVY-404)
+
    version 1.4.1 - 2006-11-09
 =====================================
 - IMPROVE: ability to rebuild all dependent projects from a leaf (IVY-101)

--- a/src/java/fr/jayasoft/ivy/xml/XmlModuleDescriptorParser.java
+++ b/src/java/fr/jayasoft/ivy/xml/XmlModuleDescriptorParser.java
@@ -53,6 +53,7 @@ import fr.jayasoft.ivy.util.XMLHelper;
  *
  */
 public class XmlModuleDescriptorParser extends AbstractModuleDescriptorParser {
+    static final String[] DEPENDENCY_REGULAR_ATTRIBUTES = new String[] {"org", "name", "branch", "rev", "force", "transitive", "changing", "conf"};
     private static XmlModuleDescriptorParser INSTANCE = new XmlModuleDescriptorParser();
     
     public static XmlModuleDescriptorParser getInstance() {
@@ -295,7 +296,7 @@ public class XmlModuleDescriptorParser extends AbstractModuleDescriptorParser {
                 String name = _ivy.substitute(attributes.getValue("name"));
                 String branch = _ivy.substitute(attributes.getValue("branch"));
                 String rev = _ivy.substitute(attributes.getValue("rev"));
-                _dd = new DefaultDependencyDescriptor(_md, ModuleRevisionId.newInstance(org, name, branch, rev, ExtendableItemHelper.getExtraAttributes(attributes, new String[] {"org", "name", "rev", "force", "transitive", "changing", "conf"})), force, changing, transitive);
+                _dd = new DefaultDependencyDescriptor(_md, ModuleRevisionId.newInstance(org, name, branch, rev, ExtendableItemHelper.getExtraAttributes(attributes, DEPENDENCY_REGULAR_ATTRIBUTES)), force, changing, transitive);
                 _md.addDependency(_dd);
                 String confs = _ivy.substitute(attributes.getValue("conf"));
                 if (confs != null && confs.length() > 0) {

--- a/src/java/fr/jayasoft/ivy/xml/XmlModuleDescriptorUpdater.java
+++ b/src/java/fr/jayasoft/ivy/xml/XmlModuleDescriptorUpdater.java
@@ -34,6 +34,7 @@ import fr.jayasoft.ivy.ModuleRevisionId;
 import fr.jayasoft.ivy.namespace.Namespace;
 import fr.jayasoft.ivy.util.Message;
 import fr.jayasoft.ivy.util.XMLHelper;
+import fr.jayasoft.ivy.extendable.ExtendableItemHelper;
 
 /**
  * Used to update ivy files. Uses ivy file as source and not ModuleDescriptor to preserve
@@ -190,7 +191,7 @@ public class XmlModuleDescriptorUpdater {
                         String module = substitute(ivy, attributes.getValue("name"));
                         String branch = substitute(ivy, attributes.getValue("branch"));
                         String revision = substitute(ivy, attributes.getValue("rev"));
-                        ModuleRevisionId localMid = ModuleRevisionId.newInstance(org, module, branch, revision);
+                        ModuleRevisionId localMid = ModuleRevisionId.newInstance(org, module, branch, revision, ExtendableItemHelper.getExtraAttributes(attributes, XmlModuleDescriptorParser.DEPENDENCY_REGULAR_ATTRIBUTES));
                         ModuleRevisionId systemMid = ns == null ? 
                                 localMid : 
                                 ns.getToSystemTransformer().transform(localMid);

--- a/test/java/fr/jayasoft/ivy/ant/ivy-latest-branch.xml
+++ b/test/java/fr/jayasoft/ivy/ant/ivy-latest-branch.xml
@@ -1,0 +1,10 @@
+<ivy-module version="1.0"> 
+	<info organisation="apache"
+	       module="resolve-latest"
+	       revision="1.0"
+	       status="release"
+	/>
+	<dependencies>
+		<dependency org="org1" name="mod1.2" rev="latest.integration" branch="TRUNK" />
+	</dependencies>
+</ivy-module>

--- a/test/java/fr/jayasoft/ivy/ant/ivy-latest-extra.xml
+++ b/test/java/fr/jayasoft/ivy/ant/ivy-latest-extra.xml
@@ -1,0 +1,10 @@
+<ivy-module version="1.0"> 
+	<info organisation="apache"
+	       module="resolve-latest"
+	       revision="1.0"
+	       status="release"
+	/>
+	<dependencies>
+		<dependency org="org1" name="mod1.2" rev="latest.integration" myExtraAtt="myValue" />
+	</dependencies>
+</ivy-module>


### PR DESCRIPTION
How do I use ivy as a standalone with the sftp resolver
ivysettings.xml

....
```
<sftp name="publish" host="ivy.boston.com" user="${login.user}" userPassword="${login.password}"  >
  <ivy pattern="/tech/ivy/[organization]/[module]/[type]s/[artifact]-[revision].[ext]" />
  <artifact pattern="/tech/ivy/[organization]/[module]/[type]s/[artifact]-[revision].[ext]" />
</sftp>
```
...
I'm getting this error 
```
"main" java.lang.NoClassDefFoundError: com/jcraft/jsch/JSchException 
```
Tried including jsch on the classpath with 
`java -cp ~/Downloads/apache-ivy-2.1.0-rc1/ivy-2.1.0-rc1.jar:lib/* com.apache.ivy.Main`
I am using ivy with deps.

Please send help, I don't want to use eclipse. 
