### PR TITLE
IVY-1656: write inherited dependencies first to preserve resolve order

### DIFF
--- a/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
+++ b/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
@@ -1122,6 +1122,7 @@ public final class XmlModuleDescriptorUpdater {
                 InheritableItem[] items = getDependencies(merged);
                 if (writeInheritedItems(merged, items, DependencyPrinter.INSTANCE, "dependencies", false)) {
                     out.println("<!-- dependencies inherited end -->");
+                    out.println(); // separate from next section
                     out.print(getIndent());
                 }
             }
@@ -1295,7 +1296,9 @@ public final class XmlModuleDescriptorUpdater {
                 writeInheritedDependencies(merged);
             }
 
-            write(new StringBuilder("<!--").append(ch, start, length).append("-->").toString());
+            write("<!--");
+            write(String.valueOf(ch, start, length));
+            write("-->");
 
             if (inHeader) {
                 write(LINE_SEPARATOR);

--- a/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
+++ b/src/java/org/apache/ivy/plugins/parser/xml/XmlModuleDescriptorUpdater.java
@@ -292,12 +292,10 @@ public final class XmlModuleDescriptorUpdater {
             // according to ivy.xsd, all <dependency> elements must occur before
             // the <exclude>, <override> or <conflict> elements
             if (options.isMerge()
-                    && ("exclude".equals(localName) || "override".equals(localName) || "conflict"
-                            .equals(localName)) && "ivy-module/dependencies".equals(getContext())) {
+                    && !mergedDependencies
+                    && "ivy-module/dependencies".equals(getContext())) {
                 ModuleDescriptor merged = options.getMergedDescriptor();
                 writeInheritedDependencies(merged);
-                out.println();
-                out.print(getIndent());
             }
 
             context.push(qName);
@@ -991,7 +989,7 @@ public final class XmlModuleDescriptorUpdater {
          *            just write the inherited items inline, with a comment indicating where they
          *            came from.
          */
-        private void writeInheritedItems(ModuleDescriptor merged, InheritableItem[] items,
+        private boolean writeInheritedItems(ModuleDescriptor merged, InheritableItem[] items,
                 ItemPrinter printer, String itemName, boolean includeContainer) {
             // first categorize inherited items by their source module, so that
             // we can add some useful comments
@@ -1014,6 +1012,10 @@ public final class XmlModuleDescriptorUpdater {
                         newMapping.isEmpty() ? "" : " defaultconfmapping=\"" + newMapping + "\"",
                         (confMappingOverride != null) ? " confmappingoverride=\"" + confMappingOverride + "\"" : ""));
                 context.push(itemName);
+                if ("dependencies".equals(itemName)) {
+                    out.println();
+                    out.print(getIndent());
+                }
                 justOpen = null;
             }
 
@@ -1039,13 +1041,17 @@ public final class XmlModuleDescriptorUpdater {
                 // restore the prior indent
                 out.print(currentIndent);
             }
+
+            return hasItems;
         }
 
         private void writeInheritanceComment(String itemDescription, Object parentInfo) {
             PrintWriter out = getWriter();
-            out.println();
-            out.println(getIndent() + "<!-- " + itemDescription + " inherited from " + parentInfo
-                    + " -->");
+            if (!"dependencies".equals(itemDescription)) {
+                out.println();
+                out.print(getIndent());
+            }
+            out.println("<!-- " + itemDescription + " inherited from " + parentInfo + " -->");
         }
 
         /**
@@ -1113,8 +1119,11 @@ public final class XmlModuleDescriptorUpdater {
         private void writeInheritedDependencies(ModuleDescriptor merged) {
             if (!mergedDependencies) {
                 mergedDependencies = true;
-                writeInheritedItems(merged, getDependencies(merged), DependencyPrinter.INSTANCE,
-                    "dependencies", false);
+                InheritableItem[] items = getDependencies(merged);
+                if (writeInheritedItems(merged, items, DependencyPrinter.INSTANCE, "dependencies", false)) {
+                    out.println("<!-- dependencies inherited end -->");
+                    out.print(getIndent());
+                }
             }
         }
 
@@ -1149,7 +1158,7 @@ public final class XmlModuleDescriptorUpdater {
          *            a descriptor element name, for example "configurations" or "info"
          */
         private void flushMergedElementsBefore(String moduleElement) {
-            if (options.isMerge() && context.size() == 1 && "ivy-module".equals(context.peek())
+            if (options.isMerge() && "ivy-module".equals(getContext())
                     && !(mergedConfigurations && mergedDependencies)) {
 
                 // calculate the position of the element in ivy-module
@@ -1184,7 +1193,6 @@ public final class XmlModuleDescriptorUpdater {
         }
 
         public void endElement(String uri, String localName, String qName) throws SAXException {
-
             String path = getContext();
             if (options.isMerge()) {
                 ModuleDescriptor merged = options.getMergedDescriptor();
@@ -1197,10 +1205,6 @@ public final class XmlModuleDescriptorUpdater {
                     case "ivy-module/configurations":
                         // write inherited configurations after all child configurations
                         writeInheritedConfigurations(merged);
-                        break;
-                    case "ivy-module/dependencies":
-                        // write inherited dependencies after all child dependencies
-                        writeInheritedDependencies(merged);
                         break;
                     case "ivy-module":
                         // write any remaining inherited data before we close the
@@ -1284,9 +1288,14 @@ public final class XmlModuleDescriptorUpdater {
                 justOpen = null;
             }
 
-            write("<!--");
-            write(String.valueOf(ch, start, length));
-            write("-->");
+            if (options.isMerge()
+                    && !mergedDependencies
+                    && "ivy-module/dependencies".equals(getContext())) {
+                ModuleDescriptor merged = options.getMergedDescriptor();
+                writeInheritedDependencies(merged);
+            }
+
+            write(new StringBuilder("<!--").append(ch, start, length).append("-->").toString());
 
             if (inHeader) {
                 write(LINE_SEPARATOR);

--- a/test/java/org/apache/ivy/ant/IvyDeliverTest.java
+++ b/test/java/org/apache/ivy/ant/IvyDeliverTest.java
@@ -118,8 +118,9 @@ public class IvyDeliverTest {
         res.setProject(project);
         res.execute();
 
-        deliver.setPubrevision("1.2");
         deliver.setDeliverpattern("build/test/deliver/merge/ivy-[revision].xml");
+        deliver.setPubrevision("1.2");
+        deliver.setStatus("release");
         deliver.execute();
 
         // should have delivered the file to the specified destination
@@ -138,10 +139,10 @@ public class IvyDeliverTest {
                mergeLine = mergeLine.trim();
                expectedLine = expectedLine.trim();
 
-               if (!mergeLine.startsWith("<info")) {
-                   assertEquals("published descriptor matches at line[" + lineNo + "]",
-                           expectedLine.trim(), mergeLine.trim());
+               if (mergeLine.startsWith("<info")) {
+                   mergeLine = mergeLine.replaceFirst(" publication=\"\\d+\"", "");
                }
+               assertEquals("published descriptor matches at line[" + lineNo + "]", expectedLine.trim(), mergeLine.trim());
 
                ++lineNo;
                mergeLine = merged.readLine();

--- a/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
+++ b/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
@@ -43,6 +43,7 @@
 		<dependency org="org1" name="mod1.2" rev="2.0" conf="default->default"/>
 		<dependency org="org1" name="mod1.1" rev="2.0" transitive="false" conf="compile->default"/>
 		<!-- dependencies inherited end -->
+
 		<!-- not in parent -->
 		<dependency org="org2" name="mod2.1" rev="0.3" conf="default->compile(default)"/>
 		<!-- overrides parent -->

--- a/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
+++ b/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
@@ -21,7 +21,7 @@
 
 	<info organisation="apache" module="resolve-extends" revision="1.2" status="release">
 		<!-- <extends organisation="apache" module="resolve-simple" revision="1.0" location="./ivy-multiconf.xml"/> -->
-
+	
 		<!-- description inherited from parent -->
 		<description>Demonstrates configuration-specific dependencies</description>
 	</info>

--- a/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
+++ b/test/java/org/apache/ivy/ant/ivy-extends-merged.xml
@@ -31,7 +31,7 @@
 		<conf name="extra"/>
 		<!-- overrides conf in parent -->
 		<conf name="default" extends="compile" description="overrides the conf definition in parent descriptor"/>
-
+	
 		<!-- configurations inherited from apache#resolve-simple;1.0 -->
 		<conf name="compile" visibility="public"/>
 	</configurations>
@@ -39,14 +39,14 @@
 	<publications/>
 
 	<dependencies>
+		<!-- dependencies inherited from apache#resolve-simple;1.0 -->
+		<dependency org="org1" name="mod1.2" rev="2.0" conf="default->default"/>
+		<dependency org="org1" name="mod1.1" rev="2.0" transitive="false" conf="compile->default"/>
+		<!-- dependencies inherited end -->
 		<!-- not in parent -->
 		<dependency org="org2" name="mod2.1" rev="0.3" conf="default->compile(default)"/>
 		<!-- overrides parent -->
 		<dependency org="org1" name="mod1.1" rev="1.1" conf="default,compile->default" transitive="false"/>
-
-		<!-- dependencies inherited from apache#resolve-simple;1.0 -->
-		<dependency org="org1" name="mod1.2" rev="2.0" conf="default->default"/>
-		<dependency org="org1" name="mod1.1" rev="2.0" transitive="false" conf="compile->default"/>
 	</dependencies>
 
 </ivy-module>


### PR DESCRIPTION
This change affects the following four tests, which share the merged output file:

<img width="440" height="533" alt="image" src="https://github.com/user-attachments/assets/321a135c-027a-4455-810f-0973ce808f51" />