### PR TITLE
Java 8: use `assertThrows` instead of `ExpectedException` rule

### DIFF
--- a/test/java/org/apache/ivy/MainTest.java
+++ b/test/java/org/apache/ivy/MainTest.java
@@ -17,17 +17,6 @@
  */
 package org.apache.ivy;
 
-import org.apache.ivy.core.retrieve.RetrieveOptions;
-import org.apache.ivy.util.CacheCleaner;
-import org.apache.ivy.util.cli.CommandLine;
-import org.apache.ivy.util.cli.ParseException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
@@ -37,17 +26,26 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.ivy.core.retrieve.RetrieveOptions;
+import org.apache.ivy.util.CacheCleaner;
+import org.apache.ivy.util.cli.CommandLine;
+import org.apache.ivy.util.cli.ParseException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class MainTest {
 
     private File cache;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
@@ -65,51 +63,47 @@ public class MainTest {
 
     @Test
     public void testHelp() throws Exception {
-        run(new String[] {"-?"});
+        run("-?");
     }
 
     @Test
-    public void testBadOption() throws Exception {
-        expExc.expect(ParseException.class);
-        expExc.expectMessage("Unrecognized option: -bad");
-
-        run(new String[] {"-bad"});
+    public void testBadOption() {
+        Exception exception = assertThrows(ParseException.class, () -> run("-bad"));
+        assertEquals("Unrecognized option: -bad", exception.getMessage());
     }
 
     @Test
-    public void testMissingParameter() throws Exception {
-        expExc.expect(ParseException.class);
-        expExc.expectMessage("no argument for: ivy");
-
-        run(new String[] {"-ivy"});
+    public void testMissingParameter() {
+        Exception exception = assertThrows(ParseException.class, () -> run("-ivy"));
+        assertEquals("no argument for: ivy", exception.getMessage());
     }
 
     @Test
     public void testResolveSimple() throws Exception {
-        run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
+        run("-settings", "test/repositories/ivysettings.xml", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml");
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     @Test
     public void testResolveSimpleWithConfs() throws Exception {
-        run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-ivy",
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "-confs", "default"});
+        run("-settings", "test/repositories/ivysettings.xml", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "-confs", "default");
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     @Test
     public void testResolveSimpleWithConfs2() throws Exception {
-        run(new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs", "default",
-                "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
+        run("-settings", "test/repositories/ivysettings.xml", "-confs", "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml");
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
     @Test
     public void testExtraParams1() throws Exception {
-        String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
-                "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "foo1",
-                "foo2"};
+        String[] params = {
+            "-settings", "test/repositories/ivysettings.xml",
+            "-confs", "default",
+            "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml",
+            "foo1", "foo2"
+        };
         CommandLine line = Main.getParser().parse(params);
         String[] leftOver = line.getLeftOverArgs();
         assertNotNull(leftOver);
@@ -120,9 +114,12 @@ public class MainTest {
 
     @Test
     public void testExtraParams2() throws Exception {
-        String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
-                "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml", "--",
-                "foo1", "foo2"};
+        String[] params = {
+            "-settings", "test/repositories/ivysettings.xml",
+            "-confs", "default",
+            "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml",
+            "--", "foo1", "foo2"
+        };
         CommandLine line = Main.getParser().parse(params);
         String[] leftOver = line.getLeftOverArgs();
         assertNotNull(leftOver);
@@ -133,8 +130,11 @@ public class MainTest {
 
     @Test
     public void testExtraParams3() throws Exception {
-        String[] params = new String[] {"-settings", "test/repositories/ivysettings.xml", "-confs",
-                "default", "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"};
+        String[] params = {
+            "-settings", "test/repositories/ivysettings.xml",
+            "-confs", "default",
+            "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"
+        };
         CommandLine line = Main.getParser().parse(params);
         String[] leftOver = line.getLeftOverArgs();
         assertNotNull(leftOver);
@@ -146,7 +146,6 @@ public class MainTest {
      * {@code types} argument to the command line must be parsed correctly when it's passed
      * more than one value for the argument.
      *
-     * @throws Exception if something goes wrong
      * @see <a href="https://issues.apache.org/jira/browse/IVY-1355">IVY-1355</a>
      */
     @Test
@@ -165,8 +164,6 @@ public class MainTest {
 
     /**
      * Tests that the {@code overwriteMode} passed for the retrieve command works as expected
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
     public void testRetrieveOverwriteMode() throws Exception {
@@ -190,8 +187,6 @@ public class MainTest {
 
     /**
      * Tests that the {@code makepom} option works as expected
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
     public void testMakePom() throws Exception {
@@ -212,14 +207,12 @@ public class MainTest {
      */
     @Test
     public void testSettingsURL() throws Exception {
-        final URL settingsURL = new File("test/repositories/ivysettings.xml").toURI().toURL();
-        run(new String[] {"-settings", settingsURL.toString(), "-ivy",
-                "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml"});
-
+        URL settingsURL = new File("test/repositories/ivysettings.xml").toURI().toURL();
+        run("-settings", settingsURL.toString(), "-ivy", "test/repositories/1/org1/mod1.1/ivys/ivy-1.0.xml");
         assertTrue(new File("build/cache/org1/mod1.2/ivy-2.0.xml").exists());
     }
 
-    private void run(String[] args) throws Exception {
+    private void run(String... args) throws Exception {
         Main.run(Main.getParser(), args);
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCacheFilesetTest.java
@@ -17,11 +17,6 @@
  */
 package org.apache.ivy.ant;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,25 +24,28 @@ import java.util.List;
 
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Delete;
 import org.apache.tools.ant.types.FileSet;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IvyCacheFilesetTest {
 
     private IvyCacheFileset fileset;
 
     private Project project;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -227,11 +225,10 @@ public class IvyCacheFilesetTest {
 
     @Test
     public void requireCommonBaseDirEmptyList() {
+        List<ArtifactDownloadReport> reports = Collections.emptyList();
         // we expect a BuildException when we try to find a (non-existent) common base dir
         // across file system roots
-        expExc.expect(BuildException.class);
-        List<ArtifactDownloadReport> reports = Collections.emptyList();
-        fileset.requireCommonBaseDir(reports);
+        assertThrows(BuildException.class, () -> fileset.requireCommonBaseDir(reports));
     }
 
     @Test
@@ -241,14 +238,13 @@ public class IvyCacheFilesetTest {
             // single file system root isn't what we are interested in, in this test method
             return;
         }
-        // we expect a BuildException when we try to find a (non-existent) common base dir
-        // across file system roots
-        expExc.expect(BuildException.class);
         List<ArtifactDownloadReport> reports = Arrays.asList(
             artifactDownloadReport(new File(fileSystemRoots[0], "a/b/c/d")),
             artifactDownloadReport(new File(fileSystemRoots[1], "a/b/e/f"))
-        );
-        fileset.requireCommonBaseDir(reports);
+                );
+        // we expect a BuildException when we try to find a (non-existent) common base dir
+        // across file system roots
+        assertThrows(BuildException.class, () -> fileset.requireCommonBaseDir(reports));
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
+++ b/test/java/org/apache/ivy/ant/IvyCleanCacheTest.java
@@ -17,20 +17,23 @@
  */
 package org.apache.ivy.ant;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 
 import org.apache.ivy.TestHelper;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
+
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IvyCleanCacheTest {
+
     private IvyCleanCache cleanCache;
 
     private File cacheDir;
@@ -40,9 +43,6 @@ public class IvyCleanCacheTest {
     private File repoCache;
 
     private File resolutionCache;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -106,10 +106,9 @@ public class IvyCleanCacheTest {
      */
     @Test
     public void testUnknownCache() {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("unknown cache 'yourcache'");
         cleanCache.setResolution(false);
         cleanCache.setCache("yourcache");
-        cleanCache.perform();
+        Exception exception = assertThrows(BuildException.class, () -> cleanCache.perform());
+        assertEquals("unknown cache 'yourcache'", exception.getMessage());
     }
 }

--- a/test/java/org/apache/ivy/ant/IvyConfigureTest.java
+++ b/test/java/org/apache/ivy/ant/IvyConfigureTest.java
@@ -17,12 +17,6 @@
  */
 package org.apache.ivy.ant;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.List;
 
@@ -33,21 +27,26 @@ import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.plugins.resolver.IvyRepResolver;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Reference;
+
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IvyConfigureTest {
+
     private IvyConfigure configure;
 
     private Project project;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -278,10 +277,6 @@ public class IvyConfigureTest {
      */
     @Test
     public void testOverrideNotAllowed() {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("Overriding a previous definition of ivy:settings with the id '"
-                + configure.getSettingsId() + "' is not allowed when using override='notallowed'.");
-
         configure.setFile(new File("test/repositories/ivysettings.xml"));
         configure.execute();
 
@@ -293,7 +288,9 @@ public class IvyConfigureTest {
         configure.setOverride("notallowed");
         configure.setFile(new File("test/repositories/ivysettings.xml"));
 
-        configure.execute();
+        Exception exception = assertThrows(BuildException.class, () -> configure.execute());
+        assertEquals("Overriding a previous definition of ivy:settings with the id '"
+                + configure.getSettingsId() + "' is not allowed when using override='notallowed'.", exception.getMessage());
     }
 
     /**
@@ -301,18 +298,13 @@ public class IvyConfigureTest {
      */
     @Test
     public void testInvalidOverride() {
-        expExc.expect(IllegalArgumentException.class);
-        expExc.expectMessage("invalid override value 'unknown'. Valid values are "
-                + "[true, false, notallowed]");
-
-        configure.setOverride("unknown");
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> configure.setOverride("unknown"));
+        assertEquals("invalid override value 'unknown'. Valid values are [true, false, notallowed]", exception.getMessage());
     }
 
     /**
      * Tests that if the Ivy settings file <code>include</code>s another file as
      * <code>optional</code>, then the absence of that file doesn't lead to failures
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
     public void testOptionalFileInclude() throws Exception {

--- a/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDependencyUpdateCheckerTest.java
@@ -28,20 +28,16 @@ import org.apache.tools.ant.Project;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
 
     private IvyDependencyUpdateChecker dependencyUpdateChecker;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -146,12 +142,10 @@ public class IvyDependencyUpdateCheckerTest extends AntTaskTestCase {
      */
     @Test
     public void testFailureWithMissingConfigurations() {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("unknown");
-
         dependencyUpdateChecker.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         dependencyUpdateChecker.setConf("default,unknown");
-        dependencyUpdateChecker.execute();
+        Exception exception = assertThrows(BuildException.class, () -> dependencyUpdateChecker.execute());
+        assertEquals("requested configuration not found in apache#resolve-simple;1.0: [ 'unknown' ]", exception.getCause().getMessage());
     }
 
     /**

--- a/test/java/org/apache/ivy/ant/IvyPublishTest.java
+++ b/test/java/org/apache/ivy/ant/IvyPublishTest.java
@@ -39,23 +39,20 @@ import org.apache.tools.ant.taskdefs.Echo;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IvyPublishTest {
-    private File cache;
 
     private IvyPublish publish;
 
     private Project project;
 
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
+    private File cache;
 
     @Before
     public void setUp() {
@@ -405,8 +402,6 @@ public class IvyPublishTest {
      */
     @Test
     public void testHaltOnMissing() {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("missing artifact apache#resolve-simple;1.2!resolve-simple.jar");
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-multiconf.xml");
         IvyResolve res = new IvyResolve();
         res.setProject(project);
@@ -415,19 +410,16 @@ public class IvyPublishTest {
         publish.setPubrevision("1.2");
         publish.setResolver("1");
         publish.setHaltonmissing(true);
-        try {
-            publish.execute();
-        } finally {
-            // should have delivered the ivy file
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
 
-            // should not have published the files with "1" resolver
-            assertFalse(new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml")
-                    .exists());
-            assertFalse(new File(
-                    "test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar")
-                    .exists());
-        }
+        Exception exception = assertThrows(BuildException.class, () -> publish.execute());
+        assertEquals("missing artifact apache#resolve-simple;1.2!resolve-simple.jar", exception.getCause().getMessage());
+
+        // should have delivered the ivy file
+        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+
+        // should not have published the files with "1" resolver
+        assertFalse(new File("test/repositories/1/apache/resolve-simple/ivys/ivy-1.2.xml").exists());
+        assertFalse(new File("test/repositories/1/apache/resolve-simple/jars/resolve-simple-1.2.jar").exists());
     }
 
     /**
@@ -437,8 +429,6 @@ public class IvyPublishTest {
      */
     @Test
     public void testHaltOnMissing2() throws IOException {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("missing artifact apache#multi;1.2!multi2.jar");
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-multi.xml");
         IvyResolve res = new IvyResolve();
         res.setProject(project);
@@ -451,15 +441,15 @@ public class IvyPublishTest {
         publish.setPubrevision("1.2");
         publish.setResolver("transactional");
         publish.setHaltonmissing(true);
-        try {
-            publish.execute();
-        } finally {
-            // should have delivered the ivy file
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
 
-            // should not have published the files with "transactional" resolver
-            assertFalse(new File("build/test/transactional/apache/multi/1.2").exists());
-        }
+        Exception exception = assertThrows(BuildException.class, () -> publish.execute());
+        assertEquals("missing artifact apache#multi;1.2!multi2.jar", exception.getCause().getMessage());
+
+        // should have delivered the ivy file
+        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+
+        // should not have published the files with "transactional" resolver
+        assertFalse(new File("build/test/transactional/apache/multi/1.2").exists());
     }
 
     /**
@@ -469,8 +459,6 @@ public class IvyPublishTest {
      */
     @Test
     public void testHaltOnMissing3() throws IOException {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("missing artifact apache#multi;1.2!multi2.jar");
         project.setProperty("ivy.dep.file", "test/java/org/apache/ivy/ant/ivy-publish-multi.xml");
         IvyResolve res = new IvyResolve();
         res.setProject(project);
@@ -483,15 +471,15 @@ public class IvyPublishTest {
         publish.setPubrevision("1.2");
         publish.setResolver("1");
         publish.setHaltonmissing(true);
-        try {
-            publish.execute();
-        } finally {
-            // should have delivered the ivy file
-            assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
 
-            // should not have published the files with "transactional" resolver
-            assertFalse(new File("test/repositories/1/apache/multi").exists());
-        }
+        Exception exception = assertThrows(BuildException.class, () -> publish.execute());
+        assertEquals("missing artifact apache#multi;1.2!multi2.jar", exception.getCause().getMessage());
+
+        // should have delivered the ivy file
+        assertTrue(new File("build/test/publish/ivy-1.2.xml").exists());
+
+        // should not have published the files with "transactional" resolver
+        assertFalse(new File("test/repositories/1/apache/multi").exists());
     }
 
     @Test

--- a/test/java/org/apache/ivy/ant/IvyResolveTest.java
+++ b/test/java/org/apache/ivy/ant/IvyResolveTest.java
@@ -31,24 +31,20 @@ import org.apache.tools.ant.taskdefs.Parallel;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IvyResolveTest {
 
-    private Project project;
-
     private IvyResolve resolve;
 
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
+    private Project project;
 
     @Before
     public void setUp() {
@@ -324,12 +320,10 @@ public class IvyResolveTest {
 
     @Test
     public void testFailureWithMissingConfigurations() {
-        expExc.expect(BuildException.class);
-        expExc.expectMessage("unknown");
-
         resolve.setFile(new File("test/java/org/apache/ivy/ant/ivy-simple.xml"));
         resolve.setConf("default,unknown");
-        resolve.execute();
+        Exception exception = assertThrows(BuildException.class, () -> resolve.execute());
+        assertEquals("requested configuration not found in apache#resolve-simple;1.0: [ 'unknown' ]", exception.getCause().getMessage());
     }
 
     @Test(expected = BuildException.class)

--- a/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
+++ b/test/java/org/apache/ivy/core/module/id/ModuleRevisionIdTest.java
@@ -17,19 +17,16 @@
  */
 package org.apache.ivy.core.module.id;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ModuleRevisionIdTest {
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Test
     public void testParse() {
@@ -67,10 +64,8 @@ public class ModuleRevisionIdTest {
     }
 
     private void testParseFailure(String mrid) {
-        expExc.expect(IllegalArgumentException.class);
-        expExc.expectMessage(mrid);
-
-        ModuleRevisionId.parse(mrid);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> ModuleRevisionId.parse(mrid));
+        assertTrue(exception.getMessage().contains(mrid));
     }
 
     @Test
@@ -90,11 +85,9 @@ public class ModuleRevisionIdTest {
         extraAttributes.put("nullatt", null);
         testEncodeDecodeToString(
             ModuleRevisionId.newInstance("org/apache", "pre/name", "1.0-dev8/2", extraAttributes));
-
     }
 
     private void testEncodeDecodeToString(ModuleRevisionId mrid) {
         assertEquals(mrid, ModuleRevisionId.decode(mrid.encodeToString()));
     }
-
 }

--- a/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
+++ b/test/java/org/apache/ivy/core/settings/XmlSettingsParserTest.java
@@ -17,6 +17,11 @@
  */
 package org.apache.ivy.core.settings;
 
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
 import org.apache.ivy.core.cache.DefaultRepositoryCacheManager;
 import org.apache.ivy.core.cache.ResolutionCacheManager;
 import org.apache.ivy.core.module.descriptor.Artifact;
@@ -43,27 +48,20 @@ import org.apache.ivy.plugins.version.ChainVersionMatcher;
 import org.apache.ivy.plugins.version.MavenTimedSnapshotVersionMatcher;
 import org.apache.ivy.plugins.version.MockVersionMatcher;
 import org.apache.ivy.plugins.version.VersionMatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.List;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Test the parsing of Ivy settings file through the {@link XmlSettingsParser}
  */
 public class XmlSettingsParserTest {
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Test
     public void test() throws Exception {
@@ -261,18 +259,15 @@ public class XmlSettingsParserTest {
 
     /**
      * Test of resolver referencing a non existent cache.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
-    public void testInvalidCache() throws Exception {
-        expExc.expect(ParseException.class);
-        expExc.expectMessage("mycache");
-
+    public void testInvalidCache() {
         IvySettings settings = new IvySettings();
         XmlSettingsParser parser = new XmlSettingsParser(settings);
 
-        parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache-invalid.xml"));
+        Exception exception = assertThrows(ParseException.class, () ->
+            parser.parse(XmlSettingsParserTest.class.getResource("ivysettings-cache-invalid.xml")));
+        assertTrue(exception.getMessage().endsWith("unknown cache manager 'mycache'. Available caches are [mycache2]"));
     }
 
     @Test

--- a/test/java/org/apache/ivy/osgi/core/ManifestHeaderTest.java
+++ b/test/java/org/apache/ivy/osgi/core/ManifestHeaderTest.java
@@ -17,20 +17,17 @@
  */
 package org.apache.ivy.osgi.core;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(Enclosed.class)
 public class ManifestHeaderTest {
@@ -92,14 +89,10 @@ public class ManifestHeaderTest {
             ManifestHeaderValue value = new ManifestHeaderValue("glassfish javax.servlet.3.1.0.b33");
             assertEquals("glassfish javax.servlet.3.1.0.b33", value.getSingleValue());
         }
-
     }
 
     @RunWith(Parameterized.class)
     public static class IllegalOptionTests {
-
-        @Rule
-        public ExpectedException expExc = ExpectedException.none();
 
         @Parameterized.Parameters(name = "Illegal token at {1} in {0}")
         public static Collection<Object[]> data() {
@@ -119,12 +112,10 @@ public class ManifestHeaderTest {
          * Expected failure when the parameter is illegal
          */
         @Test
-        public void testSyntaxError() throws ParseException {
-            expExc.expect(ParseException.class);
-            expExc.expect(hasProperty("errorOffset", is(offset)));
-            new ManifestHeaderValue(value);
+        public void testSyntaxError() {
+            ParseException exception = assertThrows(ParseException.class, () -> new ManifestHeaderValue(value));
+            assertEquals(offset, exception.getErrorOffset());
         }
-
     }
 
     @RunWith(Parameterized.class)
@@ -155,7 +146,5 @@ public class ManifestHeaderTest {
         public void testNormalisation() throws Exception {
             assertEquals(new ManifestHeaderValue(normalised), new ManifestHeaderValue(value));
         }
-
     }
-
 }

--- a/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/RegexpConflictManagerTest.java
@@ -22,24 +22,25 @@ import java.io.File;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.util.FileUtil;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class RegexpConflictManagerTest {
+
     private Ivy ivy;
 
     private File cache;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
         ivy = new Ivy();
         ivy.configure(RegexpConflictManagerTest.class.getResource("ivysettings-regexp-test.xml"));
+
         cache = new File("build/cache");
         cache.mkdirs();
     }
@@ -51,17 +52,13 @@ public class RegexpConflictManagerTest {
 
     @Test
     public void testNoApiConflictResolve() throws Exception {
-        ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-no-regexp-conflict.xml"),
-                getResolveOptions());
+        ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-no-regexp-conflict.xml"), getResolveOptions());
     }
 
     @Test
-    public void testConflictResolve() throws Exception {
-        expExc.expect(StrictConflictException.class);
-        expExc.expectMessage("org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0]) conflicts with org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])");
-
-        ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-conflict.xml"),
-                getResolveOptions());
+    public void testConflictResolve() {
+        Exception exception = assertThrows(StrictConflictException.class, () -> ivy.resolve(RegexpConflictManagerTest.class.getResource("ivy-conflict.xml"), getResolveOptions()));
+        assertEquals("org1#mod1.2;2.0.0:2.0 (needed by [apache#resolve-noconflict;1.0]) conflicts with org1#mod1.2;2.1.0:2.1 (needed by [apache#resolve-noconflict;1.0])", exception.getMessage());
     }
 
     private ResolveOptions getResolveOptions() {

--- a/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
+++ b/test/java/org/apache/ivy/plugins/parser/m2/PomModuleDescriptorParserTest.java
@@ -17,13 +17,6 @@
  */
 package org.apache.ivy.plugins.parser.m2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -58,12 +51,20 @@ import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParserTest;
 import org.apache.ivy.plugins.repository.url.URLResource;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.MockResolver;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParserTester {
 
@@ -85,9 +86,6 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     private File dest = new File("build/test/test-write.xml");
 
     private MockResolver mockedResolver = new MockedDependencyResolver();
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Rule
     public TemporaryFolder workDir = new TemporaryFolder();
@@ -220,12 +218,10 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
     }
 
     @Test
-    public void testParentNotFound() throws Exception {
-        expExc.expect(IOException.class);
-        expExc.expectMessage("Impossible to load parent");
-
-        PomModuleDescriptorParser.getInstance().parseDescriptor(new IvySettings(),
-                getClass().getResource("test-parent-not-found.pom"), false);
+    public void testParentNotFound() {
+        Exception exception = assertThrows(IOException.class, () ->
+            PomModuleDescriptorParser.getInstance().parseDescriptor(new IvySettings(), getClass().getResource("test-parent-not-found.pom"), false));
+        assertTrue(exception.getMessage().startsWith("Impossible to load parent"));
     }
 
     @Test
@@ -427,7 +423,7 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         assertEquals(5, dds.length);
         for (int i = 0; i < dds.length; i++) {
             assertEquals(2, dds[i].getAllDependencyArtifacts().length);
-            int withExt = i == 0 || i == 3 ? 1: 0;
+            int withExt = i == 0 || i == 3 ? 1 : 0;
             assertEquals(extraAtt, dds[i].getAllDependencyArtifacts()[withExt].getExtraAttributes());
         }
     }
@@ -1285,17 +1281,14 @@ public class PomModuleDescriptorParserTest extends AbstractModuleDescriptorParse
         for (final String expectedPackagingType : packagingTypesToTest) {
             String sysPropToSet = null;
             switch (expectedPackagingType) {
-                case "bundle": {
+                case "bundle":
                     sysPropToSet = "PomModuleDescriptorParserTest.some-other-test-prop";
                     break;
-                }
-                case "jar": {
+                case "jar":
                     sysPropToSet = "PomModuleDescriptorParserTest.some-test-prop";
                     break;
-                }
-                default: {
+                default:
                     fail("Unexpected packaging type");
-                }
             }
             // activate the relevant profile, based on a system property
             System.setProperty(sysPropToSet, "foo");

--- a/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/FileSystemResolverTest.java
@@ -51,21 +51,16 @@ import org.apache.ivy.util.FileUtil;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-/**
- *
- */
 public class FileSystemResolverTest extends AbstractDependencyResolverTest {
-    // CheckStyle:MagicNumberCheck OFF
 
     private static final String FS = File.separator;
 
@@ -88,9 +83,6 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
     public FileSystemResolverTest() {
         setupLastModified();
     }
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -889,21 +881,14 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
         resolver.abortPublishTransaction();
 
         assertFalse(new File("test/repositories/1/myorg/mymodule/myrevision/ivy.xml").exists());
-        assertFalse(new File(
-                "test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext")
-                .exists());
+        assertFalse(new File("test/repositories/1/myorg/mymodule/myrevision/myartifact-myrevision.myext").exists());
     }
 
     /**
      * Publishing with transaction=true and an unsupported pattern must fail.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
-    public void testUnsupportedTransaction() throws Exception {
-        expExc.expect(IllegalStateException.class);
-        expExc.expectMessage("transactional");
-
+    public void testUnsupportedTransaction() {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
         resolver.setSettings(settings);
@@ -919,20 +904,18 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 "myext");
         File src = new File("test/repositories/ivysettings.xml");
 
-        resolver.beginPublishTransaction(mrid, false);
-        resolver.publish(artifact, src, false);
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            resolver.beginPublishTransaction(mrid, false);
+            resolver.publish(artifact, src, false);
+        });
+        assertTrue(exception.getMessage().contains("transactional"));
     }
 
     /**
      * Publishing with transaction=true and an unsupported combination of patterns must fail.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
-    public void testUnsupportedTransaction2() throws Exception {
-        expExc.expect(IllegalStateException.class);
-        expExc.expectMessage("transactional");
-
+    public void testUnsupportedTransaction2() {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
         resolver.setSettings(settings);
@@ -950,21 +933,19 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 "myext");
         File src = new File("test/repositories/ivysettings.xml");
 
-        resolver.beginPublishTransaction(mrid, false);
-        resolver.publish(ivyArtifact, src, false);
-        resolver.publish(artifact, src, false);
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            resolver.beginPublishTransaction(mrid, false);
+            resolver.publish(ivyArtifact, src, false);
+            resolver.publish(artifact, src, false);
+        });
+        assertTrue(exception.getMessage().contains("transactional"));
     }
 
     /**
      * Publishing with transaction=true and overwrite mode must fail.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test
-    public void testUnsupportedTransaction3() throws Exception {
-        expExc.expect(IllegalStateException.class);
-        expExc.expectMessage("transactional");
-
+    public void testUnsupportedTransaction3() {
         FileSystemResolver resolver = new FileSystemResolver();
         resolver.setName("test");
         resolver.setSettings(settings);
@@ -978,9 +959,12 @@ public class FileSystemResolverTest extends AbstractDependencyResolverTest {
                 "myext");
         File src = new File("test/repositories/ivysettings.xml");
 
-        // overwrite transaction not supported
-        resolver.beginPublishTransaction(mrid, true);
-        resolver.publish(artifact, src, true);
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            // overwrite transaction not supported
+            resolver.beginPublishTransaction(mrid, true);
+            resolver.publish(artifact, src, true);
+        });
+        assertTrue(exception.getMessage().contains("transactional"));
     }
 
     @Test

--- a/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
+++ b/test/java/org/apache/ivy/plugins/resolver/IvyRepResolverTest.java
@@ -17,9 +17,6 @@
  */
 package org.apache.ivy.plugins.resolver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.util.List;
 
@@ -38,24 +35,23 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.resolve.ResolvedModuleRevision;
 import org.apache.ivy.core.settings.IvySettings;
 import org.apache.ivy.core.sort.SortEngine;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-/**
- *
- */
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 public class IvyRepResolverTest extends AbstractDependencyResolverTest {
+
     private IvySettings settings;
 
     private ResolveEngine engine;
 
     private ResolveData data;
-
-    @Rule
-    public ExpectedException expExc = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -97,21 +93,19 @@ public class IvyRepResolverTest extends AbstractDependencyResolverTest {
     /**
      * Test case for IVY-625. Must fail if no ivyroot specified.
      *
-     * @throws Exception if something goes wrong
      * @see <a href="https://issues.apache.org/jira/browse/IVY-625">IVY-625</a>
      */
     @Test
-    public void testMandatoryRoot() throws Exception {
-        expExc.expect(IllegalStateException.class);
-        expExc.expectMessage("ivyroot");
-
+    public void testMandatoryRoot() {
         IvyRepResolver resolver = new IvyRepResolver();
         resolver.setName("test");
         resolver.setSettings(settings);
 
         ModuleRevisionId mrid = ModuleRevisionId.newInstance("apache", "commons-cli", "1.0");
 
-        resolver.getDependency(new DefaultDependencyDescriptor(mrid, false), data);
+        Exception exception = assertThrows(IllegalStateException.class, () ->
+            resolver.getDependency(new DefaultDependencyDescriptor(mrid, false), data));
+        assertTrue(exception.getMessage().contains("ivyroot"));
     }
 
     @Test


### PR DESCRIPTION
`@Rule ExpectedException` can be replaced by the much more precise `assertThrows` now that Java 8 is the baseline.

This is extracted and expanded from https://github.com/apache/ant-ivy/pull/109/commits/f6a7c941ef0435876aa2c36673ea8da39ed72f27 (see #109)