### PR TITLE
IVY-1632: Use valid value for HTTP header "Accept".

### DIFF
--- a/asciidoc/release-notes.adoc
+++ b/asciidoc/release-notes.adoc
@@ -50,6 +50,7 @@ For details about the following changes, check our JIRA install at link:https://
 - FIX: ConcurrentModificationException in MessageLoggerHelper.sumupProblems (jira:IVY-1628[])
 - FIX: useOrigin="true" fails with file-based ibiblio (jira:IVY-1616[])
 - FIX: ivy:retrieve Ant task didn't create an empty fileset when no files were retrieved to a non-empty directory (jira:IVY-1631[])
+- FIX: ivy:retrieve Ant task relied on the default HTTP header "Accept" which caused problems with servers that interpret it strictly (e.g. AWS CodeArtifact) (jira:IVY-1632[])
 
 - IMPROVEMENT: Ivy command now accepts a URL for the -settings option (jira:IVY-1615[])
 

--- a/src/java/org/apache/ivy/util/url/BasicURLHandler.java
+++ b/src/java/org/apache/ivy/util/url/BasicURLHandler.java
@@ -41,6 +41,8 @@ public class BasicURLHandler extends AbstractURLHandler implements TimeoutConstr
 
     private static final int BUFFER_SIZE = 64 * 1024;
 
+    private static final String ACCEPT_HEADER_VALUE = "*/*";
+
     private static final class HttpStatus {
         static final int SC_OK = 200;
 
@@ -96,6 +98,7 @@ public class BasicURLHandler extends AbstractURLHandler implements TimeoutConstr
             con.setConnectTimeout(connectionTimeout);
             con.setReadTimeout(readTimeout);
             con.setRequestProperty("User-Agent", getUserAgent());
+            con.setRequestProperty("Accept", ACCEPT_HEADER_VALUE);
             if (con instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) con;
                 if (getRequestMethod() == TimeoutConstrainedURLHandler.REQUEST_METHOD_HEAD) {
@@ -199,6 +202,7 @@ public class BasicURLHandler extends AbstractURLHandler implements TimeoutConstr
             conn.setConnectTimeout(connectionTimeout);
             conn.setReadTimeout(readTimeout);
             conn.setRequestProperty("User-Agent", getUserAgent());
+            conn.setRequestProperty("Accept", ACCEPT_HEADER_VALUE);
             conn.setRequestProperty("Accept-Encoding", "gzip,deflate");
             if (conn instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) conn;
@@ -245,6 +249,7 @@ public class BasicURLHandler extends AbstractURLHandler implements TimeoutConstr
             srcConn.setConnectTimeout(connectionTimeout);
             srcConn.setReadTimeout(readTimeout);
             srcConn.setRequestProperty("User-Agent", getUserAgent());
+            srcConn.setRequestProperty("Accept", ACCEPT_HEADER_VALUE);
             srcConn.setRequestProperty("Accept-Encoding", "gzip,deflate");
             if (srcConn instanceof HttpURLConnection) {
                 HttpURLConnection httpCon = (HttpURLConnection) srcConn;


### PR DESCRIPTION
The default accept header of Java isn't valid as described at
https://bugs.openjdk.java.net/browse/JDK-8163921

Therefore set an accept header that accepts simply anything in the
ivy:retrieve Ant task.