### PR TITLE
IVY-1631: ivy:retrieve Ant task and empty FileSet bug

### DIFF
--- a/asciidoc/release-notes.adoc
+++ b/asciidoc/release-notes.adoc
@@ -49,7 +49,7 @@ For details about the following changes, check our JIRA install at link:https://
 - FIX: ResolveEngine resets dictator resolver to null in the global configuration (jira:IVY-1618[])
 - FIX: ConcurrentModificationException in MessageLoggerHelper.sumupProblems (jira:IVY-1628[])
 - FIX: useOrigin="true" fails with file-based ibiblio (jira:IVY-1616[])
-
+- FIX: ivy:retrieve Ant task didn't create an empty fileset when no files were retrieved to a non-empty directory (jira:IVY-1631[])
 
 - IMPROVEMENT: Ivy command now accepts a URL for the -settings option (jira:IVY-1615[])
 

--- a/src/java/org/apache/ivy/ant/EmptyFileSet.java
+++ b/src/java/org/apache/ivy/ant/EmptyFileSet.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.ivy.ant;
+
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Resource;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+class EmptyFileSet extends FileSet {
+
+    private DirectoryScanner ds = new EmptyDirectoryScanner();
+
+    public Iterator<Resource> iterator() {
+        return new EmptyIterator<>();
+    }
+
+    public Object clone() {
+        return new EmptyFileSet();
+    }
+
+    public int size() {
+        return 0;
+    }
+
+    public DirectoryScanner getDirectoryScanner(Project project) {
+        return ds;
+    }
+
+    private static class EmptyIterator<T> implements Iterator<T> {
+
+        public boolean hasNext() {
+            return false;
+        }
+
+        public T next() {
+            throw new NoSuchElementException("EmptyFileSet Iterator");
+        }
+
+        public void remove() {
+            throw new IllegalStateException("EmptyFileSet Iterator");
+        }
+
+    }
+
+    private static class EmptyDirectoryScanner extends DirectoryScanner {
+
+        public String[] getIncludedFiles() {
+            return new String[0];
+        }
+
+    }
+}

