### PR TITLE
Make the book variable width

### DIFF
--- a/asciidoc/style/style.css
+++ b/asciidoc/style/style.css
@@ -22,7 +22,6 @@ body  {
     background-color: #5a7418;
 }
 #body  {
-    display: table;
     margin: 8px auto;
     padding: 0;
     width: 98%;


### PR DESCRIPTION
On my 1920x1080 screen, the book is rendered 2546.2 px wide, with a horizontal scroll bar. Resizing firefox makes no change, the book is fixed width.
![image](https://github.com/user-attachments/assets/e82af366-d947-4914-9b2f-9b2a4584ce9c)

When printed, the text is illegibly small.

Without `display: table` rendering is greatly improved:
![image](https://github.com/user-attachments/assets/f1c5d68a-3db1-471f-b6a5-7744536bd7fe)
