### PR TITLE
IVY-1204, IVY-1585: if dependency is rejected, reject parent revision and restart

### DIFF
--- a/src/java/org/apache/ivy/core/resolve/IvyNode.java
+++ b/src/java/org/apache/ivy/core/resolve/IvyNode.java
@@ -55,7 +55,6 @@ import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.resolve.IvyNodeCallers.Caller;
 import org.apache.ivy.core.resolve.IvyNodeEviction.EvictionData;
 import org.apache.ivy.plugins.conflict.ConflictManager;
-import org.apache.ivy.plugins.conflict.LatestCompatibleConflictManager;
 import org.apache.ivy.plugins.matcher.MatcherHelper;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.util.Message;
@@ -366,6 +365,16 @@ public class IvyNode implements Comparable<IvyNode> {
                 continue;
             }
 
+            // IVY-1204, IVY-1228, IVY-1585: blacklisted dependency for new rev
+            if (data.isBlacklisted(rootModuleConf, requestedDependencyRevisionId)
+                    && !isRoot() && settings.getVersionMatcher().isDynamic(getId())) {
+                IvyNode node = data.getNode(requestedDependencyRevisionId);
+                IvyNodeBlacklist blacklist = node.getBlacklistData(rootModuleConf);
+                blacklist(new IvyNodeBlacklist(dds.keySet().iterator().next(), blacklist.getSelectedNode(), node, this, rootModuleConf));
+
+                throw new RestartResolveProcess("trying to handle incompatibility of " + this);
+            }
+
             // check if not already loaded here
             IvyNode depNode = dependencies.get(requestedDependencyRevisionId);
             if (depNode == null) {
@@ -381,8 +390,8 @@ public class IvyNode implements Comparable<IvyNode> {
                     // dependency already tried to be resolved, but unsuccessfully
                     // nothing special to do
                 }
-
             }
+
             String[] confsArray = depNode.resolveSpecialConfigurations(dependencyConfigurations);
             Collection<String> confs = Arrays.asList(confsArray);
             depNode.updateConfsToFetch(confs);

--- a/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
+++ b/test/java/org/apache/ivy/plugins/conflict/LatestCompatibleConflictManagerTest.java
@@ -17,9 +17,6 @@
  */
 package org.apache.ivy.plugins.conflict;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.text.ParseException;
 
@@ -28,17 +25,24 @@ import org.apache.ivy.TestFixture;
 import org.apache.ivy.TestHelper;
 import org.apache.ivy.core.report.ConfigurationResolveReport;
 import org.apache.ivy.core.report.ResolveReport;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class LatestCompatibleConflictManagerTest {
-    private TestFixture fixture;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class LatestCompatibleConflictManagerTest {
+
+    private final TestFixture fixture = new TestFixture();
 
     @Before
     public void setUp() {
-        fixture = new TestFixture();
         LatestCompatibleConflictManager cm = new LatestCompatibleConflictManager();
+        cm.setName("latest-compatible");
+
+        fixture.clean();
         fixture.getSettings().addConfigured(cm);
         fixture.getSettings().setDefaultConflictManager(cm);
     }
@@ -51,8 +55,7 @@ public class LatestCompatibleConflictManagerTest {
     @Test
     public void testInitFromSettings() throws Exception {
         Ivy ivy = new Ivy();
-        ivy.configure(LatestCompatibleConflictManagerTest.class
-                .getResource("ivysettings-latest-compatible.xml"));
+        ivy.configure(getClass().getResource("ivysettings-latest-compatible.xml"));
         ConflictManager cm = ivy.getSettings().getDefaultConflictManager();
         assertTrue(cm instanceof LatestCompatibleConflictManager);
     }
@@ -105,11 +108,40 @@ public class LatestCompatibleConflictManagerTest {
         resolveAndAssert("#A;1", "#B;1.4, #C;2.5, #D;1.5");
     }
 
+    /**
+     * Test case for <a href="https://issues.apache.org/jira/browse/IVY-1204">IVY-1204</a>.
+     */
+    @Test
+    public void testCompatibilityResolve1204() throws Exception {
+        fixture
+            .addMD("#A;1.0").addMD("#A;1.1")
+            .addMD("#B;2.0->#A;1.0").addMD("#B;2.1->#A;1.0")
+            .addMD("#C;3.0->{ #A;1.0, #B;2.0 }").addMD("#C;3.1->{ #A;1.1, #B;2.1 }")
+            .addMD("#D;1->{ #A;1.+, #B;2.+, #C;3.+ }")
+            .init();
+        resolveAndAssert("#D;1", "#A;1.0, #B;2.0, #C;3.0");
+    }
+
+    /**
+     * Test case for <a href="https://issues.apache.org/jira/browse/IVY-1585">IVY-1585</a>.
+     */
+    @Test
+    public void testCompatibilityResolve1585() throws Exception {
+        fixture
+            .addMD("#A;1.0").addMD("#A;1.1")
+            .addMD("#B;2.0->#A;1.0").addMD("#B;2.1->#A;1.1").addMD("#B;2.2->#A;1.1")
+            .addMD("#C;3.0->#A;1.0").addMD("#C;3.1->#A;1.1")
+            .addMD("#D;1->{ #A;[0.0,), #B;[0.0,), #C;3.0 }")
+            .init();
+        // first pass should blacklist #B;2.2, second pass should blacklist #B;2.1
+        resolveAndAssert("#D;1", "#A;1.0, #B;2.0, #C;3.0");
+    }
+
     @Test
     public void testCompatibilityResolveCircularDependency1() throws Exception {
-        fixture.addMD("#A;6->{ #B;[3.0,3.5] #C;4.6 }").addMD("#B;3.4->#D;2.5")
-                .addMD("#B;3.5->#D;3.0").addMD("#C;4.6->#D;2.5").addMD("#D;3.0->#B;3.5") // circular
-                                                                                         // dependency
+        fixture.addMD("#A;6->{ #B;[3.0,3.5] #C;4.6 }").addMD("#B;3.4->#D;2.5").addMD("#B;3.5->#D;3.0")
+                .addMD("#C;4.6->#D;2.5")
+                .addMD("#D;3.0->#B;3.5") // circular dependency
                 .addMD("#D;2.5->#B;3.4") // circular dependency
                 .init();
         resolveAndAssert("#A;6", "#B;3.4, #C;4.6, #D;2.5");
@@ -138,8 +170,6 @@ public class LatestCompatibleConflictManagerTest {
 
     /**
      * Resolve must fail with a conflict.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test(expected = StrictConflictException.class)
     public void testConflict() throws Exception {
@@ -151,8 +181,6 @@ public class LatestCompatibleConflictManagerTest {
 
     /**
      * Resolve must fail with a conflict.
-     *
-     * @throws Exception if something goes wrong
      */
     @Test(expected = StrictConflictException.class)
     public void testDynamicRootConflict() throws Exception {


### PR DESCRIPTION
This should also close IVY-1228 in my estimation.  After blacklisting `B;2.2` and `A;1.1`, the dynamic revision `B;[0.0,)` resolves to `B;2.1` next.  That node has dependency `A;1.1`.  The usual logic is to find or make an `IvyNode` for this mrid.  `ResolveData` retains such an `IvyNode` to hold eviction data.  This eviction data is not checked and `A;1.1` was already downloaded previously, so normal conflict resolve does not catch this.

I tried a few different things, but the most straightforward thing to do seemed to be check for blacklisting of dependency revision.  If so listed, propagate the blacklisting to the requesting node -- `B;2.1` in this case.

If instead I fed `A;1.0` and `A;1.1` into the conflict manager at this location, it throws `StrictConflictException`.