--- a/src/java/org/apache/ivy/ant/IvyCacheFileset.java
+++ b/src/java/org/apache/ivy/ant/IvyCacheFileset.java
@@ -21,15 +21,11 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.DirectoryScanner;
-import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.PatternSet.NameEntry;
-import org.apache.tools.ant.types.Resource;
 
 /**
  * Creates an ant fileset consisting in all artifacts found during a resolve. Note that this task
@@ -193,50 +189,5 @@ public class IvyCacheFileset extends IvyCacheTask {
             file = file.getParentFile();
         }
         return r;
-    }
-
-    private static class EmptyFileSet extends FileSet {
-
-        private DirectoryScanner ds = new EmptyDirectoryScanner();
-
-        public Iterator<Resource> iterator() {
-            return new EmptyIterator<>();
-        }
-
-        public Object clone() {
-            return new EmptyFileSet();
-        }
-
-        public int size() {
-            return 0;
-        }
-
-        public DirectoryScanner getDirectoryScanner(Project project) {
-            return ds;
-        }
-    }
-
-    private static class EmptyIterator<T> implements Iterator<T> {
-
-        public boolean hasNext() {
-            return false;
-        }
-
-        public T next() {
-            throw new NoSuchElementException("EmptyFileSet Iterator");
-        }
-
-        public void remove() {
-            throw new IllegalStateException("EmptyFileSet Iterator");
-        }
-
-    }
-
-    private static class EmptyDirectoryScanner extends DirectoryScanner {
-
-        public String[] getIncludedFiles() {
-            return new String[0];
-        }
-
     }
 }

--- a/src/java/org/apache/ivy/ant/IvyRetrieve.java
+++ b/src/java/org/apache/ivy/ant/IvyRetrieve.java
@@ -126,16 +126,23 @@ public class IvyRetrieve extends IvyPostResolveTask {
             }
 
             if (getSetId() != null) {
-                FileSet fileset = new FileSet();
+                FileSet fileset;
+
+                Collection<File> retrievedFiles = report.getRetrievedFiles();
+                if (retrievedFiles.isEmpty()) {
+                    fileset = new EmptyFileSet();
+                } else {
+                    fileset = new FileSet();
+                    fileset.setDir(report.getRetrieveRoot());
+
+                    for (File file : retrievedFiles) {
+                        PatternSet.NameEntry ne = fileset.createInclude();
+                        ne.setName(getPath(report.getRetrieveRoot(), file));
+                    }
+                }
+
                 fileset.setProject(getProject());
                 getProject().addReference(getSetId(), fileset);
-
-                fileset.setDir(report.getRetrieveRoot());
-
-                for (File file : report.getRetrievedFiles()) {
-                    PatternSet.NameEntry ne = fileset.createInclude();
-                    ne.setName(getPath(report.getRetrieveRoot(), file));
-                }
             }
         } catch (Exception ex) {
             throw new BuildException("impossible to ivy retrieve: " + ex, ex);

--- a/src/java/org/apache/ivy/ant/IvyRetrieve.java
+++ b/src/java/org/apache/ivy/ant/IvyRetrieve.java
@@ -131,8 +131,10 @@ public class IvyRetrieve extends IvyPostResolveTask {
                 Collection<File> retrievedFiles = report.getRetrievedFiles();
                 if (retrievedFiles.isEmpty()) {
                     fileset = new EmptyFileSet();
+                    fileset.setProject(getProject());
                 } else {
                     fileset = new FileSet();
+                    fileset.setProject(getProject());
                     fileset.setDir(report.getRetrieveRoot());
 
                     for (File file : retrievedFiles) {
@@ -141,7 +143,6 @@ public class IvyRetrieve extends IvyPostResolveTask {
                     }
                 }
 
-                fileset.setProject(getProject());
                 getProject().addReference(getSetId(), fileset);
             }
         } catch (Exception ex) {

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -79,22 +79,27 @@ public class IvyRetrieveTest {
     }
 
     @Test
-    public void testRetrieveFileSetToNonEmptyDirectory() throws IOException {
+    public void testRetrieveToNonEmptyDirectory() throws IOException {
         new File("build/test/lib").mkdirs();
         new File("build/test/lib/foo.txt").createNewFile(); // make sure the retrieve dir is not empty
 
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
 
-        retrieve.setSetId("testId");
+        retrieve.setSetId("setId");
+        retrieve.setPathId("pathId");
         retrieve.execute();
 
-        FileSet fileSet = project.getReference("testId");
+        FileSet fileSet = project.getReference("setId");
         assertNotNull(fileSet);
         assertEquals(1, fileSet.size());
+
+        Path path = project.getReference("pathId");
+        assertNotNull(path);
+        assertEquals(1, path.size());
     }
 
     @Test
-    public void testRetrieveEmptyFileSetToNonEmptyDirectory() throws IOException {
+    public void testEmptyRetrieveToNonEmptyDirectory() throws IOException {
         new File("build/test/lib").mkdirs();
         new File("build/test/lib/foo.txt").createNewFile(); // make sure the retrieve dir is not empty
 

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -22,17 +22,20 @@ import java.io.IOException;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyPatternHelper;
+import org.apache.ivy.plugins.matcher.GlobPatternMatcher;
 import org.apache.ivy.util.CacheCleaner;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Mapper;
+import org.apache.tools.ant.types.Resource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class IvyRetrieveTest {
     private static final String IVY_RETRIEVE_PATTERN = "build/test/lib/[organisation]/[module]/ivy-[revision].xml";
@@ -75,6 +78,37 @@ public class IvyRetrieveTest {
         retrieve.execute();
         assertTrue(new File(IvyPatternHelper.substitute(RETRIEVE_PATTERN, "org1", "mod1.2", "2.0",
             "mod1.2", "jar", "jar")).exists());
+    }
+
+    @Test
+    public void testRetrieveFileSetToNonEmptyDirectory() throws IOException {
+        new File("build/test/lib").mkdirs();
+        new File("build/test/lib/foo.txt").createNewFile(); // make sure the retrieve dir is not empty
+
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
+
+        retrieve.setSetId("testId");
+        retrieve.execute();
+
+        FileSet fileSet = project.getReference("testId");
+        assertNotNull(fileSet);
+        assertEquals(1, fileSet.size());
+    }
+
+    @Test
+    public void testRetrieveEmptyFileSetToNonEmptyDirectory() throws IOException {
+        new File("build/test/lib").mkdirs();
+        new File("build/test/lib/foo.txt").createNewFile(); // make sure the retrieve dir is not empty
+
+        project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
+
+        retrieve.setType("foo"); // make sure we don't retrieve anything
+        retrieve.setSetId("testId");
+        retrieve.execute();
+
+        FileSet fileSet = project.getReference("testId");
+        assertNotNull(fileSet);
+        assertEquals(0, fileSet.size());
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyRetrieveTest.java
@@ -22,15 +22,13 @@ import java.io.IOException;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.IvyPatternHelper;
-import org.apache.ivy.plugins.matcher.GlobPatternMatcher;
 import org.apache.ivy.util.CacheCleaner;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
 import org.apache.tools.ant.types.FileSet;
-import org.apache.tools.ant.types.Mapper;
-import org.apache.tools.ant.types.Resource;
+import org.apache.tools.ant.types.Path;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -103,12 +101,17 @@ public class IvyRetrieveTest {
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-simple.xml");
 
         retrieve.setType("foo"); // make sure we don't retrieve anything
-        retrieve.setSetId("testId");
+        retrieve.setSetId("setId");
+        retrieve.setPathId("pathId");
         retrieve.execute();
 
-        FileSet fileSet = project.getReference("testId");
+        FileSet fileSet = project.getReference("setId");
         assertNotNull(fileSet);
         assertEquals(0, fileSet.size());
+
+        Path path = project.getReference("pathId");
+        assertNotNull(path);
+        assertEquals(0, path.size());
     }
 
     @Test


### PR DESCRIPTION
IVY-1631: when the ivy:retrieve Ant task retrieves the jars to a non-empty directory, but the retrieve task itself didn't retrieve any files, the created fileset was not empty but contained the existing files in that directory.