### PR TITLE
Partial fix for IVY-1649

### DIFF
--- a/src/java/org/apache/ivy/core/module/descriptor/DefaultModuleDescriptor.java
+++ b/src/java/org/apache/ivy/core/module/descriptor/DefaultModuleDescriptor.java
@@ -111,7 +111,7 @@ public class DefaultModuleDescriptor implements ModuleDescriptor {
             for (DependencyArtifactDescriptor artifact : artifacts) {
                 moduleDescriptor.addArtifact(DEFAULT_CONFIGURATION,
                     new MDArtifact(moduleDescriptor, artifact.getName(), artifact.getType(),
-                            artifact.getExt(), artifact.getUrl(), artifact.getExtraAttributes()));
+                            artifact.getExt(), artifact.getUrl(), artifact.getQualifiedExtraAttributes()));
             }
         } else {
             moduleDescriptor.addArtifact(DEFAULT_CONFIGURATION,


### PR DESCRIPTION
The namespaces of dependencies' extra attributes were forgotten before writing them to the cache when a module descriptor was created from scratch. With this change, namespaced attributes are correctly transferred to the generated module descriptor, but the xmlns declarations still have to be specified locally on each dependency element (see IVY-1650).